### PR TITLE
Fix BigQuery type errors on load

### DIFF
--- a/buildmimic/bigquery/schemas/MICROBIOLOGYEVENTS.schema.json
+++ b/buildmimic/bigquery/schemas/MICROBIOLOGYEVENTS.schema.json
@@ -17,7 +17,7 @@
   {
     "mode": "NULLABLE", 
     "name": "CHARTDATE", 
-    "type": "DATE"
+    "type": "DATETIME"
   }, 
   {
     "mode": "NULLABLE", 

--- a/buildmimic/bigquery/schemas/PATIENTS.schema.json
+++ b/buildmimic/bigquery/schemas/PATIENTS.schema.json
@@ -17,22 +17,22 @@
   {
     "mode": "NULLABLE", 
     "name": "DOB", 
-    "type": "DATE"
+    "type": "DATETIME"
   }, 
   {
     "mode": "NULLABLE", 
     "name": "DOD", 
-    "type": "DATE"
+    "type": "DATETIME"
   }, 
   {
     "mode": "NULLABLE", 
     "name": "DOD_HOSP", 
-    "type": "DATE"
+    "type": "DATETIME"
   }, 
   {
     "mode": "NULLABLE", 
     "name": "DOD_SSN", 
-    "type": "DATE"
+    "type": "DATETIME"
   }, 
   {
     "mode": "NULLABLE", 

--- a/buildmimic/bigquery/schemas/PRESCRIPTIONS.schema.json
+++ b/buildmimic/bigquery/schemas/PRESCRIPTIONS.schema.json
@@ -22,12 +22,12 @@
     {
       "mode": "NULLABLE", 
       "name": "STARTDATE", 
-      "type": "DATE"
+      "type": "DATETIME"
     }, 
     {
       "mode": "NULLABLE", 
       "name": "ENDDATE", 
-      "type": "DATE"
+      "type": "DATETIME"
     }, 
     {
       "mode": "NULLABLE", 


### PR DESCRIPTION
I experienced the same `DATE` type error described in https://github.com/MIT-LCP/mimic-code/issues/556, which prevents the load of three tables in BigQuery.

A number of date fields in the CSV files include 00:00:00. Evidently the BigQuery load has become more strict in its `DATE` type parsing, now raising an error on these values.

This fix is consistent with README's description of how `DATETIME` is handled in the schemas.