### PR TITLE
code filters icu_length_of_stay at 2 days while comments says 1 day

### DIFF
--- a/tutorials/cohort-selection.ipynb
+++ b/tutorials/cohort-selection.ipynb
@@ -468,9 +468,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Looks good - none of the above stays are shorter than a day.\n",
+    "Looks good - none of the above stays are shorter than 2 days.\n",
     "\n",
-    "Many studies using the MIMIC-III database are focused on specific subgroups of patients. For example, MIMIC-III contains both adults and neonates, but it is rare that a study would like to evaluate some phenomenom in both groups simulatenously. As a result, the first step of many studies is selecting a subpopulation from the *icustays* table. Concretely, we will want to select a set of `icustay_id` which represent our patient population. You've just seen an example of doing this: in the above code, we limited our population to only those who were in the ICU for at least 1 day.\n",
+    "Many studies using the MIMIC-III database are focused on specific subgroups of patients. For example, MIMIC-III contains both adults and neonates, but it is rare that a study would like to evaluate some phenomenom in both groups simulatenously. As a result, the first step of many studies is selecting a subpopulation from the *icustays* table. Concretely, we will want to select a set of `icustay_id` which represent our patient population. You've just seen an example of doing this: in the above code, we limited our population to only those who were in the ICU for at least 2 days.\n",
     "\n",
     "When subselecting the patient population, it is generally good practice to build a \"cohort\" table - that is a table with all `icustay_id` available in the database, each associated with binary flags indicating whether or not they are excluded from your population. Let's take a look at how this would work with the above query which limited the dataset to patients who stayed longer than 2 days."
    ]


### PR DESCRIPTION
in code block 5 `WHERE icu_length_of_stay >= 2` filters the cohort for patients with icu_length_of_stay >= 2 while the comments below says 1 day twice. I've corrected it.