### PR TITLE
Change logic for KDIGO staging

### DIFF
--- a/concepts/organfailure/kdigo-stages-48hr.sql
+++ b/concepts/organfailure/kdigo-stages-48hr.sql
@@ -26,12 +26,12 @@ WITH cr_aki AS
   SELECT
     k.icustay_id
     , k.charttime
-    , k.uo_6hr, k.uo_12hr, k.uo_24hr
+    , k.uo_rt_6hr, k.uo_rt_12hr, k.uo_rt_24hr
     , k.aki_stage_uo
     , ROW_NUMBER() OVER 
     (
       PARTITION BY k.icustay_id
-      ORDER BY k.aki_stage_uo DESC, k.uo_24hr DESC, k.uo_12hr DESC, k.uo_6hr DESC
+      ORDER BY k.aki_stage_uo DESC, k.uo_rt_24hr DESC, k.uo_rt_12hr DESC, k.uo_rt_6hr DESC
     ) AS rn
   FROM icustays ie
   INNER JOIN kdigo_stages k
@@ -47,9 +47,9 @@ select
   , cr.creat
   , cr.aki_stage_creat
   , uo.charttime as charttime_uo
-  , uo.uo_6hr
-  , uo.uo_12hr
-  , uo.uo_24hr
+  , uo.uo_rt_6hr
+  , uo.uo_rt_12hr
+  , uo.uo_rt_24hr
   , uo.aki_stage_uo
 
   -- Classify AKI using both creatinine/urine output criteria

--- a/concepts/organfailure/kdigo-stages-48hr.sql
+++ b/concepts/organfailure/kdigo-stages-48hr.sql
@@ -1,133 +1,66 @@
--- This query checks if the patient had AKI according to KDIGO on admission
--- AKI can be defined either using data from the first 2 days, or first 7 days
-
--- For urine output: the highest UO in hours 0-48 is used
--- For creatinine: the creatinine value from days 0-2 or 0-7 is used.
--- Baseline creatinine is defined as first measurement in hours [-6, 24] from ICU admit
+-- This query checks if the patient had AKI during the first 48 hours of their ICU
+-- stay according to the KDIGO guideline.
+-- https://kdigo.org/wp-content/uploads/2016/10/KDIGO-2012-AKI-Guideline-English.pdf
 
 DROP MATERIALIZED VIEW IF EXISTS kdigo_stages_48hr;
 CREATE MATERIALIZED VIEW kdigo_stages_48hr AS
-with uo_6hr as
+-- get the worst staging of creatinine in the first 48 hours
+WITH cr_aki AS
 (
-  select
-        ie.icustay_id
-      -- , uo.charttime
-      -- , uo.urineoutput_6hr
-      , min(uo.urineoutput_6hr / uo.weight / 6.0)::numeric as uo6
-  from icustays ie
-  inner join kdigo_uo uo
-    on ie.icustay_id = uo.icustay_id
-    -- require the patient to be in the ICU for at least 6 hours
-    -- allows us to have at least 6 hours of documentation
-    and uo.charttime >= ie.intime + interval '6' hour
-    and uo.charttime <= ie.intime + interval '48' hour
-  group by ie.icustay_id
+  SELECT
+    k.icustay_id
+    , k.charttime
+    , k.creat
+    , k.aki_stage_creat
+    , ROW_NUMBER() OVER (PARTITION BY k.icustay_id ORDER BY k.aki_stage_creat DESC, k.creat DESC) AS rn
+  FROM icustays ie
+  INNER JOIN kdigo_stages k
+    ON ie.icustay_id = k.icustay_id
+  WHERE k.charttime > (ie.intime - interval '6' hour)
+  AND k.charttime <= (ie.intime + interval '48' hour)
+  AND k.aki_stage_creat IS NOT NULL
 )
-, uo_12hr as
+-- get the worst staging of urine output in the first 48 hours
+, uo_aki AS
 (
-  select
-      ie.icustay_id
-      -- , uo.charttime
-      -- , uo.weight
-      -- , uo.urineoutput_12hr
-      , min(uo.urineoutput_12hr / uo.weight / 12.0)::numeric as uo12
-  from icustays ie
-  inner join kdigo_uo uo
-    on ie.icustay_id = uo.icustay_id
-    -- require the patient to be in the ICU for 12 hours
-    -- allows us to have at least 12 hours of documentation
-    and uo.charttime >= ie.intime + interval '12' hour
-    and uo.charttime <= ie.intime + interval '48' hour
-  group by ie.icustay_id
+  SELECT
+    k.icustay_id
+    , k.charttime
+    , k.uo_6hr, k.uo_12hr, k.uo_24hr
+    , k.aki_stage_uo
+    , ROW_NUMBER() OVER 
+    (
+      PARTITION BY k.icustay_id
+      ORDER BY k.aki_stage_uo DESC, k.uo_24hr DESC, k.uo_12hr DESC, k.uo_6hr DESC
+    ) AS rn
+  FROM icustays ie
+  INNER JOIN kdigo_stages k
+    ON ie.icustay_id = k.icustay_id
+  WHERE k.charttime > (ie.intime - interval '6' hour)
+  AND k.charttime <= (ie.intime + interval '48' hour)
+  AND k.aki_stage_uo IS NOT NULL
 )
