### PR TITLE
Fixed type comparison in adenosine-durations.sql

### DIFF
--- a/etc/vasopressor-durations/adenosine-durations.sql
+++ b/etc/vasopressor-durations/adenosine-durations.sql
@@ -17,9 +17,9 @@ with vasocv1 as
 
     -- the 'stopped' column indicates if a vasopressor has been disconnected
     , 0 as vaso_stopped
-    , max(case when itemid = 4649 and value is not null then 1 else 0 end) as vaso_null
+    , max(case when itemid = 4649 and valuenum is not null then 1 else 0 end) as vaso_null
     , max(case when itemid = 4649 then valuenum else null end) as vaso_rate
-    , max(case when itemid = 4649 then value else null end) as vaso_amount
+    , max(case when itemid = 4649 then valuenum else null end) as vaso_amount
 
   from mimiciii.chartevents
   where itemid = 4649 -- adenosine

--- a/etc/vasopressor-durations/adenosine-durations.sql
+++ b/etc/vasopressor-durations/adenosine-durations.sql
@@ -18,7 +18,7 @@ with vasocv1 as
     -- the 'stopped' column indicates if a vasopressor has been disconnected
     , 0 as vaso_stopped
     , max(case when itemid = 4649 and value is not null then 1 else 0 end) as vaso_null
-    , max(case when itemid = 4649 then value else null end) as vaso_rate
+    , max(case when itemid = 4649 then valuenum else null end) as vaso_rate
     , max(case when itemid = 4649 then value else null end) as vaso_amount
 
   from mimiciii.chartevents


### PR DESCRIPTION
Fixes the following error:

ERROR:  operator does not exist: text > integer
LINE 48:         when vaso_rate > 0 and
                                                  ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.