### PR TITLE
include itemid column in d_items table of cloudformation template

### DIFF
--- a/buildmimic/aws-athena/mimic-iii-athena.yaml
+++ b/buildmimic/aws-athena/mimic-iii-athena.yaml
@@ -372,6 +372,8 @@ Resources:
           Columns:
           - Name: row_id 
             Type: int
+          - Name: itemid
+            Type: int
           - Name: icd9_code
             Type: int
           - Name: label


### PR DESCRIPTION
'itemid' column was missing from d_items table in the AWS Cloudformation template script. 