### PR TITLE
Making Dockerfile friendly for auto-builds

### DIFF
--- a/buildmimic/docker/Dockerfile
+++ b/buildmimic/docker/Dockerfile
@@ -16,9 +16,8 @@ RUN echo "buildmimic/postgres/" >> .git/info/sparse-checkout
 RUN git pull origin master
 
 # copy the build scripts into a different folder
-RUN cp -r buildmimic /docker-entrypoint-initdb.d/
+RUN cp -r buildmimic /docker-entrypoint-initdb.d/ \
+ && cp buildmimic/docker/setup.sh /docker-entrypoint-initdb.d/
 
 # make a directory for the data
 RUN mkdir /mimic_data
-
-RUN cp buildmimic/docker/setup.sh /docker-entrypoint-initdb.d/

--- a/buildmimic/docker/Dockerfile
+++ b/buildmimic/docker/Dockerfile
@@ -3,19 +3,22 @@ FROM postgres:latest
 # in the docker initialization, we do not build the data
 ENV BUILD_MIMIC 0
 
-RUN apt-get update && apt-get install -y vim git
+RUN apt-get update \
+ && apt-get install -y vim git \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# make a directory for the data 
-RUN mkdir /mimic_data \
+RUN mkdir /mimic-code \
+ && cd /mimic-code \
  # clone the postgres build scripts into a local folder
- && mkdir mimic-code \
- && cd mimic-code \
  && git init \
  && git remote add -f origin https://github.com/MIT-lcp/mimic-code \
  && git config core.sparseCheckout true \
  && echo "buildmimic/postgres/" >> .git/info/sparse-checkout \
  && echo "buildmimic/docker/"   >> .git/info/sparse-checkout \
  && git pull origin master \
- # copy the build scripts into a different folder
+ # copy the build scripts into a different folder and remove the temp folder
  && cp -r buildmimic /docker-entrypoint-initdb.d/ \
- && cp buildmimic/docker/setup.sh /docker-entrypoint-initdb.d/
+ && cp buildmimic/docker/setup.sh /docker-entrypoint-initdb.d/ \
+ && rm -rf /mimic-code \ 
+ # make a directory for the data
+ mkdir /mimic_data

--- a/buildmimic/docker/Dockerfile
+++ b/buildmimic/docker/Dockerfile
@@ -3,17 +3,17 @@ FROM postgres:latest
 # in the docker initialization, we do not build the data
 ENV BUILD_MIMIC 0
 
-RUN apt-get update
-RUN apt-get install -y vim git
+RUN apt-get update && apt-get install -y vim git
 
 # clone the postgres build scripts into a local folder
-RUN mkdir mimic-code
-RUN cd mimic-code
-RUN git init
-RUN git remote add -f origin https://github.com/MIT-lcp/mimic-code
-RUN git config core.sparseCheckout true
-RUN echo "buildmimic/postgres/" >> .git/info/sparse-checkout
-RUN git pull origin master
+RUN mkdir mimic-code \
+ && cd mimic-code \
+ && git init \
+ && git remote add -f origin https://github.com/MIT-lcp/mimic-code \
+ && git config core.sparseCheckout true \
+ && echo "buildmimic/postgres/" >> .git/info/sparse-checkout \
+ && echo "buildmimic/docker/"   >> .git/info/sparse-checkout \
+ && git pull origin master
 
 # copy the build scripts into a different folder
 RUN cp -r buildmimic /docker-entrypoint-initdb.d/ \

--- a/buildmimic/docker/Dockerfile
+++ b/buildmimic/docker/Dockerfile
@@ -13,11 +13,10 @@ RUN mkdir mimic-code \
  && git config core.sparseCheckout true \
  && echo "buildmimic/postgres/" >> .git/info/sparse-checkout \
  && echo "buildmimic/docker/"   >> .git/info/sparse-checkout \
- && git pull origin master
-
-# copy the build scripts into a different folder
-RUN cp -r buildmimic /docker-entrypoint-initdb.d/ \
- && cp buildmimic/docker/setup.sh /docker-entrypoint-initdb.d/
-
-# make a directory for the data
-RUN mkdir /mimic_data
+ && git pull origin master \
+ # copy the build scripts into a different folder
+ && cp -r buildmimic /docker-entrypoint-initdb.d/ \
+ && cp buildmimic/docker/setup.sh /docker-entrypoint-initdb.d/ \
+ # make a directory for the data 
+ && mkdir /mimic_data
+ 

