### PR TITLE
Fixed icustay_details query

### DIFF
--- a/demographics/postgres/icustay_details.sql
+++ b/demographics/postgres/icustay_details.sql
@@ -32,8 +32,8 @@ select ie.subject_id, ie.hadm_id, ie.icustay_id
   
 -- icu level factors
 , ie.intime, ie.outtime
-, round(EXTRACT(EPOCH FROM (ie.intime-pat.dob)) / 60 / 60 / 24 / 365.242, 4) as Age
-, round(EXTRACT(EPOCH FROM (ie.outtime - ie.intime)) / 60 / 60 / 24, 4) as LOS_ICU
+, round((EXTRACT(EPOCH FROM (ie.intime-pat.dob)) / 60 / 60 / 24 / 365.242) :: NUMERIC, 4) as Age
+, round((EXTRACT(EPOCH FROM (ie.outtime - ie.intime)) / 60 / 60 / 24) :: NUMERIC, 4) as LOS_ICU
 , row_number() over (partition by ie.subject_id, ie.hadm_id order by ie.intime) as icustay_num
 
 from mimiciii.icustays ie


### PR DESCRIPTION
I tried running your icustay_deail sql file with PostgreSQL 9.3.6 and had an error due to the round function's first parameter not being of numeric type. I updated the code to cast the double to numeric and it now runs.