### PR TITLE
Fix subtracting GU irrigant volume in urine-output-first-day.sql

### DIFF
--- a/etc/firstday/urine-output-first-day.sql
+++ b/etc/firstday/urine-output-first-day.sql
@@ -11,7 +11,7 @@ select
   -- volumes associated with urine output ITEMIDs
   , sum(
       -- we consider input of GU irrigant as a negative volume
-      case when s.parameterid = 7488 then -1*VALUE
+      case when oe.itemid = 227489 then -1*VALUE
       else VALUE end
   ) as UrineOutput
 from icustays ie


### PR DESCRIPTION
Current version throws error. This should provide expected functionality for subtracting GU irritant volume.