### PR TITLE
Change comment re: ventilation-durations.sql location

### DIFF
--- a/notebooks/aline/aline_cohort.sql
+++ b/notebooks/aline/aline_cohort.sql
@@ -21,7 +21,7 @@
 
 
 -- This query requires the following tables:
---  ventdurations - extracted by mimic-code/etc/ventilation-durations.sql
+--  ventdurations - extracted by mimic-code/concepts/durations/ventilation-durations.sql
 
 
 DROP MATERIALIZED VIEW IF EXISTS ALINE_COHORT_ALL CASCADE;


### PR DESCRIPTION
mimic-code/etc/ventilation-durations.sql no longer exists. I'm assuming this query needs mimic-code/concepts/durations/ventilation-durations.sql instead?