-, uo_24hr as
-(
-  select
-      ie.icustay_id
-      -- , uo.charttime
-      -- , uo.weight
-      -- , uo.urineoutput_24hr
-      , min(uo.urineoutput_24hr / uo.weight / 24.0)::numeric as uo24
-  from icustays ie
-  inner join kdigo_uo uo
-    on ie.icustay_id = uo.icustay_id
-    -- require the patient to be in the ICU for 24 hours
-    -- allows us to have at least 24 hours of documentation
-    and uo.charttime >= ie.intime + interval '24' hour
-    and uo.charttime <= ie.intime + interval '48' hour
-  group by ie.icustay_id
-)
--- stages for UO / creat
-, kdigo_stg as
-(
-
-  select ie.icustay_id
-  , ie.intime, ie.outtime
-  , case
-    when HighCreat48hr >= (LowCreat48hr*3.0) then 3
-    when HighCreat48hr >= 4 -- note the criteria specify an INCREASE to >=4
-      and LowCreat48hr <= (3.7)  then 3 -- therefore we check that adm <= 3.7
-    -- TODO: initiation of RRT
-    when HighCreat48hr >= (LowCreat48hr*2.0) then 2
-    when HighCreat48hr >= (LowCreat48hr+0.3) then 1
-    when HighCreat48hr >= (LowCreat48hr*1.5) then 1
-    when HighCreat48hr is null then null
-      when LowCreat48hr is null then null
-    else 0 end as AKI_stage_48hr_creat
-
-  -- AKI stages according to urine output
-  , case
-      when UO24 < 0.3 then 3
-      when UO12 = 0 then 3
-      when UO12 < 0.5 then 2
-      when UO6  < 0.5 then 1
-      when UO6  is null then null
-    else 0 end as AKI_stage_48hr_uo
-
-  -- Creatinine information
-  , HighCreat48hr, HighCreat48hrTime
-  , LowCreat48hr, LowCreat48hrTime
-
-  -- Urine output information: the values and the time of their measurement
-  , round(UO6,4) as UO6_48hr
-  , round(UO12,4) as UO12_48hr
-  , round(UO24,4) as UO24_48hr
-  from icustays ie
-  left join uo_6hr  on ie.icustay_id = uo_6hr.icustay_id
-  left join uo_12hr on ie.icustay_id = uo_12hr.icustay_id
-  left join uo_24hr on ie.icustay_id = uo_24hr.icustay_id
-  left join KDIGO_CREAT cr on ie.icustay_id = cr.icustay_id
-)
+-- final table is aki_stage, include worst cr/uo for convenience
 select
-  kd.icustay_id
+    ie.icustay_id
+  , cr.charttime as charttime_creat
+  , cr.creat
+  , cr.aki_stage_creat
+  , uo.charttime as charttime_uo
+  , uo.uo_6hr
+  , uo.uo_12hr
+  , uo.uo_24hr
+  , uo.aki_stage_uo
 
   -- Classify AKI using both creatinine/urine output criteria
-  , case
-      when coalesce(AKI_stage_48hr_creat,AKI_stage_48hr_uo) > 0 then 1
-      else coalesce(AKI_stage_48hr_creat,AKI_stage_48hr_uo)
-    end as AKI_48hr
+  , GREATEST(cr.aki_stage_creat,uo.aki_stage_uo) AS aki_stage_48hr
+  , CASE WHEN GREATEST(cr.aki_stage_creat, uo.aki_stage_uo) > 0 THEN 1 ELSE 0 END AS aki_48hr
 
-  , case
-      when AKI_stage_48hr_creat >= AKI_stage_48hr_uo then AKI_stage_48hr_creat
-      when AKI_stage_48hr_uo > AKI_stage_48hr_creat then AKI_stage_48hr_uo
-      else coalesce(AKI_stage_48hr_creat,AKI_stage_48hr_uo)
-    end as AKI_stage_48hr
-
-  -- components
-  , AKI_stage_48hr_creat
-  , AKI_stage_48hr_uo
-
-  -- Creatinine information - convert absolute times to hours since admission
-  , LowCreat48hr
-  , HighCreat48hr
-  , ROUND(extract(epoch from (LowCreat48hrTime-intime))::numeric / 60.0 / 60.0 / 24.0, 4) as LowCreat48hrTimeElapsed
-  , ROUND(extract(epoch from (HighCreat48hrTime-intime))::numeric / 60.0 / 60.0 / 24.0, 4) as HighCreat48hrTimeElapsed
-  , LowCreat48hrTime
-  , HighCreat48hrTime
-
-  -- Urine output information: the values and the time of their measurement
-  , UO6_48hr
-  , UO12_48hr
-  , UO24_48hr
-from kdigo_stg kd
-order by kd.icustay_id;
+FROM icustays ie
+LEFT JOIN cr_aki cr
+  ON ie.icustay_id = cr.icustay_id
+  AND cr.rn = 1
+LEFT JOIN uo_aki uo
+  ON ie.icustay_id = uo.icustay_id
+  AND uo.rn = 1
+order by ie.icustay_id;

--- a/concepts/organfailure/kdigo-stages-7day.sql
+++ b/concepts/organfailure/kdigo-stages-7day.sql
@@ -1,131 +1,66 @@
--- This query checks if the patient had AKI according to KDIGO on admission
--- AKI can be defined either using data from the first 2 days, or first 7 days
-
--- For urine output: the highest UO in hours 0-48 is used
--- For creatinine: the creatinine value from days 0-2 or 0-7 is used.
--- Baseline creatinine is defined as first measurement in hours [-6, 24] from ICU admit
+-- This query checks if the patient had AKI during the first 7 days of their ICU
+-- stay according to the KDIGO guideline.
+-- https://kdigo.org/wp-content/uploads/2016/10/KDIGO-2012-AKI-Guideline-English.pdf
 
 DROP MATERIALIZED VIEW IF EXISTS kdigo_stages_7day;
 CREATE MATERIALIZED VIEW kdigo_stages_7day AS