--- a/buildmimic/docker/Dockerfile
+++ b/buildmimic/docker/Dockerfile
@@ -5,8 +5,10 @@ ENV BUILD_MIMIC 0
 
 RUN apt-get update && apt-get install -y vim git
 
-# clone the postgres build scripts into a local folder
-RUN mkdir mimic-code \
+# make a directory for the data 
+RUN mkdir /mimic_data \
+ # clone the postgres build scripts into a local folder
+ && mkdir mimic-code \
  && cd mimic-code \
  && git init \
  && git remote add -f origin https://github.com/MIT-lcp/mimic-code \
@@ -16,7 +18,4 @@ RUN mkdir mimic-code \
  && git pull origin master \
  # copy the build scripts into a different folder
  && cp -r buildmimic /docker-entrypoint-initdb.d/ \
- && cp buildmimic/docker/setup.sh /docker-entrypoint-initdb.d/ \
- # make a directory for the data 
- && mkdir /mimic_data
- 
+ && cp buildmimic/docker/setup.sh /docker-entrypoint-initdb.d/

--- a/buildmimic/docker/Dockerfile
+++ b/buildmimic/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM postgres:latest
 ENV BUILD_MIMIC 0
 
 RUN apt-get update \
- && apt-get install -y vim git \
+ && apt-get install -y git \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /mimic-code \

--- a/buildmimic/docker/Dockerfile
+++ b/buildmimic/docker/Dockerfile
@@ -21,4 +21,4 @@ RUN cp -r buildmimic /docker-entrypoint-initdb.d/
 # make a directory for the data
 RUN mkdir /mimic_data
 
-ADD setup.sh /docker-entrypoint-initdb.d/
+RUN cp buildmimic/docker/setup.sh /docker-entrypoint-initdb.d/

--- a/buildmimic/docker/setup.sh
+++ b/buildmimic/docker/setup.sh
@@ -47,8 +47,14 @@ for TBL in $ALLTABLES; do
 done
 
 # checks passed - begin building the database
-echo "$0: running postgres_create_tables.sql"
-psql --username "$POSTGRES_USER" --dbname mimic < /docker-entrypoint-initdb.d/buildmimic/postgres/postgres_create_tables.sql
+PG_VER=$(postgres -V | egrep -o -m 1 '[0-9]{1,}\.[0-9]{1,}')
+if [ $${PG_VER:0:1} -eq 1 ]; then
+echo "$0: running postgres_create_tables_pg10.sql"
+psql --username "$POSTGRES_USER" --dbname mimic < /docker-entrypoint-initdb.d/buildmimic/postgres/postgres_create_tables_pg10.sql
+else
+echo "$0: running postgres_create_tables_pg.sql"
+psql --username "$POSTGRES_USER" --dbname mimic < /docker-entrypoint-initdb.d/buildmimic/postgres/postgres_create_tables_pg.sql
+fi
 
 if [ $COMPRESSED -eq 1 ]; then
 echo "$0: running postgres_load_data_gz.sql"

--- a/concepts/code-status.sql
+++ b/concepts/code-status.sql
@@ -99,15 +99,20 @@ select ie.subject_id, ie.hadm_id, ie.icustay_id
   -- *** not totally robust, the note could say "NOT CMO", which would be flagged as 1
   , max(case when disch.cmo = 1 then 1 else 0 end) as CMO_ds
 
-  -- time until their first DNR
-  , min(case when t1.DNR = 1 then t1.charttime else null end)
-        as TimeDNR_chart
-
-  -- first code status of CMO
+  , min(case when t1.FullCode = 1 then t1.charttime else null end)
+        as FullCode_first_charttime
   , min(case when t1.CMO = 1 then t1.charttime else null end)
-        as TimeCMO_chart
+        as CMO_first_charttime
+  , min(case when t1.DNR = 1 then t1.charttime else null end)
+        as DNR_first_charttime
+  , min(case when t1.DNI = 1 then t1.charttime else null end)
+        as DNI_first_charttime
+  , min(case when t1.DNCPR = 1 then t1.charttime else null end)
+        as DNCPR_first_charttime
+
+  -- first code status of CMO from the nursing note
   , min(case when t1.CMO = 1 then nn.charttime else null end)
