### PR TITLE
Fix #455: Add concepts goal to postgres Makefile

### DIFF
--- a/buildmimic/postgres/Makefile
+++ b/buildmimic/postgres/Makefile
@@ -347,4 +347,17 @@ endif
 clean:
 	@echo
 
+concepts:
+	@echo '------------------------'
+	@echo '-- Building MIMIC-III --'
+	@echo '------------------------'
+	@echo ''
+	@echo '---------------------'
+	@echo '-- Adding concepts --'
+	@echo '---------------------'
+	@echo ''
+	@sleep 2
+	psql "$(DBSTRING)" -v ON_ERROR_STOP=1 -f ../../concepts/make-concepts.sql
+
+
 .PHONY: help mimic clean

--- a/buildmimic/postgres/Makefile
+++ b/buildmimic/postgres/Makefile
@@ -357,7 +357,7 @@ concepts:
 	@echo '---------------------'
 	@echo ''
 	@sleep 2
-	psql "$(DBSTRING)" -v ON_ERROR_STOP=1 -f ../../concepts/make-concepts.sql
+	cd ../../concepts/ && psql "$(DBSTRING)" -v ON_ERROR_STOP=1 -f make-concepts.sql
 
 
 .PHONY: help mimic clean


### PR DESCRIPTION
The [Makefile guide](https://github.com/MIT-LCP/mimic-code/blob/master/Makefile.md) describes a way to import concepts like this:

>Optionally, additional contributed materialized views can be created afterward by running:
>
>make concepts

This PR actually implements this goal, so you can actually run `make concepts`.