-with uo_6hr as
+-- get the worst staging of creatinine in the first 48 hours
+WITH cr_aki AS
 (
-  select
-        ie.icustay_id
-      -- , uo.charttime
-      -- , uo.urineoutput_6hr
-      , min(uo.urineoutput_6hr / uo.weight / 6.0)::numeric as uo6
-  from icustays ie
-  inner join kdigo_uo uo
-    on ie.icustay_id = uo.icustay_id
-    -- require the patient to be in the ICU for at least 6 hours
-    -- allows us to have at least 6 hours of documentation
-    and uo.charttime >= ie.intime + interval '6' hour
-    and uo.charttime <= ie.intime + interval '7' day
-  group by ie.icustay_id
+  SELECT
+    k.icustay_id
+    , k.charttime
+    , k.creat
+    , k.aki_stage_creat
+    , ROW_NUMBER() OVER (PARTITION BY k.icustay_id ORDER BY k.aki_stage_creat DESC, k.creat DESC) AS rn
+  FROM icustays ie
+  INNER JOIN kdigo_stages k
+    ON ie.icustay_id = k.icustay_id
+  WHERE k.charttime > (ie.intime - interval '6' hour)
+  AND k.charttime <= (ie.intime + interval '7' day)
+  AND k.aki_stage_creat IS NOT NULL
 )
-, uo_12hr as
+-- get the worst staging of urine output in the first 48 hours
+, uo_aki AS
 (
-  select
-      ie.icustay_id
-      -- , uo.charttime
-      -- , uo.weight
-      -- , uo.urineoutput_12hr
-      , min(uo.urineoutput_12hr / uo.weight / 12.0)::numeric as uo12
-  from icustays ie
-  inner join kdigo_uo uo
-    on ie.icustay_id = uo.icustay_id
-    -- require the patient to be in the ICU for at least 12 hours
-    -- allows us to have at least 12 hours of documentation
-    and uo.charttime >= ie.intime + interval '12' hour
-    and uo.charttime <= ie.intime + interval '7' day
-  group by ie.icustay_id
+  SELECT
+    k.icustay_id
+    , k.charttime
+    , k.uo_6hr, k.uo_12hr, k.uo_24hr
+    , k.aki_stage_uo
+    , ROW_NUMBER() OVER 
+    (
+      PARTITION BY k.icustay_id
+      ORDER BY k.aki_stage_uo DESC, k.uo_24hr DESC, k.uo_12hr DESC, k.uo_6hr DESC
+    ) AS rn
+  FROM icustays ie
+  INNER JOIN kdigo_stages k
+    ON ie.icustay_id = k.icustay_id
+  WHERE k.charttime > (ie.intime - interval '6' hour)
+  AND k.charttime <= (ie.intime + interval '7' day)
+  AND k.aki_stage_uo IS NOT NULL
 )
-, uo_24hr as
-(
-  select
-      ie.icustay_id
-      -- , uo.charttime
-      -- , uo.weight
-      -- , uo.urineoutput_24hr
-      , min(uo.urineoutput_24hr / uo.weight / 24.0)::numeric as uo24
-  from icustays ie
-  inner join kdigo_uo uo
-    on ie.icustay_id = uo.icustay_id
-    -- require the patient to be in the ICU for at least 12 hours
-    -- allows us to have at least 12 hours of documentation
-    and uo.charttime >= ie.intime + interval '24' hour
-    and uo.charttime <= ie.intime + interval '7' day
-  group by ie.icustay_id
-)
--- stages for UO / creat
-, kdigo_stg as
-(
-
-  select ie.icustay_id
-  , ie.intime, ie.outtime
-  , case
-    when HighCreat7day >= (LowCreat7day*3.0) then 3
-    when HighCreat7day >= 4 -- note the criteria specify an INCREASE to >=4
-      and LowCreat7day <= (3.7)  then 3 -- therefore we check that adm <= 3.7
-    -- TODO: initiation of RRT
-    when HighCreat7day >= (LowCreat7day*2.0) then 2
-    when HighCreat7day >= (LowCreat7day+0.3) then 1
-    when HighCreat7day >= (LowCreat7day*1.5) then 1
-    when HighCreat7day is null then null
-      when LowCreat7day is null then null
-    else 0 end as AKI_stage_7day_creat
-
-  -- AKI stages according to urine output
-  , case
-      when UO24 < 0.3 then 3
-      when UO12 = 0 then 3
-      when UO12 < 0.5 then 2
-      when UO6  < 0.5 then 1
-      when UO6  is null then null
-    else 0 end as AKI_stage_7day_uo
-
-  -- Creatinine information
-  , LowCreat7dayTime, LowCreat7day
-  , HighCreat7dayTime, HighCreat7day
-
-  -- Urine output information: the values and the time of their measurement
-  , round(UO6,4) as UO6_48hr
-  , round(UO12,4) as UO12_48hr
-  , round(UO24,4) as UO24_48hr
-  from icustays ie
-  left join uo_6hr  on ie.icustay_id = uo_6hr.icustay_id
-  left join uo_12hr on ie.icustay_id = uo_12hr.icustay_id
-  left join uo_24hr on ie.icustay_id = uo_24hr.icustay_id
-  left join KDIGO_CREAT cr on ie.icustay_id = cr.icustay_id
-)
+-- final table is aki_stage, include worst cr/uo for convenience
 select
