### PR TITLE
md5 txt checker for freeBSD (no -c option)

### DIFF
--- a/tests/md5.sh
+++ b/tests/md5.sh
@@ -1,13 +1,13 @@
 while read p; do
   A="$(echo $p | cut -d' ' -f1)"
   B="$(echo $p | cut -d' ' -f2)"
-  read C< <(md5 -q $B)
-  echo $B $A = $C
-  if [ ! -z $B ]
+  if [ ! -f $B ]
   then
     echo "ERROR: $B does not exist"
-    exit
+    continue
   fi
+  read C< <(md5 -q $B)
+  echo $B $A = $C
   if [ $C != $A ]
   then
     echo "ERROR: $B wrong md5"

--- a/tests/md5.sh
+++ b/tests/md5.sh
@@ -1,0 +1,16 @@
+while read p; do
+  A="$(echo $p | cut -d' ' -f1)"
+  B="$(echo $p | cut -d' ' -f2)"
+  read C< <(md5 -q $B)
+  echo $B $A = $C
+  if [ ! -z $B ]
+  then
+    echo "ERROR: $B does not exist"
+    exit
+  fi
+  if [ $C != $A ]
+  then
+    echo "ERROR: $B wrong md5"
+    exit
+  fi
+done <$1


### PR DESCRIPTION
freeBSD md5 command doesn't have a --check option. Quick script automatically checks the checksums for zipped and unzipped txt file.

Usage: 
1) Move md5.sh to files repository.
`./md5.sh checksum_md5_zipped.txt`
OR
`./md5.sh checksum_md5_unzipped.txt`

Per the instructions here: https://physionet.org/works/MIMICIIIClinicalDatabase/files/