-        as TimeCMO_NursingNote
+        as CMO_NursingNote_charttime
 
 from icustays ie
 left join t1

--- a/concepts/demographics/icustay-detail.sql
+++ b/concepts/demographics/icustay-detail.sql
@@ -21,8 +21,70 @@ SELECT ie.subject_id, ie.hadm_id, ie.icustay_id
 -- hospital level factors
 , adm.admittime, adm.dischtime
 , ROUND( (CAST(EXTRACT(epoch FROM adm.dischtime - adm.admittime)/(60*60*24) AS numeric)), 4) AS los_hospital
-, ROUND( (CAST(EXTRACT(epoch FROM adm.admittime - pat.dob)/(60*60*24*365.242) AS numeric)), 4) AS admission_age
-, adm.ethnicity, adm.admission_type
+, ROUND( (CAST(EXTRACT(epoch FROM adm.admittime - pat.dob)/(60*60*24*365.242) AS numeric)), 4) AS age
+, adm.ethnicity
+, case when ethnicity in
+  (
+       'WHITE' --  40996
+     , 'WHITE - RUSSIAN' --    164
+     , 'WHITE - OTHER EUROPEAN' --     81
+     , 'WHITE - BRAZILIAN' --     59
+     , 'WHITE - EASTERN EUROPEAN' --     25
+  ) then 'white'
+  when ethnicity in
+  (
+      'BLACK/AFRICAN AMERICAN' --   5440
+    , 'BLACK/CAPE VERDEAN' --    200
+    , 'BLACK/HAITIAN' --    101
+    , 'BLACK/AFRICAN' --     44
+    , 'CARIBBEAN ISLAND' --      9
+  ) then 'black'
+  when ethnicity in
+    (
+      'HISPANIC OR LATINO' --   1696
+    , 'HISPANIC/LATINO - PUERTO RICAN' --    232
+    , 'HISPANIC/LATINO - DOMINICAN' --     78
+    , 'HISPANIC/LATINO - GUATEMALAN' --     40
+    , 'HISPANIC/LATINO - CUBAN' --     24
+    , 'HISPANIC/LATINO - SALVADORAN' --     19
+    , 'HISPANIC/LATINO - CENTRAL AMERICAN (OTHER)' --     13
+    , 'HISPANIC/LATINO - MEXICAN' --     13
+    , 'HISPANIC/LATINO - COLOMBIAN' --      9
+    , 'HISPANIC/LATINO - HONDURAN' --      4
+  ) then 'hispanic'
+  when ethnicity in
+  (
+      'ASIAN' --   1509
+    , 'ASIAN - CHINESE' --    277
+    , 'ASIAN - ASIAN INDIAN' --     85
+    , 'ASIAN - VIETNAMESE' --     53
+    , 'ASIAN - FILIPINO' --     25
+    , 'ASIAN - CAMBODIAN' --     17
+    , 'ASIAN - OTHER' --     17
+    , 'ASIAN - KOREAN' --     13
+    , 'ASIAN - JAPANESE' --      7
+    , 'ASIAN - THAI' --      4
+  ) then 'asian'
+  when ethnicity in
+  (
+       'AMERICAN INDIAN/ALASKA NATIVE' --     51
+     , 'AMERICAN INDIAN/ALASKA NATIVE FEDERALLY RECOGNIZED TRIBE' --      3
+  ) then 'native'
+  when ethnicity in
+  (
+      'UNKNOWN/NOT SPECIFIED' --   4523
+    , 'UNABLE TO OBTAIN' --    814
+    , 'PATIENT DECLINED TO ANSWER' --    559
+  ) then 'unknown'
+  else 'other' end as ethnicity_grouped
+  -- , 'OTHER' --   1512
+  -- , 'MULTI RACE ETHNICITY' --    130
+  -- , 'PORTUGUESE' --     61
+  -- , 'MIDDLE EASTERN' --     43
+  -- , 'NATIVE HAWAIIAN OR OTHER PACIFIC ISLANDER' --     18
+  -- , 'SOUTH AMERICAN' --      8
+
+, adm.admission_type
 , adm.hospital_expire_flag
 , DENSE_RANK() OVER (PARTITION BY adm.subject_id ORDER BY adm.admittime) AS hospstay_seq
 , CASE