-  kd.icustay_id
+    ie.icustay_id
+  , cr.charttime as charttime_creat
+  , cr.creat
+  , cr.aki_stage_creat
+  , uo.charttime as charttime_uo
+  , uo.uo_6hr
+  , uo.uo_12hr
+  , uo.uo_24hr
+  , uo.aki_stage_uo
 
   -- Classify AKI using both creatinine/urine output criteria
-  , case
-      when coalesce(AKI_stage_7day_creat,AKI_stage_7day_uo) > 0 then 1
-      else coalesce(AKI_stage_7day_creat,AKI_stage_7day_uo)
-    end as AKI_7day
+  , GREATEST(cr.aki_stage_creat,uo.aki_stage_uo) AS aki_stage_48hr
+  , CASE WHEN GREATEST(cr.aki_stage_creat, uo.aki_stage_uo) > 0 THEN 1 ELSE 0 END AS aki_48hr
 
-  , case
-      when AKI_stage_7day_creat >= AKI_stage_7day_uo then AKI_stage_7day_creat
-      when AKI_stage_7day_uo > AKI_stage_7day_creat then AKI_stage_7day_uo
-      else coalesce(AKI_stage_7day_creat,AKI_stage_7day_uo)
-    end as AKI_stage_7day
-
-  , AKI_stage_7day_creat
-
-  -- Creatinine information - convert absolute times to hours since admission
-  , LowCreat7day
-  , HighCreat7day
-  , ROUND(extract(epoch from (LowCreat7dayTime-intime))::numeric / 60.0 / 60.0 / 24.0, 4) as LowCreat7dayTimeElapsed
-  , ROUND(extract(epoch from (HighCreat7dayTime-intime))::numeric / 60.0 / 60.0 / 24.0, 4) as HighCreat7dayTimeElapsed
-  , LowCreat7dayTime
-  , HighCreat7dayTime
-
-  -- Urine output information: the values and the time of their measurement
-  , UO6_48hr
-  , UO12_48hr
-  , UO24_48hr
-from kdigo_stg kd
-order by kd.icustay_id;
+FROM icustays ie
+LEFT JOIN cr_aki cr
+  ON ie.icustay_id = cr.icustay_id
+  AND cr.rn = 1
+LEFT JOIN uo_aki uo
+  ON ie.icustay_id = uo.icustay_id
+  AND uo.rn = 1
+order by ie.icustay_id;

--- a/concepts/organfailure/kdigo-stages-7day.sql
+++ b/concepts/organfailure/kdigo-stages-7day.sql
@@ -26,12 +26,12 @@ WITH cr_aki AS
   SELECT
     k.icustay_id
     , k.charttime
-    , k.uo_6hr, k.uo_12hr, k.uo_24hr
+    , k.uo_rt_6hr, k.uo_rt_12hr, k.uo_rt_24hr
     , k.aki_stage_uo
     , ROW_NUMBER() OVER 
     (
       PARTITION BY k.icustay_id
-      ORDER BY k.aki_stage_uo DESC, k.uo_24hr DESC, k.uo_12hr DESC, k.uo_6hr DESC
+      ORDER BY k.aki_stage_uo DESC, k.uo_rt_24hr DESC, k.uo_rt_12hr DESC, k.uo_rt_6hr DESC
     ) AS rn
   FROM icustays ie
   INNER JOIN kdigo_stages k
@@ -47,14 +47,14 @@ select
   , cr.creat
   , cr.aki_stage_creat
   , uo.charttime as charttime_uo
-  , uo.uo_6hr
-  , uo.uo_12hr
-  , uo.uo_24hr
+  , uo.uo_rt_6hr
+  , uo.uo_rt_12hr
+  , uo.uo_rt_24hr
   , uo.aki_stage_uo
 
   -- Classify AKI using both creatinine/urine output criteria
-  , GREATEST(cr.aki_stage_creat,uo.aki_stage_uo) AS aki_stage_48hr
-  , CASE WHEN GREATEST(cr.aki_stage_creat, uo.aki_stage_uo) > 0 THEN 1 ELSE 0 END AS aki_48hr
+  , GREATEST(cr.aki_stage_creat,uo.aki_stage_uo) AS aki_stage_7day
+  , CASE WHEN GREATEST(cr.aki_stage_creat, uo.aki_stage_uo) > 0 THEN 1 ELSE 0 END AS aki_7day
 
 FROM icustays ie
 LEFT JOIN cr_aki cr

--- a/concepts/organfailure/kdigo-stages.sql
+++ b/concepts/organfailure/kdigo-stages.sql
@@ -45,14 +45,10 @@ with cr_stg AS
         WHEN uo.charttime <= ie.intime + interval '6' hour THEN 0
         -- require the UO rate to be calculated over half the period
         -- i.e. for uo rate over 24 hours, require documentation at least 12 hr apart
-        WHEN uo.charttime >= uo.uo_tm_24hr + interval '12' hour
-            AND uo.uo_rt_24hr < 0.3 THEN 3
-        WHEN uo.charttime >= uo.uo_tm_12hr + interval '6' hour
-            AND uo.uo_rt_12hr = 0 THEN 3
-        WHEN uo.charttime >= uo.uo_tm_12hr + interval '6' hour
-            AND uo.uo_rt_12hr < 0.5 THEN 2
-        WHEN uo.charttime >= uo.uo_tm_6hr + interval '3' hour
-            AND uo.uo_rt_6hr  < 0.5 THEN 1
+        WHEN uo.uo_tm_24hr >= 11 AND uo.uo_rt_24hr < 0.3 THEN 3
+        WHEN uo.uo_tm_12hr >= 5 AND uo.uo_rt_12hr = 0 THEN 3
+        WHEN uo.uo_tm_12hr >= 5 AND uo.uo_rt_12hr < 0.5 THEN 2
+        WHEN uo.uo_tm_6hr >= 2 AND uo.uo_rt_6hr  < 0.5 THEN 1
     ELSE 0 END AS aki_stage_uo
   from kdigo_uo uo
   INNER JOIN icustays ie

