### PR TITLE
Replace link to MIMIC-II Vagrant repo with one for MIMIC-III

### DIFF
--- a/buildmimic/vagrant/README.md
+++ b/buildmimic/vagrant/README.md
@@ -1,15 +1,18 @@
-# Vagrant VM for MIMIC II
+# Vagrant VM for MIMIC III
 
-## (MIMIC-III version coming soon...)
-
-See: [mimic-ii-vm](https://github.com/nsh87/mimic-ii-vm)
+See: [mimic-iii-vm](https://github.com/nsh87/mimic-iii-vm)
 
 Vagrant allows you to easily automate the creation of virtual machines.
-The [mimic-ii-vm](https://github.com/nsh87/mimic-ii-vm) repository will
-create a virtual machine with Vagrant, download the MIMIC II data, and
-make it accessible to you via command line or graphical interface with
-a single command.
+The [mimic-iii-vm](https://github.com/nsh87/mimic-iii-vm) repository will
+create a virtual machine with Vagrant, download version three of the
+MIMIC III data, and make it accessible to you via command line or graphical
+interface with a single command.
 
 The automated steps performed on the VM are similar to those in the
 [Install MIMIC locally](http://mimic.physionet.org/tutorials/install_mimic_locally/)
 instructions on the official website.
+
+<hr>
+
+If you would like to use the MIMIC II data, please use the
+[mimic-ii-vm](https://github.com/nsh87/mimic-ii-vm) repository, instead.


### PR DESCRIPTION
Currently the **buildmimic/vagrant/README.md** links to a repo that automatically downloads and loads the MIMIC-II data into a Vagrant VM. This commit replaces the links and language in that README to reference a sister repo that downloads and loads the MIMIC-III v3 data. I left a link at the bottom of the README to the MIMIC II repo in case usage of that data is desired. This also removes the sub-header that says "MIMIC-III version coming soon...", since this is the previously-pending MIMIC-III version.

Notable details about the MIMIC-III repo:

* Created a new Vagrant box to accommodate the large disk size required to hold the data (~90GB).
* Provisioner can be run again if interrupted....download script will avoid redownloading a file from PhysioNet if its checksum is correct.
* User must supply a valid PhysioNet username and password to download the data.
* Minimizes total required disk space by loading each table individually, starting from the smallest tables, then deleting its extracted file. Handles the large CHARTEVENTS.csv.gz uniquely by splitting it into multiple small files that are loaded in sequence and deleted as they're loaded, again minimizing required disk space (i.e. the entire 27GB `CHARTEVENTS` table is never duplicated in Postgres and .csv files at the same time...at most there is ~2-3GB of Postgres and .csv data duplication during data load).