### PR TITLE
Updated README.md in buildmimic/docker to use the correct mount point

### DIFF
--- a/buildmimic/docker/README.md
+++ b/buildmimic/docker/README.md
@@ -78,7 +78,7 @@ is the owner of the `mimic` database. Note that these scripts may take several h
     -e POSTGRES_PASSWORD=POSTGRES_USER_PASSWORD \
     -e MIMIC_PASSWORD=MIMIC_USER_PASSWORD \
     -v /HOST/mimic_data/csv:/mimic_data \
-    -v /HOST/PGDATA_DIR:/var/lib/PostgreSQL/data \
+    -v /HOST/PGDATA_DIR:/var/lib/postgresql/data \
     -d postgres/mimic
 
 In detail, this command:


### PR DESCRIPTION
I updated the README.md in buildmimic/docker to use the correct volume mount point for pg_data.  The original capitalization was "/var/lib/PostgreSQL/data", but the "postgres:latest" image writes to "/var/lib/postgresql/data" by default.