--- a/concepts/organfailure/kdigo-stages.sql
+++ b/concepts/organfailure/kdigo-stages.sql
@@ -35,16 +35,16 @@ with cr_stg AS
       uo.icustay_id
     , uo.charttime
     , uo.weight
-    , ROUND(CAST(uo.UrineOutput_6hr  AS NUMERIC), 4) AS uo_6hr
-    , ROUND(CAST(uo.UrineOutput_12hr AS NUMERIC), 4) AS uo_12hr
-    , ROUND(CAST(uo.UrineOutput_24hr AS NUMERIC), 4) AS uo_24hr
+    , uo.uo_rt_6hr
+    , uo.uo_rt_12hr
+    , uo.uo_rt_24hr
     -- AKI stages according to urine output
     , case
-        when uo.UrineOutput_6hr is null then null
-        when uo.UrineOutput_24hr < 0.3 then 3
-        when uo.UrineOutput_12hr = 0 then 3
-        when uo.UrineOutput_12hr < 0.5 then 2
-        when uo.UrineOutput_6hr  < 0.5 then 1
+        when uo.uo_rt_6hr is null then null
+        when uo.uo_rt_24hr < 0.3 then 3
+        when uo.uo_rt_12hr = 0 then 3
+        when uo.uo_rt_12hr < 0.5 then 2
+        when uo.uo_rt_6hr  < 0.5 then 1
     else 0 end as aki_stage_uo
   from kdigo_uo uo
 )
@@ -64,11 +64,10 @@ select
   , tm.charttime
   , cr.creat
   , cr.aki_stage_creat
-  , uo.uo_6hr
-  , uo.uo_12hr
-  , uo.uo_24hr
+  , uo.uo_rt_6hr
+  , uo.uo_rt_12hr
+  , uo.uo_rt_24hr
   , uo.aki_stage_uo
-
   -- Classify AKI using both creatinine/urine output criteria
   , GREATEST(cr.aki_stage_creat, uo.aki_stage_uo) AS aki_stage
 FROM icustays ie

--- a/concepts/organfailure/kdigo-stages.sql
+++ b/concepts/organfailure/kdigo-stages.sql
@@ -1,0 +1,84 @@
+-- This query checks if the patient had AKI according to KDIGO.
+-- AKI is calculated every time a creatinine or urine output measurement occurs.
+-- Baseline creatinine is defined as the lowest creatinine in the past 7 days.
+
+DROP MATERIALIZED VIEW IF EXISTS kdigo_stages;
+CREATE MATERIALIZED VIEW kdigo_stages AS
+-- get creatinine stages
+with cr_stg AS
+(
+  SELECT
+    cr.icustay_id
+    , cr.charttime
+    , cr.creat
+    , case
+        -- 3x baseline
+        when cr.creat >= (cr.creat_low_past_7day*3.0) then 3
+        -- *OR* cr >= 4.0 with associated increase
+        when cr.creat >= 4
+        -- For patients reaching Stage 3 by SCr >4.0 mg/dl
+        -- require that the patient first achieve ... acute increase >= 0.3 within 48 hr
+        -- *or* an increase of >= 1.5 times baseline
+        and (cr.creat_low_past_48hr <= 3.7 OR cr.creat >= (1.5*cr.creat_low_past_7day))
+            then 3 
+        -- TODO: initiation of RRT
+        when cr.creat >= (cr.creat_low_past_7day*2.0) then 2
+        when cr.creat >= (cr.creat_low_past_48hr+0.3) then 1
+        when cr.creat >= (cr.creat_low_past_7day*1.5) then 1
+    else 0 end as aki_stage_creat
+  FROM kdigo_creat cr
+)
+-- stages for UO / creat
+, uo_stg as
+(
+  select
+      uo.icustay_id
+    , uo.charttime
+    , uo.weight
+    , ROUND(CAST(uo.UrineOutput_6hr  AS NUMERIC), 4) AS uo_6hr
+    , ROUND(CAST(uo.UrineOutput_12hr AS NUMERIC), 4) AS uo_12hr
+    , ROUND(CAST(uo.UrineOutput_24hr AS NUMERIC), 4) AS uo_24hr
+    -- AKI stages according to urine output
+    , case
+        when uo.UrineOutput_6hr is null then null
+        when uo.UrineOutput_24hr < 0.3 then 3
+        when uo.UrineOutput_12hr = 0 then 3
+        when uo.UrineOutput_12hr < 0.5 then 2
+        when uo.UrineOutput_6hr  < 0.5 then 1
+    else 0 end as aki_stage_uo
+  from kdigo_uo uo
+)
+-- get all charttimes documented
+, tm_stg AS
+(
+    SELECT
+      icustay_id, charttime
+    FROM cr_stg
+    UNION
+    SELECT
+      icustay_id, charttime
+    FROM uo_stg
+)
+select
+    ie.icustay_id
+  , tm.charttime
+  , cr.creat
+  , cr.aki_stage_creat
+  , uo.uo_6hr
+  , uo.uo_12hr
+  , uo.uo_24hr
+  , uo.aki_stage_uo
+
+  -- Classify AKI using both creatinine/urine output criteria
+  , GREATEST(cr.aki_stage_creat, uo.aki_stage_uo) AS aki_stage
+FROM icustays ie
+-- get all possible charttimes as listed in tm_stg
+LEFT JOIN tm_stg tm
+  ON ie.icustay_id = tm.icustay_id
+LEFT JOIN cr_stg cr
+  ON ie.icustay_id = cr.icustay_id
+  AND tm.charttime = cr.charttime
+LEFT JOIN uo_stg uo
+  ON ie.icustay_id = uo.icustay_id
+  AND tm.charttime = uo.charttime
+order by ie.icustay_id, tm.charttime;

