### PR TITLE
Updating pg copy

### DIFF
--- a/buildmimic/postgres/postgres_load_data.sql
+++ b/buildmimic/postgres/postgres_load_data.sql
@@ -48,181 +48,154 @@ SET search_path TO mimiciii;
 --  Load Data for Table ADMISSIONS
 --------------------------------------------------------
 
-\set admissions_csv :mimic_data_dir 'ADMISSIONS.csv'
-COPY ADMISSIONS FROM :'admissions_csv' DELIMITER ',' CSV HEADER;
+\copy ADMISSIONS FROM 'ADMISSIONS.csv' DELIMITER ',' CSV HEADER
 
 --------------------------------------------------------
 --  Load Data for Table CALLOUT
 --------------------------------------------------------
 
-\set callout_csv :mimic_data_dir 'CALLOUT.csv'
-COPY CALLOUT FROM :'callout_csv' DELIMITER ',' CSV HEADER;
+\copy CALLOUT from 'CALLOUT.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table CAREGIVERS
 --------------------------------------------------------
 
-\set caregivers_csv :mimic_data_dir 'CAREGIVERS.csv'
-COPY CAREGIVERS FROM :'caregivers_csv' DELIMITER ',' CSV HEADER;
+\copy CAREGIVERS from 'CAREGIVERS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table CHARTEVENTS
 --------------------------------------------------------
 
-\set chartevents_csv :mimic_data_dir 'CHARTEVENTS.csv'
-COPY CHARTEVENTS FROM :'chartevents_csv' DELIMITER ',' CSV HEADER;
+\copy CHARTEVENTS from 'CHARTEVENTS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table CPTEVENTS
 --------------------------------------------------------
 
-\set cptevents_csv :mimic_data_dir 'CPTEVENTS.csv'
-COPY CPTEVENTS FROM :'cptevents_csv' DELIMITER ',' CSV HEADER;
+\copy CPTEVENTS from 'CPTEVENTS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table DATETIMEEVENTS
 --------------------------------------------------------
 
-\set datetimeevents_csv :mimic_data_dir 'DATETIMEEVENTS.csv'
-COPY DATETIMEEVENTS FROM :'datetimeevents_csv' DELIMITER ',' CSV HEADER;
+\copy DATETIMEEVENTS from 'DATETIMEEVENTS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table DIAGNOSES_ICD
 --------------------------------------------------------
 
-\set diagnoses_icd_csv :mimic_data_dir 'DIAGNOSES_ICD.csv'
-COPY DIAGNOSES_ICD FROM :'diagnoses_icd_csv' DELIMITER ',' CSV HEADER;
+\copy DIAGNOSES_ICD from 'DIAGNOSES_ICD.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table DRGCODES
 --------------------------------------------------------
 
-\set drgcodes_csv :mimic_data_dir 'DRGCODES.csv'
-COPY DRGCODES FROM :'drgcodes_csv' DELIMITER ',' CSV HEADER;
+\copy DRGCODES from 'DRGCODES.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table D_CPT
 --------------------------------------------------------
 
-\set d_cpt_csv :mimic_data_dir 'D_CPT.csv'
-COPY D_CPT FROM :'d_cpt_csv' DELIMITER ',' CSV HEADER;
+\copy D_CPT from 'D_CPT.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table D_ICD_DIAGNOSES
 --------------------------------------------------------
 
-\set d_icd_diagnoses_csv :mimic_data_dir 'D_ICD_DIAGNOSES.csv'
-COPY D_ICD_DIAGNOSES FROM :'d_icd_diagnoses_csv' DELIMITER ',' CSV HEADER;
+\copy D_ICD_DIAGNOSES from 'D_ICD_DIAGNOSES.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table D_ICD_PROCEDURES
 --------------------------------------------------------
 
-\set d_icd_procedures_csv :mimic_data_dir 'D_ICD_PROCEDURES.csv'
-COPY D_ICD_PROCEDURES FROM :'d_icd_procedures_csv' DELIMITER ',' CSV HEADER;
+\copy D_ICD_PROCEDURES from 'D_ICD_PROCEDURES.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table D_ITEMS
 --------------------------------------------------------
 
-\set d_items_csv :mimic_data_dir 'D_ITEMS.csv'
-COPY D_ITEMS FROM :'d_items_csv' DELIMITER ',' CSV HEADER;
+\copy D_ITEMS from 'D_ITEMS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table D_LABITEMS
 --------------------------------------------------------
 
-\set d_labitems_csv :mimic_data_dir 'D_LABITEMS.csv'
-COPY D_LABITEMS FROM :'d_labitems_csv' DELIMITER ',' CSV HEADER;
+\copy D_LABITEMS from 'D_LABITEMS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table ICUSTAYS
 --------------------------------------------------------
 
-\set icustays_csv :mimic_data_dir 'ICUSTAYS.csv'
-COPY ICUSTAYS FROM :'icustays_csv' DELIMITER ',' CSV HEADER;
-
+\copy ICUSTAYS from 'ICUSTAYS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table INPUTEVENTS_CV
 --------------------------------------------------------
 
-\set inputevents_cv_csv :mimic_data_dir 'INPUTEVENTS_CV.csv'
-COPY INPUTEVENTS_CV FROM :'inputevents_cv_csv' WITH DELIMITER ',' CSV HEADER;
+\copy INPUTEVENTS_CV from 'INPUTEVENTS_CV.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table INPUTEVENTS_MV
 --------------------------------------------------------
 
