### PR TITLE
Pg add user

### DIFF
--- a/buildmimic/postgres/create_mimic_user.sh
+++ b/buildmimic/postgres/create_mimic_user.sh
@@ -3,7 +3,4 @@
 gosu postgres psql > /dev/null <<- EOSQL
                 CREATE USER MIMIC WITH PASSWORD '$MIMIC_PASSWORD';
                 CREATE DATABASE MIMIC OWNER MIMIC;
-                \c mimic;
-                CREATE SCHEMA MIMICIII;
-		ALTER SCHEMA MIMICIII OWNER TO MIMIC;
 EOSQL

--- a/buildmimic/postgres/create_mimic_user.sh
+++ b/buildmimic/postgres/create_mimic_user.sh
@@ -21,7 +21,13 @@ else
   echo "MIMIC_USER is set to '$MIMIC_USER'";
 fi
 
-sudo -u postgres psql > /dev/null <<- EOSQL
-                CREATE USER MIMIC WITH PASSWORD '$MIMIC_PASSWORD';
-                CREATE DATABASE $MIMIC_DB OWNER $MIMIC_USER;
+if hash gosu 2>/dev/null; then
+    SUDO='gosu postgres'
+else
+    SUDO='sudo -u postgres'
+fi
+
+$SUDO psql > /dev/null <<- EOSQL
+    CREATE USER MIMIC WITH PASSWORD '$MIMIC_PASSWORD';
+    CREATE DATABASE $MIMIC_DB OWNER $MIMIC_USER;
 EOSQL

--- a/buildmimic/postgres/create_mimic_user.sh
+++ b/buildmimic/postgres/create_mimic_user.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-gosu postgres psql > /dev/null <<- EOSQL
+sudo -u postgres psql > /dev/null <<- EOSQL
                 CREATE USER MIMIC WITH PASSWORD '$MIMIC_PASSWORD';
                 CREATE DATABASE MIMIC OWNER MIMIC;
 EOSQL

--- a/buildmimic/postgres/create_mimic_user.sh
+++ b/buildmimic/postgres/create_mimic_user.sh
@@ -1,36 +1,9 @@
 #!/bin/bash
 
-if [ -z ${MIMIC_PASSWORD+x} ]; then
-  echo "MIMIC_PASSWORD is unset";
-  exit 1
-else
-  echo "MIMIC_PASSWORD is set";
-fi
-
-if [ -z ${MIMIC_DB+x} ]; then
-  MIMIC_DB=mimic
-  echo "MIMIC_DB is unset, using default '$MIMIC_DB'";
-else
-  echo "MIMIC_DB is set to '$MIMIC_DB'";
-fi
-
-if [ -z ${MIMIC_USER+x} ]; then
-  MIMIC_USER=MIMIC
-  echo "MIMIC_USER is unset, using default '$MIMIC_USER'";
-else
-  echo "MIMIC_USER is set to '$MIMIC_USER'";
-fi
-
-if hash gosu 2>/dev/null; then
-    SUDO='gosu postgres'
-else
-    SUDO='sudo -u postgres'
-fi
-
-$SUDO psql > /dev/null <<- EOSQL
-    CREATE USER MIMIC WITH PASSWORD '$MIMIC_PASSWORD';
-    CREATE DATABASE $MIMIC_DB OWNER $MIMIC_USER;
-    \c $MIMIC_DB;
-    CREATE SCHEMA MIMICIII;
-    ALTER SCHEMA MIMICIII OWNER TO $MIMIC_USER;
+gosu postgres psql > /dev/null <<- EOSQL
+                CREATE USER MIMIC WITH PASSWORD '$MIMIC_PASSWORD';
+                CREATE DATABASE MIMIC OWNER MIMIC;
+                \c mimic;
+                CREATE SCHEMA MIMICIII;
+		ALTER SCHEMA MIMICIII OWNER TO MIMIC;
 EOSQL

--- a/buildmimic/postgres/create_mimic_user.sh
+++ b/buildmimic/postgres/create_mimic_user.sh
@@ -1,6 +1,27 @@
 #!/bin/bash
 