--- a/concepts/organfailure/kdigo-stages.sql
+++ b/concepts/organfailure/kdigo-stages.sql
@@ -2,7 +2,7 @@
 -- AKI is calculated every time a creatinine or urine output measurement occurs.
 -- Baseline creatinine is defined as the lowest creatinine in the past 7 days.
 
-DROP MATERIALIZED VIEW IF EXISTS kdigo_stages;
+DROP MATERIALIZED VIEW IF EXISTS kdigo_stages CASCADE;
 CREATE MATERIALIZED VIEW kdigo_stages AS
 -- get creatinine stages
 with cr_stg AS
@@ -41,19 +41,22 @@ with cr_stg AS
     -- AKI stages according to urine output
     , CASE
         WHEN uo.uo_rt_6hr IS NULL THEN NULL
-        -- require the patient to be in the ICU for X hours
-        WHEN uo.charttime >= ie.intime + interval '24' hour
+        -- require patient to be in ICU for at least 6 hours to stage UO
+        WHEN uo.charttime <= ie.intime + interval '6' hour THEN 0
+        -- require the UO rate to be calculated over half the period
+        -- i.e. for uo rate over 24 hours, require documentation at least 12 hr apart
+        WHEN uo.charttime >= uo.uo_tm_24hr + interval '12' hour
             AND uo.uo_rt_24hr < 0.3 THEN 3
-        WHEN uo.charttime >= ie.intime + interval '12' hour
+        WHEN uo.charttime >= uo.uo_tm_12hr + interval '6' hour
             AND uo.uo_rt_12hr = 0 THEN 3
-        WHEN uo.charttime >= ie.intime + interval '12' hour
+        WHEN uo.charttime >= uo.uo_tm_12hr + interval '6' hour
             AND uo.uo_rt_12hr < 0.5 THEN 2
-        WHEN uo.charttime >= ie.intime + interval '6' hour
+        WHEN uo.charttime >= uo.uo_tm_6hr + interval '3' hour
             AND uo.uo_rt_6hr  < 0.5 THEN 1
     ELSE 0 END AS aki_stage_uo
   from kdigo_uo uo
   INNER JOIN icustays ie
-    on ie.icustay_id = uo.icustay_id
+    ON uo.icustay_id = ie.icustay_id
 )
 -- get all charttimes documented
 , tm_stg AS

--- a/concepts/organfailure/kdigo-uo.sql
+++ b/concepts/organfailure/kdigo-uo.sql
@@ -14,6 +14,14 @@ with ur_stg as
       then iosum.VALUE
     else null end) as UrineOutput_12hr
   , sum(iosum.VALUE) as UrineOutput_24hr
+  -- count number of measures to protect against missing data
+  , MIN(case when io.charttime <= iosum.charttime + interval '5' hour
+      then iosum.charttime
+    else null end) AS uo_tm_6hr
+  , MIN(case when io.charttime <= iosum.charttime + interval '11' hour
+      then iosum.charttime
+    else null end) AS uo_tm_12hr
+  , MIN(iosum.charttime) AS uo_tm_24hr
   from urineoutput io
   -- this join gives you all UO measurements over a 24 hour period
   left join urineoutput iosum
@@ -33,6 +41,10 @@ select
 , ROUND((ur.UrineOutput_6hr/wd.weight/6.0)::NUMERIC, 4) AS uo_rt_6hr
 , ROUND((ur.UrineOutput_12hr/wd.weight/12.0)::NUMERIC, 4) AS uo_rt_12hr
 , ROUND((ur.UrineOutput_24hr/wd.weight/24.0)::NUMERIC, 4) AS uo_rt_24hr
+-- time of earliest UO measurement that was used to calculate the rate
+, uo_tm_6hr
+, uo_tm_12hr
+, uo_tm_24hr
 from ur_stg ur
 left join weightdurations wd
   on  ur.icustay_id = wd.icustay_id

--- a/concepts/organfailure/kdigo-uo.sql
+++ b/concepts/organfailure/kdigo-uo.sql
@@ -29,6 +29,10 @@ select
 , ur.UrineOutput_6hr
 , ur.UrineOutput_12hr
 , ur.UrineOutput_24hr
+-- calculate rates
+, ROUND((ur.UrineOutput_6hr/wd.weight/6.0)::NUMERIC, 4) AS uo_rt_6hr
+, ROUND((ur.UrineOutput_12hr/wd.weight/12.0)::NUMERIC, 4) AS uo_rt_12hr
+, ROUND((ur.UrineOutput_24hr/wd.weight/24.0)::NUMERIC, 4) AS uo_rt_24hr
 from ur_stg ur
 left join weightdurations wd
   on  ur.icustay_id = wd.icustay_id