-\set inputevents_mv_csv :mimic_data_dir 'INPUTEVENTS_MV.csv'
-COPY INPUTEVENTS_MV FROM :'inputevents_mv_csv' DELIMITER ',' CSV HEADER;
+\copy INPUTEVENTS_MV from 'INPUTEVENTS_MV.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table LABEVENTS
 --------------------------------------------------------
 
-\set labevents_csv :mimic_data_dir 'LABEVENTS.csv'
-COPY LABEVENTS FROM :'labevents_csv' DELIMITER ',' CSV HEADER;
+\copy LABEVENTS from 'LABEVENTS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table MICROBIOLOGYEVENTS
 --------------------------------------------------------
 
-\set microbiologyevents_csv :mimic_data_dir 'MICROBIOLOGYEVENTS.csv'
-COPY MICROBIOLOGYEVENTS FROM :'microbiologyevents_csv' DELIMITER ',' CSV HEADER;
+\copy MICROBIOLOGYEVENTS from 'MICROBIOLOGYEVENTS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table NOTEEVENTS
 --------------------------------------------------------
 
-\set noteevents_csv :mimic_data_dir 'NOTEEVENTS.csv'
-COPY NOTEEVENTS FROM :'noteevents_csv' DELIMITER ',' CSV HEADER;
+\copy NOTEEVENTS from 'NOTEEVENTS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table OUTPUTEVENTS
 --------------------------------------------------------
 
-\set outputevents_csv :mimic_data_dir 'OUTPUTEVENTS.csv'
-COPY OUTPUTEVENTS FROM :'outputevents_csv' WITH DELIMITER ',' CSV HEADER;
+\copy OUTPUTEVENTS from 'OUTPUTEVENTS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table PATIENTS
 --------------------------------------------------------
 
-\set patients_csv :mimic_data_dir 'PATIENTS.csv'
-COPY PATIENTS FROM :'patients_csv' DELIMITER ',' CSV HEADER;
+\copy PATIENTS from 'PATIENTS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table PRESCRIPTIONS
 --------------------------------------------------------
 
-\set prescriptions_csv :mimic_data_dir 'PRESCRIPTIONS.csv'
-COPY PRESCRIPTIONS FROM :'prescriptions_csv' DELIMITER ',' CSV HEADER;
+\copy PRESCRIPTIONS from 'PRESCRIPTIONS.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table PROCEDUREEVENTS_MV
 --------------------------------------------------------
 
-\set procedureevents_mv_csv :mimic_data_dir 'PROCEDUREEVENTS_MV.csv'
-COPY PROCEDUREEVENTS_MV FROM :'procedureevents_mv_csv' WITH DELIMITER ',' CSV HEADER;
+\copy PROCEDUREEVENTS_MV from 'PROCEDUREEVENTS_MV.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table PROCEDURES_ICD
 --------------------------------------------------------
 
-\set procedures_icd_csv :mimic_data_dir 'PROCEDURES_ICD.csv'
-COPY PROCEDURES_ICD FROM :'procedures_icd_csv' DELIMITER ',' CSV HEADER;
+\copy PROCEDURES_ICD from 'PROCEDURES_ICD.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table SERVICES
 --------------------------------------------------------
 
-\set services_csv :mimic_data_dir 'SERVICES.csv'
-COPY SERVICES FROM :'services_csv' DELIMITER ',' CSV HEADER;
+\copy SERVICES from 'SERVICES.csv' delimiter ',' csv header
 
 --------------------------------------------------------
 --  Load Data for Table TRANSFERS
 --------------------------------------------------------
 
-\set transfers_csv :mimic_data_dir 'TRANSFERS.csv'
-COPY TRANSFERS FROM :'transfers_csv' DELIMITER ',' CSV HEADER;
+\copy TRANSFERS from 'TRANSFERS.csv' delimiter ',' csv header

--- a/buildmimic/postgres/postgres_load_data.sql
+++ b/buildmimic/postgres/postgres_load_data.sql
@@ -21,6 +21,8 @@ CREATE SCHEMA MIMICIII;
 
 \set ON_ERROR_STOP 1
 
+\cd :mimic_data_dir
+
 -- The below command defines the schema where all tables are created
 SET search_path TO mimiciii;
 


### PR DESCRIPTION
Hi - thanks for the great work on MIMIC III and using github for sharing!  

I just finished getting the db built in a postgres environment that may be a bit more generalizable - interested in your thoughts on whether this can be integrated.  

Mainly, the current postgres build scripts assume:

* the user has the ability to put data locally on the db server
* the user has the ability to create a superuser account.  

Switching from "COPY" to "\copy", the local psql command, avoids both of these requirements.  Right now the script assumes the data csv files are in the current working directory - I'm not sure how to get \copy to to accept the data directory variable.

My procedure for creating the database was:

    # sudo as postgres, create mimic_rw user and mimic3_v1_3 database
    export PGPASSWORD=<secret>
    export PGUSER=mimic_rw
    export PGDATABASE=mimic3_v1_3
    export PGHOSTADDR=<db_host_addr>
    export SCRIPT_DIR=../mimic_code/buildmimic/postgres/
    psql -f $SCRIPT_DIR/postgres_create_tables.sql
    psql -f $SCRIPT_DIR/postgres_load_data.sql
    psql -f $SCRIPT_DIR/postgres_add_indexes.sql
    # create mimic_ro user with only schema usage and select, this is used by researchers