@@ -44,5 +106,4 @@ INNER JOIN admissions adm
     ON ie.hadm_id = adm.hadm_id
 INNER JOIN patients pat
     ON ie.subject_id = pat.subject_id
-WHERE adm.has_chartevents_data = 1
 ORDER BY ie.subject_id, adm.admittime, ie.intime;

--- a/concepts/durations/neuroblock-dose.sql
+++ b/concepts/durations/neuroblock-dose.sql
@@ -1,0 +1,318 @@
+-- This query extracts dose+durations of neuromuscular blocking agents
+-- Note: we assume that injections will be filtered for carevue as they will have starttime = stopttime.
+DROP MATERIALIZED VIEW IF EXISTS neuroblock_dose;
+CREATE MATERIALIZED VIEW neuroblock_dose as
+-- Get drug administration data from CareVue and MetaVision
+-- metavision is simple and only requires one temporary table
+with drugmv as
+(
+  select
+      icustay_id, linkorderid
+    , max(rate) as drug_rate
+    , sum(amount) as drug_amount
+    , min(starttime) as starttime
+    , max(endtime) as endtime
+  from inputevents_mv
+  where itemid in
+  (
+      222062 -- Vecuronium (664 rows, 154 infusion rows)
+    , 221555 -- Cisatracurium (9334 rows, 8970 infusion rows)
+  )
+  and statusdescription != 'Rewritten' -- only valid orders
+  and rate is not null -- only continuous infusions
+  group by icustay_id, linkorderid
+)
+, drugcv1 as
+(
+  select
+    icustay_id, charttime
+    -- where clause below ensures all rows are instance of the drug
+    , 1 as drug
+
+    -- the 'stopped' column indicates if a drug has been disconnected
+    , max(case when stopped in ('Stopped','D/C''d') then 1 else 0 end) as drug_stopped
+
+    -- we only include continuous infusions, therefore expect a rate
+    , max(case
+            -- for "free form" entries (itemid >= 40000) rate is not available
+            when itemid >= 40000 and amount is not null then 1
+            when itemid <  40000 and rate is not null then 1
+          else 0 end) as drug_null
+    , max(case
+            -- for "free form" entries (itemid >= 40000) rate is not available
+            when itemid >= 40000 then coalesce(rate, amount)
+          else rate end) as drug_rate
+    , max(amount) as drug_amount
+  from inputevents_cv
+  where itemid in
+  (
+      30114 -- Cisatracurium (63994 rows)
+    , 30138	-- Vecuronium	 (5160 rows)
+    , 30113 -- Atracurium  (1163 rows)
+    -- Below rows are less frequent ad-hoc documentation, but worth including!
+    , 42174	-- nimbex cc/hr (207 rows)
+    , 42385	-- Cisatracurium gtt (156 rows)
+    , 41916	-- NIMBEX	inputevents_cv (136 rows)
+    , 42100	-- cistatracurium	(132 rows)
+    , 42045	-- nimbex mcg/kg/min (78 rows)
+    , 42246 -- CISATRICARIUM CC/HR (70 rows)
+    , 42291	-- NIMBEX CC/HR (48 rows)
+    , 42590	-- nimbex	inputevents_cv (38 rows)
+    , 42284	-- CISATRACURIUM DRIP (9 rows)
+    , 45096	-- Vecuronium drip (2 rows)
+  )
+  group by icustay_id, charttime
+  UNION
+  -- add data from chartevents
+  select
+    icustay_id, charttime
+    -- where clause below ensures all rows are instance of the drug
+    , 1 as drug
+
+    -- the 'stopped' column indicates if a drug has been disconnected
+    , max(case when stopped in ('Stopped','D/C''d') then 1 else 0 end) as drug_stopped
+    , max(case when valuenum <= 10 then 0 else 1 end) as drug_null
+
+    -- educated guess!
+    , max(case when valuenum <= 10 then valuenum else null end) as drug_rate
+    , max(case when valuenum  > 10 then valuenum else null end) as drug_amount
+  from chartevents
+  where itemid in
+  (
+      1856 -- Vecuronium mcg/min  (8 rows)
+    , 2164 -- NIMBEX MG/KG/HR  (243 rows)
+    , 2548 -- nimbex mg/kg/hr  (103 rows)
+    , 2285 -- nimbex mcg/kg/min  (85 rows)
+    , 2290 -- nimbex mcg/kg/m  (32 rows)
+    , 2670 -- nimbex  (38 rows)
+    , 2546 -- CISATRACURIUMMG/KG/H  (7 rows)
+    , 1098 -- cisatracurium mg/kg  (36 rows)
+    , 2390 -- cisatracurium mg/hr  (15 rows)
+    , 2511 -- CISATRACURIUM GTT  (4 rows)
+    , 1028 -- Cisatracurium  (208 rows)
+    , 1858 -- cisatracurium  (351 rows)
+  )
+  group by icustay_id, charttime
+
+)
+, drugcv2 as
+(
+  select v.*
+    , sum(drug_null) over (partition by icustay_id order by charttime) as drug_partition
+  from
+    drugcv1 v
+)
+, drugcv3 as
+(
+  select v.*
+    , first_value(drug_rate) over (partition by icustay_id, drug_partition order by charttime) as drug_prevrate_ifnull
+  from
+    drugcv2 v
+)
+, drugcv4 as
+(
+select
+    icustay_id
+    , charttime
+    -- , (CHARTTIME - (LAG(CHARTTIME, 1) OVER (partition by icustay_id, drug order by charttime))) AS delta
+
+    , drug
+    , drug_rate
+    , drug_amount
+    , drug_stopped
+    , drug_prevrate_ifnull
+
+    -- We define start time here
+    , case
+        when drug = 0 then null
+
+        -- if this is the first instance of the drug
+        when drug_rate > 0 and
+          LAG(drug_prevrate_ifnull,1)
+          OVER
+          (
+          partition by icustay_id, drug, drug_null
+          order by charttime
+          )
+          is null
+          then 1
+
+        -- you often get a string of 0s
+        -- we decide not to set these as 1, just because it makes drugnum sequential
+        when drug_rate = 0 and
+          LAG(drug_prevrate_ifnull,1)
+          OVER
+          (
+          partition by icustay_id, drug
+          order by charttime
+          )
+          = 0
+          then 0
+
+        -- sometimes you get a string of NULL, associated with 0 volumes
+        -- same reason as before, we decide not to set these as 1
+        -- drug_prevrate_ifnull is equal to the previous value *iff* the current value is null
+        when drug_prevrate_ifnull = 0 and
+          LAG(drug_prevrate_ifnull,1)
+          OVER
+          (
+          partition by icustay_id, drug
+          order by charttime
+          )
+          = 0
+          then 0
+
+        -- If the last recorded rate was 0, newdrug = 1
+        when LAG(drug_prevrate_ifnull,1)
+          OVER
+          (
+          partition by icustay_id, drug
+          order by charttime
+          ) = 0
+          then 1
+
+        -- If the last recorded drug was D/C'd, newdrug = 1
+        when
+          LAG(drug_stopped,1)
+          OVER
+          (
+          partition by icustay_id, drug
+          order by charttime
+          )
+          = 1 then 1
+
+        when (CHARTTIME - (LAG(CHARTTIME, 1) OVER (partition by icustay_id, drug order by charttime))) > (interval '8 hours') then 1
+      else null
+      end as drug_start
+
+FROM
+  drugcv3
+)
+-- propagate start/stop flags forward in time
+, drugcv5 as
+(
+  select v.*
+    , SUM(drug_start) OVER (partition by icustay_id, drug order by charttime) as drug_first
+FROM
+  drugcv4 v
+)
+, drugcv6 as
+(
+  select v.*
+    -- We define end time here
+    , case
+        when drug = 0
+          then null
+
+        -- If the recorded drug was D/C'd, this is an end time
+        when drug_stopped = 1
+          then drug_first
+
+        -- If the rate is zero, this is the end time
+        when drug_rate = 0
+          then drug_first
+
+        -- the last row in the table is always a potential end time
+        -- this captures patients who die/are discharged while on drug
+        -- in principle, this could add an extra end time for the drug
+        -- however, since we later group on drug_start, any extra end times are ignored
+        when LEAD(CHARTTIME,1)
+          OVER
+          (
+          partition by icustay_id, drug
+          order by charttime
+          ) is null
+          then drug_first
+
+        else null
+        end as drug_stop
+    from drugcv5 v
+)
+
+-- -- if you want to look at the results of the table before grouping:
+-- select
+--   icustay_id, charttime, drug, drug_rate, drug_amount
+--     , drug_stopped
+--     , drug_start
+--     , drug_first
+--     , drug_stop
+-- from drugcv6 order by icustay_id, charttime;
+
+, drugcv7 as
+(
+select
+  icustay_id
+  , charttime as starttime
+  , lead(charttime) OVER (partition by icustay_id, drug_first order by charttime) as endtime
+  , drug, drug_rate, drug_amount, drug_stop, drug_start, drug_first
+from drugcv6
+where
+  drug_first is not null -- bogus data
+and
+  drug_first != 0 -- sometimes *only* a rate of 0 appears, i.e. the drug is never actually delivered
+and
+  icustay_id is not null -- there are data for "floating" admissions, we don't worry about these
+)
+-- table of start/stop times for event
+, drugcv8 as
+(
+  select
+    icustay_id
+    , starttime, endtime
+    , drug, drug_rate, drug_amount, drug_stop, drug_start, drug_first
+  from drugcv7
+  where endtime is not null
+  and drug_rate > 0
+  and starttime != endtime
+)
+-- collapse these start/stop times down if the rate doesn't change
+, drugcv9 as
+(
+  select
+    icustay_id
+    , starttime, endtime
+    , case
+        when LAG(endtime) OVER (partition by icustay_id order by starttime, endtime) = starttime
+        AND  LAG(drug_rate) OVER (partition by icustay_id order by starttime, endtime) = drug_rate
+        THEN 0
+      else 1
+    end as drug_groups
+    , drug, drug_rate, drug_amount, drug_stop, drug_start, drug_first
+  from drugcv8
+  where endtime is not null
+  and drug_rate > 0
+  and starttime != endtime
+)
+, drugcv10 as
+(
+  select
+    icustay_id
+    , starttime, endtime
+    , drug_groups
+    , SUM(drug_groups) OVER (partition by icustay_id order by starttime, endtime) as drug_groups_sum
+    , drug, drug_rate, drug_amount, drug_stop, drug_start, drug_first
+  from drugcv9
+)
+, drugcv as
+(
+  select icustay_id
+  , min(starttime) as starttime
+  , max(endtime) as endtime
+  , drug_groups_sum
+  , drug_rate
+  , sum(drug_amount) as drug_amount
+  from drugcv10
+  group by icustay_id, drug_groups_sum, drug_rate
+)
+-- now assign this data to every hour of the patient's stay
+-- drug_amount for carevue is not accurate
+SELECT icustay_id
+  , starttime, endtime
+  , drug_rate, drug_amount
+from drugcv
+UNION
+SELECT icustay_id
+  , starttime, endtime
+  , drug_rate, drug_amount
+from drugmv
+order by icustay_id, starttime;

