### PR TITLE
The \c meta-command is case-sensitive.

### DIFF
--- a/buildmimic/postgres/postgres_create_tables.sql
+++ b/buildmimic/postgres/postgres_create_tables.sql
@@ -13,7 +13,7 @@
 -- Create the database and schema
 CREATE USER MIMIC;
 CREATE DATABASE MIMIC OWNER MIMIC;
-\c MIMIC;
+\c mimic;
 CREATE SCHEMA MIMICIII;
 
 


### PR DESCRIPTION
The `\c` meta-command is [case-sensitive](http://postgresql.nabble.com/Case-sensitive-connect-in-psql-is-perplexing-td1912216.html), unlike `CREATE DATABASE` (unless using quotes, e.g. `CREATE DATABASE "MIIMIC"`) :-/

![image](https://cloud.githubusercontent.com/assets/15331/10654275/565c49dc-7836-11e5-8d5c-b1f9c40103c9.png)

```
postgres=#
postgres=# CREATE USER MIMIC;
CREATE ROLE
postgres=# CREATE DATABASE MIMIC OWNER MIMIC;
CREATE DATABASE
postgres=# \c MIMIC
FATAL:  database "MIMIC" does not exist
Previous connection kept
postgres=# CREATE DATABASE MIMIC OWNER MIMIC;
ERROR:  database "mimic" already exists
postgres=# \c MIMIC
FATAL:  database "MIMIC" does not exist
Previous connection kept
postgres=# \c mimic
WARNING: Console code page (437) differs from Windows code page (1252)
         8-bit characters might not work correctly. See psql reference
         page "Notes for Windows users" for details.
You are now connected to database "mimic" as user "postgres".
mimic=#
```

Same issue on http://mimic.physionet.org/tutorials/install_mimic_locally/ section 4.

