### PR TITLE
Create link to repo that installs MIMIC in a Vagrant VM

### DIFF
--- a/buildmimic/vagrant/README.md
+++ b/buildmimic/vagrant/README.md
@@ -1,0 +1,13 @@
+# Vagrant VM for MIMIC II
+
+See: [mimic-ii-vm](https://github.com/nsh87/mimic-ii-vm)
+
+Vagrant allows you to easily automate the creation of virtual machines.
+The [mimic-ii-vm](https://github.com/nsh87/mimic-ii-vm) repository will
+create a virtual machine with Vagrant, download the MIMIC II data, and
+make it accessible to you via command line or graphical interface with
+a single command.
+
+The automated steps performed on the VM are similar to those in the
+[Install MIMIC locally](http://mimic.physionet.org/tutorials/install_mimic_locally/)
+instructions on the official website.


### PR DESCRIPTION
I'm not sure how best to give this code back to the community (I'm up for alternative ways if this isn't the best). I created a repo that automates the steps given on the website here inside a VM: http://mimic.physionet.org/tutorials/install_mimic_locally/.

There are a lot of advantages to loading the MIMIC II data into a VM. For those that are new to databases, this should make it very easy to get started without mucking about with local databases. And for those who are familiar with software development, I'm sure they could appreciate getting the DB up and running with less work than usual.