--- a/concepts/fluid-balance/colloid-bolus.sql
+++ b/concepts/fluid-balance/colloid-bolus.sql
@@ -1,0 +1,122 @@
+DROP TABLE IF EXISTS colloid_bolus CASCADE;
+CREATE TABLE colloid_bolus AS
+-- received colloid before admission
+-- 226365  --  OR Colloid Intake
+-- 226376  --  PACU Colloid Intake
+
+with t1 as
+(
+  select
+    mv.icustay_id
+  , mv.starttime as charttime
+  -- standardize the units to millilitres
+  -- also metavision has floating point precision.. but we only care down to the mL
+  , round(case
+      when mv.amountuom = 'L'
+        then mv.amount * 1000.0
+      when mv.amountuom = 'ml'
+        then mv.amount
+    else null end) as amount
+  from inputevents_mv mv
+  where mv.itemid in
+  (
+    220864, --	Albumin 5%	7466 132 7466
+    220862, --	Albumin 25%	9851 174 9851
+    225174, --	Hetastarch (Hespan) 6%	82 1 82
+    225795,  --	Dextran 40	38 3 38
+    225796 --  Dextran 70
+    -- below ITEMIDs not in use
+   -- 220861 | Albumin (Human) 20%
+   -- 220863 | Albumin (Human) 4%
+  )
+  and mv.statusdescription != 'Rewritten'
+  and
+  -- in MetaVision, these ITEMIDs never appear with a null rate
+  -- so it is sufficient to check the rate is > 100
+    (
+      (mv.rateuom = 'mL/hour' and mv.rate > 100)
+      OR (mv.rateuom = 'mL/min' and mv.rate > (100/60.0))
+      OR (mv.rateuom = 'mL/kg/hour' and (mv.rate*mv.patientweight) > 100)
+    )
+)
+, t2 as
+(
+  select
+    cv.icustay_id
+  , cv.charttime
+  -- carevue always has units in millilitres (or null)
+  , round(cv.amount) as amount
+  from inputevents_cv cv
+  where cv.itemid in
+  (
+   30008 --	Albumin 5%
+  ,30009 --	Albumin 25%
+  ,42832 --	albumin 12.5%
+  ,40548 --	ALBUMIN
+  ,45403 --	albumin
+  ,44203 --	Albumin 12.5%
+  ,30181 -- Serum Albumin 5%
+  ,46564 -- Albumin
+  ,43237 -- 25% Albumin
+  ,43353 -- Albumin (human) 25%
+
+  ,30012 --	Hespan
+  ,46313 --	6% Hespan
+
+  ,42975 --	DEXTRAN DRIP
+  ,42944 --	dextran
+  ,46336 --	10% Dextran 40/D5W
+  ,46729 --	Dextran
+  ,40033 --	DEXTRAN
+  ,45410 --	10% Dextran 40
+  ,30011 -- Dextran 40
+  ,30016 -- Dextrose 10%
+  ,42731 -- Dextran40 10%
+  )
+  and cv.amount > 100
+  and cv.amount < 2000
+)
+-- some colloids are charted in chartevents
+, t3 as
+(
+  select
+    ce.icustay_id
+  , ce.charttime
+  -- carevue always has units in millilitres (or null)
+  , round(ce.valuenum) as amount
+  from chartevents ce
+  where ce.itemid in
+  (
+      2510 --	DEXTRAN LML 10%
+    , 3087 --	DEXTRAN 40  10%
+    , 6937 --	Dextran
+    , 3087 -- | DEXTRAN 40  10%
+    , 3088 --	DEXTRAN 40%
+  )
+  and ce.valuenum is not null
+  and ce.valuenum > 100
+  and ce.valuenum < 2000
+)
+select
+    icustay_id
+  , charttime
+  , sum(amount) as colloid_bolus
+from t1
+-- just because the rate was high enough, does *not* mean the final amount was
+where amount > 100
+group by t1.icustay_id, t1.charttime
+UNION
+select
+    icustay_id
+  , charttime
+  , sum(amount) as colloid_bolus
+from t2
+group by t2.icustay_id, t2.charttime
+UNION
+select
+    icustay_id
+  , charttime
+  , sum(amount) as colloid_bolus
+from t3
+group by t3.icustay_id, t3.charttime
+order by icustay_id, charttime;