+if [ -z ${MIMIC_PASSWORD+x} ]; then
+  echo "MIMIC_PASSWORD is unset";
+  exit 1
+else
+  echo "MIMIC_PASSWORD is set";
+fi
+
+if [ -z ${MIMIC_DB+x} ]; then
+  MIMIC_DB=MIMIC
+  echo "MIMIC_DB is unset, using default '$MIMIC_DB'";
+else
+  echo "MIMIC_DB is set to '$MIMIC_DB'";
+fi
+
+if [ -z ${MIMIC_USER+x} ]; then
+  MIMIC_USER=MIMIC
+  echo "MIMIC_USER is unset, using default '$MIMIC_USER'";
+else
+  echo "MIMIC_USER is set to '$MIMIC_USER'";
+fi
+
 sudo -u postgres psql > /dev/null <<- EOSQL
                 CREATE USER MIMIC WITH PASSWORD '$MIMIC_PASSWORD';
-                CREATE DATABASE MIMIC OWNER MIMIC;
+                CREATE DATABASE $MIMIC_DB OWNER $MIMIC_USER;
 EOSQL

--- a/buildmimic/postgres/create_mimic_user.sh
+++ b/buildmimic/postgres/create_mimic_user.sh
@@ -8,7 +8,7 @@ else
 fi
 
 if [ -z ${MIMIC_DB+x} ]; then
-  MIMIC_DB=MIMIC
+  MIMIC_DB=mimic
   echo "MIMIC_DB is unset, using default '$MIMIC_DB'";
 else
   echo "MIMIC_DB is set to '$MIMIC_DB'";
@@ -30,4 +30,7 @@ fi
 $SUDO psql > /dev/null <<- EOSQL
     CREATE USER MIMIC WITH PASSWORD '$MIMIC_PASSWORD';
     CREATE DATABASE $MIMIC_DB OWNER $MIMIC_USER;
+    \c $MIMIC_DB;
+    CREATE SCHEMA MIMICIII;
+    ALTER SCHEMA MIMICIII OWNER TO $MIMIC_USER;
 EOSQL

--- a/buildmimic/postgres/create_mimic_user.sh
+++ b/buildmimic/postgres/create_mimic_user.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 
-gosu postgres psql > /dev/null <<- EOSQL
-                CREATE USER MIMIC WITH PASSWORD '$MIMIC_PASSWORD';
-                CREATE DATABASE MIMIC OWNER MIMIC;
-                \c mimic;
-                CREATE SCHEMA MIMICIII;
-		ALTER SCHEMA MIMICIII OWNER TO MIMIC;
+if [ -z ${MIMIC_PASSWORD+x} ]; then
+  echo "MIMIC_PASSWORD is unset";
+  exit 1
+else
+  echo "MIMIC_PASSWORD is set";
+fi
+
+if [ -z ${MIMIC_DB+x} ]; then
+  MIMIC_DB=mimic
+  echo "MIMIC_DB is unset, using default '$MIMIC_DB'";
+else
+  echo "MIMIC_DB is set to '$MIMIC_DB'";
+fi
+
+if [ -z ${MIMIC_USER+x} ]; then
+  MIMIC_USER=MIMIC
+  echo "MIMIC_USER is unset, using default '$MIMIC_USER'";
+else
+  echo "MIMIC_USER is set to '$MIMIC_USER'";
+fi
+
+if hash gosu 2>/dev/null; then
+    SUDO='gosu postgres'
+else
+    SUDO='sudo -u postgres'
+fi
+
+$SUDO psql > /dev/null <<- EOSQL
+    CREATE USER $MIMIC_USER WITH PASSWORD '$MIMIC_PASSWORD';
+    CREATE DATABASE $MIMIC_DB OWNER $MIMIC_USER;
 EOSQL


### PR DESCRIPTION
Wanted to reduce what's required to be run as superuser (schema is already created in 'create_tables', now just creating user and database), remove dependency (gosu), and make it easier to use database and usernames other than "MIMIC" (e.g. if database has multiple versions of MIMIC3).

Can use with following command:

    MIMIC_USER=mimic_rw MIMIC_DB=mimic3_v1_3 MIMIC_PASSWORD=secret ./create_scmimic_user.sh