--- a/concepts/organfailure/kdigo-uo.sql
+++ b/concepts/organfailure/kdigo-uo.sql
@@ -25,24 +25,24 @@ with ur_stg as
   -- 24 hours
   , sum(iosum.VALUE) as UrineOutput_24hr
   -- calculate the number of hours over which we've tabulated UO
-  , ROUND(EXTRACT(EPOCH FROM
+  , ROUND(CAST(EXTRACT(EPOCH FROM
       io.charttime - 
         -- below MIN() gets the earliest time that was used in the summation 
         MIN(case when io.charttime <= iosum.charttime + interval '5' hour
           then iosum.charttime
         else null end)
     -- convert from EPOCH (seconds) to hours by dividing by 360.0
-    )/360.0, 4) AS uo_tm_6hr
+    )/360.0 AS NUMERIC), 4) AS uo_tm_6hr
   -- repeat extraction for 12 hours and 24 hours
-  , ROUND(EXTRACT(EPOCH FROM
+  , ROUND(CAST(EXTRACT(EPOCH FROM
       io.charttime - 
         MIN(case when io.charttime <= iosum.charttime + interval '11' hour
           then iosum.charttime
         else null end)
-   )/360.0, 4) AS uo_tm_12hr
-  , ROUND(EXTRACT(EPOCH FROM
+   )/360.0 AS NUMERIC), 4) AS uo_tm_12hr
+  , ROUND(CAST(EXTRACT(EPOCH FROM
       io.charttime - MIN(iosum.charttime)
-   )/360.0, 4) AS uo_tm_24hr
+   )/360.0 AS NUMERIC), 4) AS uo_tm_24hr
   from urineoutput io
   -- this join gives all UO measurements over the 24 hours preceding this row
   left join urineoutput iosum

--- a/concepts/organfailure/kdigo-uo.sql
+++ b/concepts/organfailure/kdigo-uo.sql
@@ -32,17 +32,17 @@ with ur_stg as
           then iosum.charttime
         else null end)
     -- convert from EPOCH (seconds) to hours by dividing by 360.0
-    )/360.0 AS NUMERIC), 4) AS uo_tm_6hr
+    )/3600.0 AS NUMERIC), 4) AS uo_tm_6hr
   -- repeat extraction for 12 hours and 24 hours
   , ROUND(CAST(EXTRACT(EPOCH FROM
       io.charttime - 
         MIN(case when io.charttime <= iosum.charttime + interval '11' hour
           then iosum.charttime
         else null end)
-   )/360.0 AS NUMERIC), 4) AS uo_tm_12hr
+   )/3600.0 AS NUMERIC), 4) AS uo_tm_12hr
   , ROUND(CAST(EXTRACT(EPOCH FROM
       io.charttime - MIN(iosum.charttime)
-   )/360.0 AS NUMERIC), 4) AS uo_tm_24hr
+   )/3600.0 AS NUMERIC), 4) AS uo_tm_24hr
   from urineoutput io
   -- this join gives all UO measurements over the 24 hours preceding this row
   left join urineoutput iosum

--- a/concepts/organfailure/kdigo-uo.sql
+++ b/concepts/organfailure/kdigo-uo.sql
@@ -3,27 +3,48 @@ CREATE MATERIALIZED VIEW kdigo_uo AS
 with ur_stg as
 (
   select io.icustay_id, io.charttime
-  -- three sums:
+  -- we have joined each row to all rows preceding within 24 hours
+  -- we can now sum these rows to get total UO over the last 24 hours
+  -- we can use case statements to restrict it to only the last 6/12 hours
+  -- therefore we have three sums:
   -- 1) over a 6 hour period
   -- 2) over a 12 hour period
   -- 3) over a 24 hour period
+  -- note that we assume data charted at charttime corresponds to 1 hour of UO
+  -- therefore we use '5' and '11' to restrict the period, rather than 6/12
+  -- this assumption may overestimate UO rate when documentation is done less than hourly
+
+  -- 6 hours
   , sum(case when io.charttime <= iosum.charttime + interval '5' hour
       then iosum.VALUE
     else null end) as UrineOutput_6hr
+  -- 12 hours
   , sum(case when io.charttime <= iosum.charttime + interval '11' hour
       then iosum.VALUE
     else null end) as UrineOutput_12hr
+  -- 24 hours
   , sum(iosum.VALUE) as UrineOutput_24hr
-  -- count number of measures to protect against missing data
-  , MIN(case when io.charttime <= iosum.charttime + interval '5' hour
-      then iosum.charttime
-    else null end) AS uo_tm_6hr
-  , MIN(case when io.charttime <= iosum.charttime + interval '11' hour
-      then iosum.charttime
-    else null end) AS uo_tm_12hr
-  , MIN(iosum.charttime) AS uo_tm_24hr
+  -- calculate the number of hours over which we've tabulated UO
+  , ROUND(EXTRACT(EPOCH FROM
+      io.charttime - 
+        -- below MIN() gets the earliest time that was used in the summation 
+        MIN(case when io.charttime <= iosum.charttime + interval '5' hour
+          then iosum.charttime
+        else null end)
+    -- convert from EPOCH (seconds) to hours by dividing by 360.0
+    )/360.0, 4) AS uo_tm_6hr
+  -- repeat extraction for 12 hours and 24 hours
+  , ROUND(EXTRACT(EPOCH FROM
+      io.charttime - 
+        MIN(case when io.charttime <= iosum.charttime + interval '11' hour
+          then iosum.charttime
+        else null end)
+   )/360.0, 4) AS uo_tm_12hr
+  , ROUND(EXTRACT(EPOCH FROM
+      io.charttime - MIN(iosum.charttime)
+   )/360.0, 4) AS uo_tm_24hr
   from urineoutput io
