### PR TITLE
Update Logic for Central and Arterial Line Durations

### DIFF
--- a/concepts/durations/arterial-line-durations.sql
+++ b/concepts/durations/arterial-line-durations.sql
@@ -6,9 +6,11 @@ with mv as
     pe.icustay_id
   , pe.starttime, pe.endtime
   , case
-      when itemid = 225752
+      when itemid in (225752, 224272)
         then 1
       when pe.locationcategory = 'Invasive Arterial'
+        then 1
+      when itemid = 225789 and pe.locationcategory IS NULL
         then 1
       else 0
     end as arterial_line
@@ -24,6 +26,8 @@ with mv as
     -- , 225203 -- Pheresis Catheter | None | 12 | Processes
     -- , 225315 -- Tunneled (Hickman) Line | None | 12 | Processes
     , 225752 -- Arterial Line | None | 12 | Processes
+    , 225789 -- Sheath
+    , 224272 -- IABP Line
     -- , 227719 -- AVA Line | None | 12 | Processes
     -- , 228286 -- Intraosseous Device | None | 12 | Processes
   )
@@ -102,14 +106,14 @@ with mv as
 (
   select distinct icustay_id, charttime
   from cv_grp
-  where (inv1_type = 'A-Line')
-     OR (inv2_type = 'A-Line')
-     OR (inv3_type = 'A-Line')
-     OR (inv4_type = 'A-Line')
-     OR (inv5_type = 'A-Line')
-     OR (inv6_type = 'A-Line')
-     OR (inv7_type = 'A-Line')
-     OR (inv8_type = 'A-Line')
+  where (inv1_type in ('A-Line', 'IABP'))
+     OR (inv2_type in ('A-Line', 'IABP'))
+     OR (inv3_type in ('A-Line', 'IABP'))
+     OR (inv4_type in ('A-Line', 'IABP'))
+     OR (inv5_type in ('A-Line', 'IABP'))
+     OR (inv6_type in ('A-Line', 'IABP'))
+     OR (inv7_type in ('A-Line', 'IABP'))
+     OR (inv8_type in ('A-Line', 'IABP'))
 )
 -- transform carevue data into durations
 , cv0 as

--- a/concepts/durations/central-line-durations.sql
+++ b/concepts/durations/central-line-durations.sql
@@ -101,14 +101,14 @@ with mv as
 (
   select distinct icustay_id, charttime
   from cv_grp
-  where (inv1_type in ('PICC line', 'Hickman', 'Portacath'))
-     OR (inv2_type in ('PICC line', 'Hickman', 'Portacath'))
-     OR (inv3_type in ('PICC line', 'Hickman', 'Portacath'))
-     OR (inv4_type in ('PICC line', 'Hickman', 'Portacath'))
-     OR (inv5_type in ('PICC line', 'Hickman', 'Portacath'))
-     OR (inv6_type in ('PICC line', 'Hickman', 'Portacath'))
-     OR (inv7_type in ('PICC line', 'Hickman', 'Portacath'))
-     OR (inv8_type in ('PICC line', 'Hickman', 'Portacath'))
+  where (inv1_type in ('Multi-lumen', 'PICC line', 'Dialysis Line', 'Introducer','Trauma Line', 'Portacath', 'Venous Access', 'Hickman', 'PacerIntroducer', 'TripleIntroducer'))
+     OR (inv2_type in ('Multi-lumen', 'PICC line', 'Dialysis Line', 'Introducer','Trauma Line', 'Portacath', 'Venous Access', 'Hickman', 'PacerIntroducer', 'TripleIntroducer'))
+     OR (inv3_type in ('Multi-lumen', 'PICC line', 'Dialysis Line', 'Introducer','Trauma Line', 'Portacath', 'Venous Access', 'Hickman', 'PacerIntroducer', 'TripleIntroducer'))
+     OR (inv4_type in ('Multi-lumen', 'PICC line', 'Dialysis Line', 'Introducer','Trauma Line', 'Portacath', 'Venous Access', 'Hickman', 'PacerIntroducer', 'TripleIntroducer'))
+     OR (inv5_type in ('Multi-lumen', 'PICC line', 'Dialysis Line', 'Introducer','Trauma Line', 'Portacath', 'Venous Access', 'Hickman', 'PacerIntroducer', 'TripleIntroducer'))
+     OR (inv6_type in ('Multi-lumen', 'PICC line', 'Dialysis Line', 'Introducer','Trauma Line', 'Portacath', 'Venous Access', 'Hickman', 'PacerIntroducer', 'TripleIntroducer'))
+     OR (inv7_type in ('Multi-lumen', 'PICC line', 'Dialysis Line', 'Introducer','Trauma Line', 'Portacath', 'Venous Access', 'Hickman', 'PacerIntroducer', 'TripleIntroducer'))
+     OR (inv8_type in ('Multi-lumen', 'PICC line', 'Dialysis Line', 'Introducer','Trauma Line', 'Portacath', 'Venous Access', 'Hickman', 'PacerIntroducer', 'TripleIntroducer'))
 )
 -- transform carevue data into durations
 , cv0 as