--- a/concepts/fluid-balance/crystalloid-bolus.sql
+++ b/concepts/fluid-balance/crystalloid-bolus.sql
@@ -1,0 +1,145 @@
+DROP TABLE IF EXISTS crystalloid_bolus CASCADE;
+CREATE TABLE crystalloid_bolus AS
+with t1 as
+(
+  select
+    mv.icustay_id
+  , mv.starttime as charttime
+  -- standardize the units to millilitres
+  -- also metavision has floating point precision.. but we only care down to the mL
+  , round(case
+      when mv.amountuom = 'L'
+        then mv.amount * 1000.0
+      when mv.amountuom = 'ml'
+        then mv.amount
+    else null end) as amount
+  from inputevents_mv mv
+  where mv.itemid in
+  (
+    -- 225943 Solution
+    225158, -- NaCl 0.9%
+    225828, -- LR
+    225944, -- Sterile Water
+    225797  -- Free Water
+  )
+  and mv.statusdescription != 'Rewritten'
+  and
+  -- in MetaVision, these ITEMIDs appear with a null rate IFF endtime=starttime + 1 minute
+  -- so it is sufficient to:
+  --    (1) check the rate is > 240 if it exists or
+  --    (2) ensure the rate is null and amount > 240 ml
+    (
+      (mv.rate is not null and mv.rateuom = 'mL/hour' and mv.rate > 248)
+      OR (mv.rate is not null and mv.rateuom = 'mL/min' and mv.rate > (248/60.0))
+      OR (mv.rate is null and mv.amountuom = 'L' and mv.amount > 0.248)
+      OR (mv.rate is null and mv.amountuom = 'ml' and mv.amount > 248)
+    )
+)
+, t2 as
+(
+  select
+    cv.icustay_id
+  , cv.charttime
+  -- carevue always has units in millilitres
+  , round(cv.amount) as amount
+  from inputevents_cv cv
+  where cv.itemid in
+  (
+    30018 --	.9% Normal Saline
+  , 30021 --	Lactated Ringers
+  , 30058 --	Free Water Bolus
+  , 40850 --	ns bolus
+  , 41491 --	fluid bolus
+  , 42639 --	bolus
+  , 30065 --	Sterile Water
+  , 42187 --	free h20
+  , 43819 --	1:1 NS Repletion.
+  , 30063 --	IV Piggyback
+  , 41430 --	free water boluses
+  , 40712 --	free H20
+  , 44160 --	BOLUS
+  , 42383 --	cc for cc replace
+  , 30169 --	Sterile H20_GU
+  , 42297 --	Fluid bolus
+  , 42453 --	Fluid Bolus
+  , 40872 --	free water
+  , 41915 --	FREE WATER
+  , 41490 --	NS bolus
+  , 46501 --	H2O Bolus
+  , 45045 --	WaterBolus
+  , 41984 --	FREE H20
+  , 41371 --	ns fluid bolus
+  , 41582 --	free h20 bolus
+  , 41322 --	rl bolus
+  , 40778 --	Free H2O
+  , 41896 --	ivf boluses
+  , 41428 --	ns .9% bolus
+  , 43936 --	FREE WATER BOLUSES
+  , 44200 --	FLUID BOLUS
+  , 41619 --	frfee water boluses
+  , 40424 --	free H2O
+  , 41457 --	Free H20 intake
+  , 41581 --	Water bolus
+  , 42844 --	NS fluid bolus
+  , 42429 --	Free water
+  , 41356 --	IV Bolus
+  , 40532 --	FREE H2O
+  , 42548 --	NS Bolus
+  , 44184 --	LR Bolus
+  , 44521 --	LR bolus
+  , 44741 --	NS FLUID BOLUS
+  , 44126 --	fl bolus
+  , 44110 --	RL BOLUS
+  , 44633 --	ns boluses
+  , 44983 --	Bolus NS
+  , 44815 --	LR BOLUS
+  , 43986 --	iv bolus
+  , 45079 --	500 cc ns bolus
+  , 46781 --	lr bolus
+  , 45155 --	ns cc/cc replacement
+  , 43909 --	H20 BOlus
+  , 41467 --	NS IV bolus
+  , 44367 --	LR
+  , 41743 --	water bolus
+  , 40423 --	Bolus
+  , 44263 --	fluid bolus ns
+  , 42749 --	fluid bolus NS
+  , 45480 --	500cc ns bolus
+  , 44491 --	.9NS bolus
+  , 41695 --	NS fluid boluses
+  , 46169 --	free water bolus.
+  , 41580 --	free h2o bolus
+  , 41392 --	ns b
+  , 45989 --	NS Fluid Bolus
+  , 45137 --	NS cc/cc
+  , 45154 --	Free H20 bolus
+  , 44053 --	normal saline bolus
+  , 41416 --	free h2o boluses
+  , 44761 --	Free H20
+  , 41237 --	ns fluid boluses
+  , 44426 --	bolus ns
+  , 43975 --	FREE H20 BOLUSES
+  , 44894 --	N/s 500 ml bolus
+  , 41380 --	nsbolus
+  , 42671 --	free h2o
+  )
+  and cv.amount > 248
+  and cv.amount <= 2000
+  and cv.amountuom = 'ml'
+)
+select
+    icustay_id
+  , charttime
+  , sum(amount) as crystalloid_bolus
+from t1
+-- just because the rate was high enough, does *not* mean the final amount was
+where amount > 248
+group by t1.icustay_id, t1.charttime
+UNION
+select
+    icustay_id
+  , charttime
+  , sum(amount) as crystalloid_bolus
+from t2
+group by t2.icustay_id, t2.charttime
+order by icustay_id, charttime;


### PR DESCRIPTION
Why: Use `cp buildmimic/docker/setup.sh /docker-entrypoint-initdb.d/` instead of `ADD setup.sh /docker-entrypoint-initdb.d/`, because in auto-builds (like dockerhub), the system will use the root folder of this repo as root.

This PR make it easier to make auto builds by refactoring the Dockerfile. Reference case: https://hub.docker.com/r/qpod/postgres-mimic/tags