### PR TITLE
don't assume existence of $USER database

### DIFF
--- a/buildmimic/postgres/create_mimic_user.sh
+++ b/buildmimic/postgres/create_mimic_user.sh
@@ -27,7 +27,7 @@ fi
 #     SUDO='sudo -u postgres'
 # fi
 
-$SUDO psql > /dev/null <<- EOSQL
+$SUDO psql postgres > /dev/null <<- EOSQL
     CREATE USER $MIMIC_USER WITH PASSWORD '$MIMIC_PASSWORD';
     DROP DATABASE IF EXISTS $MIMIC_DB;
     CREATE DATABASE $MIMIC_DB OWNER $MIMIC_USER;


### PR DESCRIPTION
When run without an argument `psql` assumes that there is a database of
name $USER. This is not always the case. However, generally there will
be a database called `postgres` which gives a db to login into in order
to create the `mimic` database.