-  -- this join gives you all UO measurements over a 24 hour period
+  -- this join gives all UO measurements over the 24 hours preceding this row
   left join urineoutput iosum
     on  io.icustay_id = iosum.icustay_id
     and io.charttime >= iosum.charttime
@@ -37,10 +58,10 @@ select
 , ur.UrineOutput_6hr
 , ur.UrineOutput_12hr
 , ur.UrineOutput_24hr
--- calculate rates
-, ROUND((ur.UrineOutput_6hr/wd.weight/6.0)::NUMERIC, 4) AS uo_rt_6hr
-, ROUND((ur.UrineOutput_12hr/wd.weight/12.0)::NUMERIC, 4) AS uo_rt_12hr
-, ROUND((ur.UrineOutput_24hr/wd.weight/24.0)::NUMERIC, 4) AS uo_rt_24hr
+-- calculate rates - adding 1 hour as we assume data charted at 10:00 corresponds to previous hour
+, ROUND((ur.UrineOutput_6hr/wd.weight/(uo_tm_6hr+1))::NUMERIC, 4) AS uo_rt_6hr
+, ROUND((ur.UrineOutput_12hr/wd.weight/(uo_tm_12hr+1))::NUMERIC, 4) AS uo_rt_12hr
+, ROUND((ur.UrineOutput_24hr/wd.weight/(uo_tm_24hr+1))::NUMERIC, 4) AS uo_rt_24hr
 -- time of earliest UO measurement that was used to calculate the rate
 , uo_tm_6hr
 , uo_tm_12hr


### PR DESCRIPTION
* kdigo-creatinine.sql - now creates a row for every creatinine value, along with (1) the lowest previous creatinine in last 48 hours and (2) the lowest previous creatinine in the last 7 days
* kdigo-uo.sql - added the time of earliest UO measurement that was used to calculate the rate (so, if we calculated a 6 hour rate using a measurement 3 hours ago, this would be the time of the measurement 3 hours ago). This time is used in staging (see below).
* kdigo-stages.sql added - stages AKI at all time points (rather than once for 48 hours/7 days)
* kdigo-stages-48hr.sql - subselects from above query, and gets the highest AKI stage in the first 48 hours of a patient's stay
* kdigo-stages-7day.sql - subselects from above query, and gets the highest AKI stage in the first 7 days of a patient's stay

Some logic changes:

* baseline has been redefined from lowest value in the first 24 hours of the ICU stay to the lowest value in the last 7 days. This is more consistent with KDIGO, which states baseline "...is known or presumed to have occurred within the prior 7 days" - and mentioned by Chris in an issue.
* UO rate is only used if the rate was calculated over at least N/2 hours, where N=6, 12, 24 as appropriate

Regarding some open issues/PRs, this closes #486 (no longer relevant), closes #484, and refers to #476 (but not necessarily closed).

Contingency table:

 aki_48hr | aki_creat_48hr | aki_uo_48hr |   n   | % of stays 
--------- | -------------- | ----------- | ----- | -----
0         |              0 |           0 | 10299 | 29.5
0         |              0 |             |  1647 |  4.7
0         |                |           0 |    25 |  0.1
0         |                |             |    25 |  0.1
1         |              0 |           1 |  2902 |  8.3
1         |              0 |           2 |  7543 | 21.6
1         |              0 |           3 |  2853 |  8.2
1         |              1 |           0 |  1484 |  4.3
1         |              1 |           1 |   788 |  2.3
1         |              1 |           2 |  2263 |  6.5
1         |              1 |           3 |  2037 |  5.8
1         |              1 |             |   460 |  1.3
1         |              2 |           0 |   250 |  0.7
1         |              2 |           1 |    90 |  0.3
1         |              2 |           2 |   401 |  1.1
1         |              2 |           3 |   503 |  1.4
1         |              2 |             |    95 |  0.3
1         |              3 |           0 |   134 |  0.4
1         |              3 |           1 |    34 |  0.1
1         |              3 |           2 |   150 |  0.4
1         |              3 |           3 |   702 |  2.0
1         |              3 |             |   185 |  0.5
1         |                |           2 |    14 |  0.0
1         |                |           3 |    11 |  0.0

Query for above table:

```sql
with t1 as
(
SELECT ic.icustay_id
, ic.gender
, ic.admission_age AS age
, w.weight
, h.height
, los_icu
, first_hosp_stay
, aki_48hr
, k4.aki_stage_creat as AKI_stage_48hr_creat
, k4.aki_stage_uo AS AKI_stage_48hr_uo
FROM icustay_detail ic
LEFT JOIN weightfirstday w USING(icustay_id)
LEFT JOIN heightfirstday h USING(icustay_id)
LEFT JOIN kdigo_stages_48hr k4 USING(icustay_id)
)
, t2 as
(
select aki_48hr, AKI_stage_48hr_creat, AKI_stage_48hr_uo
, count(*) as n
from t1
where age > 18
and first_hosp_stay
and los_icu > 1
group by aki_48hr, AKI_stage_48hr_creat, AKI_stage_48hr_uo
)
select aki_48hr, AKI_stage_48hr_creat, AKI_stage_48hr_uo, n
, round(cast(n AS NUMERIC)*100/SUM(n) OVER (), 1) as frac
from t2
order by 1, 2, 3;
```

I'd be interested in people's thoughts on this - in particular @JackieMium / @steph409 / @chris20881 