--- a/concepts/durations/central-line-durations.sql
+++ b/concepts/durations/central-line-durations.sql
@@ -6,9 +6,7 @@ with mv as
     pe.icustay_id
   , pe.starttime, pe.endtime
     , case
-        when itemid in (224264,225202,225315,227719)
-          then 1
-        when pe.locationcategory = 'Invasive Venous'
+        when (locationcategory <> 'Invasive Arterial' or locationcategory is null)
           then 1
         else 0
       end as central_line
@@ -21,11 +19,12 @@ with mv as
     , 224268 -- Trauma line | None | 12 | Processes
     , 225199 -- Triple Introducer | None | 12 | Processes
     , 225202 -- Indwelling Port (PortaCath) | None | 12 | Processes
-    -- , 225203 -- Pheresis Catheter | None | 12 | Processes
+    , 225203 -- Pheresis Catheter | None | 12 | Processes
     , 225315 -- Tunneled (Hickman) Line | None | 12 | Processes
     , 225752 -- Arterial Line | None | 12 | Processes
     , 227719 -- AVA Line | None | 12 | Processes
     -- , 228286 -- Intraosseous Device | None | 12 | Processes
+    , 224270 -- Dialysis Catheter
   )
 )
 , cv_grp as


### PR DESCRIPTION
I was looking at the views for arterial and central line durations and I think we should make a couple of changes:
1) For Metavision Arterial Lines, IABP should be considered arterial access. Also, a sheath without a venous location category is likely arterial -- All of these patients also have arterial blood pressures recorded despite having no other arterial lines. Here is a query I used to confirm this. 
WITH mv_artlines AS (
	SELECT 
		icustay_id
		, COUNT(*) AS totalLines
		, COUNT(location) as NullLocationLines
	FROM
		procedureevents_mv
	WHERE
		itemid = 225789
	GROUP BY icustay_id
	HAVING COUNT(*) > 0 AND COUNT(location) = 0
)
SELECT
	icustay_id
	, COUNT(*)
	, MIN(totalLines)
	, MIN(NullLocationLines)
FROM
	chartevents
INNER JOIN mv_artlines USING (icustay_id)
WHERE
	itemid IN (225309, 225310, 225312) -- MV ArtLine S/D/M BP
GROUP BY icustay_id;

2) IABP should also be considered an arterial line for carevue. Some of the sheaths that are counted as venous access are likely arterial but there's no great way to tease these out.

3) For the central lines in meta vision, I added a couple items. Also, all of these lines should be presumed venous if their location is null (rather than just PICC, port, hickman, and AVA). 

4) For the central lines in carevue, I added several line types that were commonly seen (and should be counted as central lines). The line types are now also sorted by frequency.