### PR TITLE
add missing example subject_id

### DIFF
--- a/tutorials/cohort-selection.ipynb
+++ b/tutorials/cohort-selection.ipynb
@@ -1822,7 +1822,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Above we can see that the `curr_service` column gives an abbreviation for the current service. The `prev_service` column is null, *unless* the patient had a transfer of service, in which case it identifies the previous service. For example, we can see `subject_id` has had at least two service changes: once from TSURG to MED and once from MED back to TSURG (note: there may be more as we have limited this query using `LIMIT 10`, and you could examine this patient in detail using `SELECT * FROM services WHERE subject_id = 471` if you like).\n",
+    "Above we can see that the `curr_service` column gives an abbreviation for the current service. The `prev_service` column is null, *unless* the patient had a transfer of service, in which case it identifies the previous service. For example, we can see `subject_id = 471` has had at least two service changes: once from TSURG to MED and once from MED back to TSURG (note: there may be more as we have limited this query using `LIMIT 10`, and you could examine this patient in detail using `SELECT * FROM services WHERE subject_id = 471` if you like).\n",
     "\n",
     "A list of the unique services and their descriptions can be found at:\n",
     "http://mimic.physionet.org/mimictables/services/\n",


### PR DESCRIPTION
In the output result above,  the case with `subject_id = 471` has a tranfer service and the ` = 471` seems missing in text.