### PR TITLE
add ";" in 3-constraints

### DIFF
--- a/buildmimic/mysql/3-constraints.sql
+++ b/buildmimic/mysql/3-constraints.sql
@@ -35,7 +35,7 @@ DELIMITER ;
 -- ------------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('ADMISSIONS', 'admissions_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('ADMISSIONS', 'admissions_fk_subject_id');
 ALTER TABLE ADMISSIONS
 ADD CONSTRAINT admissions_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
@@ -46,14 +46,14 @@ ADD CONSTRAINT admissions_fk_subject_id
 -- ---------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('CALLOUT', 'callout_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('CALLOUT', 'callout_fk_subject_id');
 ALTER TABLE CALLOUT
 ADD CONSTRAINT callout_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('CALLOUT', 'callout_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('CALLOUT', 'callout_fk_hadm_id');
 ALTER TABLE CALLOUT
 ADD CONSTRAINT callout_fk_hadm_id
   FOREIGN KEY (HADM_ID)
@@ -70,35 +70,35 @@ ADD CONSTRAINT callout_fk_hadm_id
 -- -------------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('CHARTEVENTS', 'chartevents_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('CHARTEVENTS', 'chartevents_fk_subject_id');
 ALTER TABLE CHARTEVENTS
 ADD CONSTRAINT chartevents_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- cgid
-CALL PROC_DROP_FOREIGN_KEY('CHARTEVENTS', 'chartevents_fk_cgid')
+CALL PROC_DROP_FOREIGN_KEY('CHARTEVENTS', 'chartevents_fk_cgid');
 ALTER TABLE CHARTEVENTS
 ADD CONSTRAINT chartevents_fk_cgid
   FOREIGN KEY (CGID)
   REFERENCES CAREGIVERS(CGID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('CHARTEVENTS', 'chartevents_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('CHARTEVENTS', 'chartevents_fk_hadm_id');
 ALTER TABLE CHARTEVENTS
 ADD CONSTRAINT chartevents_fk_hadm_id
   FOREIGN KEY (HADM_ID)
   REFERENCES ADMISSIONS(HADM_ID);
 
 -- item_id
-CALL PROC_DROP_FOREIGN_KEY('CHARTEVENTS', 'chartevents_fk_itemid')
+CALL PROC_DROP_FOREIGN_KEY('CHARTEVENTS', 'chartevents_fk_itemid');
 ALTER TABLE CHARTEVENTS
 ADD CONSTRAINT chartevents_fk_itemid
   FOREIGN KEY (ITEMID)
   REFERENCES D_ITEMS(ITEMID);
 
 -- icustay_id
-CALL PROC_DROP_FOREIGN_KEY('CHARTEVENTS', 'chartevents_fk_icustay_id')
+CALL PROC_DROP_FOREIGN_KEY('CHARTEVENTS', 'chartevents_fk_icustay_id');
 ALTER TABLE CHARTEVENTS
 ADD CONSTRAINT chartevents_fk_icustay_id
   FOREIGN KEY (ICUSTAY_ID)
@@ -109,14 +109,14 @@ ADD CONSTRAINT chartevents_fk_icustay_id
 -- -----------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('CPTEVENTS', 'cptevents_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('CPTEVENTS', 'cptevents_fk_subject_id');
 ALTER TABLE CPTEVENTS
 ADD CONSTRAINT cptevents_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('CPTEVENTS', 'cptevents_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('CPTEVENTS', 'cptevents_fk_hadm_id');
 ALTER TABLE CPTEVENTS
 ADD CONSTRAINT cptevents_fk_hadm_id
   FOREIGN KEY (HADM_ID)
@@ -127,35 +127,35 @@ ADD CONSTRAINT cptevents_fk_hadm_id
 -- ----------------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('DATETIMEEVENTS', 'datetimeevents_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('DATETIMEEVENTS', 'datetimeevents_fk_subject_id');
 ALTER TABLE DATETIMEEVENTS
 ADD CONSTRAINT datetimeevents_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- cgid
-CALL PROC_DROP_FOREIGN_KEY('DATETIMEEVENTS', 'datetimeevents_fk_cgid')
+CALL PROC_DROP_FOREIGN_KEY('DATETIMEEVENTS', 'datetimeevents_fk_cgid');
 ALTER TABLE DATETIMEEVENTS
 ADD CONSTRAINT datetimeevents_fk_cgid
   FOREIGN KEY (CGID)
   REFERENCES CAREGIVERS(CGID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('DATETIMEEVENTS', 'datetimeevents_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('DATETIMEEVENTS', 'datetimeevents_fk_hadm_id');
 ALTER TABLE DATETIMEEVENTS
 ADD CONSTRAINT datetimeevents_fk_hadm_id
   FOREIGN KEY (HADM_ID)
   REFERENCES ADMISSIONS(HADM_ID);
 
 -- item_id
-CALL PROC_DROP_FOREIGN_KEY('DATETIMEEVENTS', 'datetimeevents_fk_itemid')
+CALL PROC_DROP_FOREIGN_KEY('DATETIMEEVENTS', 'datetimeevents_fk_itemid');
 ALTER TABLE DATETIMEEVENTS
 ADD CONSTRAINT datetimeevents_fk_itemid
   FOREIGN KEY (ITEMID)
   REFERENCES D_ITEMS(ITEMID);
 
 -- icustay_id
-CALL PROC_DROP_FOREIGN_KEY('DATETIMEEVENTS', 'datetimeevents_fk_icustay_id')
+CALL PROC_DROP_FOREIGN_KEY('DATETIMEEVENTS', 'datetimeevents_fk_icustay_id');
 ALTER TABLE DATETIMEEVENTS
 ADD CONSTRAINT datetimeevents_fk_icustay_id
   FOREIGN KEY (ICUSTAY_ID)
@@ -167,14 +167,14 @@ ADD CONSTRAINT datetimeevents_fk_icustay_id
 -- ---------------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('DIAGNOSES_ICD', 'diagnoses_icd_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('DIAGNOSES_ICD', 'diagnoses_icd_fk_subject_id');
 ALTER TABLE DIAGNOSES_ICD
 ADD CONSTRAINT diagnoses_icd_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('DIAGNOSES_ICD', 'diagnoses_icd_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('DIAGNOSES_ICD', 'diagnoses_icd_fk_hadm_id');
 ALTER TABLE DIAGNOSES_ICD
 ADD CONSTRAINT diagnoses_icd_fk_hadm_id
   FOREIGN KEY (HADM_ID)
@@ -183,7 +183,7 @@ ADD CONSTRAINT diagnoses_icd_fk_hadm_id
 -- ICD9_code
 -- Cannot impose this constraint because icd9_code contains 143 codes not in c_icd_diagnoses
 -- See https://github.com/MIT-LCP/mimic-code/issues/20
--- CALL PROC_DROP_FOREIGN_KEY('DIAGNOSES_ICD', 'diagnoses_icd_fk_icd9')
+-- CALL PROC_DROP_FOREIGN_KEY('DIAGNOSES_ICD', 'diagnoses_icd_fk_icd9');
 -- ALTER TABLE DIAGNOSES_ICD
 -- ADD CONSTRAINT diagnoses_icd_fk_icd9
 --   FOREIGN KEY (ICD9_CODE)
@@ -194,14 +194,14 @@ ADD CONSTRAINT diagnoses_icd_fk_hadm_id
 -- ------------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('DRGCODES', 'drgcodes_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('DRGCODES', 'drgcodes_fk_subject_id');
 ALTER TABLE DRGCODES
 ADD CONSTRAINT drgcodes_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('DRGCODES', 'drgcodes_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('DRGCODES', 'drgcodes_fk_hadm_id');
 ALTER TABLE DRGCODES
 ADD CONSTRAINT drgcodes_fk_hadm_id
   FOREIGN KEY (HADM_ID)
@@ -212,14 +212,14 @@ ADD CONSTRAINT drgcodes_fk_hadm_id
 -- ---------------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('ICUSTAYS', 'icustays_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('ICUSTAYS', 'icustays_fk_subject_id');
 ALTER TABLE ICUSTAYS
 ADD CONSTRAINT icustays_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('ICUSTAYS', 'icustays_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('ICUSTAYS', 'icustays_fk_hadm_id');
 ALTER TABLE ICUSTAYS
 ADD CONSTRAINT icustays_fk_hadm_id
   FOREIGN KEY (HADM_ID)
@@ -230,28 +230,28 @@ ADD CONSTRAINT icustays_fk_hadm_id
 -- ----------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_CV', 'inputevents_cv_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_CV', 'inputevents_cv_fk_subject_id');
 ALTER TABLE INPUTEVENTS_CV
 ADD CONSTRAINT inputevents_cv_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_CV', 'inputevents_cv_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_CV', 'inputevents_cv_fk_hadm_id');
 ALTER TABLE INPUTEVENTS_CV
 ADD CONSTRAINT inputevents_cv_fk_hadm_id
   FOREIGN KEY (HADM_ID)
   REFERENCES ADMISSIONS(HADM_ID);
 
 -- icustay_id
-CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_CV', 'inputevents_cv_fk_icustay_id')
+CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_CV', 'inputevents_cv_fk_icustay_id');
 ALTER TABLE INPUTEVENTS_CV
 ADD CONSTRAINT inputevents_cv_fk_icustay_id
   FOREIGN KEY (ICUSTAY_ID)
   REFERENCES ICUSTAYS(ICUSTAY_ID);
 
 -- cgid
-CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_CV', 'inputevents_cv_fk_cgid')
+CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_CV', 'inputevents_cv_fk_cgid');
 ALTER TABLE INPUTEVENTS_CV
 ADD CONSTRAINT inputevents_cv_fk_cgid
   FOREIGN KEY (CGID)
@@ -262,28 +262,28 @@ ADD CONSTRAINT inputevents_cv_fk_cgid
 -- ----------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_MV', 'inputevents_mv_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_MV', 'inputevents_mv_fk_subject_id');
 ALTER TABLE INPUTEVENTS_MV
 ADD CONSTRAINT inputevents_mv_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_MV', 'inputevents_mv_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_MV', 'inputevents_mv_fk_hadm_id');
 ALTER TABLE INPUTEVENTS_MV
 ADD CONSTRAINT inputevents_mv_fk_hadm_id
   FOREIGN KEY (HADM_ID)
   REFERENCES ADMISSIONS(HADM_ID);
 
 -- icustay_id
-CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_MV', 'inputevents_mv_fk_icustay_id')
+CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_MV', 'inputevents_mv_fk_icustay_id');
 ALTER TABLE INPUTEVENTS_MV
 ADD CONSTRAINT inputevents_mv_fk_icustay_id
   FOREIGN KEY (ICUSTAY_ID)
   REFERENCES ICUSTAYS(ICUSTAY_ID);
 
 -- cgid
-CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_MV', 'inputevents_mv_fk_cgid')
+CALL PROC_DROP_FOREIGN_KEY('INPUTEVENTS_MV', 'inputevents_mv_fk_cgid');
 ALTER TABLE INPUTEVENTS_MV
 ADD CONSTRAINT inputevents_mv_fk_cgid
   FOREIGN KEY (CGID)
@@ -294,21 +294,21 @@ ADD CONSTRAINT inputevents_mv_fk_cgid
 -- -----------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('LABEVENTS', 'labevents_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('LABEVENTS', 'labevents_fk_subject_id');
 ALTER TABLE LABEVENTS
 ADD CONSTRAINT labevents_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('LABEVENTS', 'labevents_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('LABEVENTS', 'labevents_fk_hadm_id');
 ALTER TABLE LABEVENTS
 ADD CONSTRAINT labevents_fk_hadm_id
   FOREIGN KEY (HADM_ID)
   REFERENCES ADMISSIONS(HADM_ID);
 
 -- item_id
-CALL PROC_DROP_FOREIGN_KEY('LABEVENTS', 'labevents_fk_itemid')
+CALL PROC_DROP_FOREIGN_KEY('LABEVENTS', 'labevents_fk_itemid');
 ALTER TABLE LABEVENTS
 ADD CONSTRAINT labevents_fk_itemid
   FOREIGN KEY (ITEMID)
@@ -319,14 +319,14 @@ ADD CONSTRAINT labevents_fk_itemid
 -- --------------------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('MICROBIOLOGYEVENTS', 'microbiologyevents_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('MICROBIOLOGYEVENTS', 'microbiologyevents_fk_subject_id');
 ALTER TABLE MICROBIOLOGYEVENTS
 ADD CONSTRAINT microbiologyevents_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('MICROBIOLOGYEVENTS', 'microbiologyevents_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('MICROBIOLOGYEVENTS', 'microbiologyevents_fk_hadm_id');
 ALTER TABLE MICROBIOLOGYEVENTS
 ADD CONSTRAINT microbiologyevents_fk_hadm_id
   FOREIGN KEY (HADM_ID)
@@ -337,21 +337,21 @@ ADD CONSTRAINT microbiologyevents_fk_hadm_id
 -- ------------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('NOTEEVENTS', 'noteevents_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('NOTEEVENTS', 'noteevents_fk_subject_id');
 ALTER TABLE NOTEEVENTS
 ADD CONSTRAINT noteevents_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('NOTEEVENTS', 'noteevents_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('NOTEEVENTS', 'noteevents_fk_hadm_id');
 ALTER TABLE NOTEEVENTS
 ADD CONSTRAINT noteevents_fk_hadm_id
   FOREIGN KEY (HADM_ID)
   REFERENCES ADMISSIONS(HADM_ID);
 
 -- cgid
-CALL PROC_DROP_FOREIGN_KEY('NOTEEVENTS', 'noteevents_fk_cgid')
+CALL PROC_DROP_FOREIGN_KEY('NOTEEVENTS', 'noteevents_fk_cgid');
 ALTER TABLE NOTEEVENTS
 ADD CONSTRAINT noteevents_fk_cgid
   FOREIGN KEY (CGID)
@@ -362,28 +362,28 @@ ADD CONSTRAINT noteevents_fk_cgid
 -- ----------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('OUTPUTEVENTS', 'outputevents_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('OUTPUTEVENTS', 'outputevents_fk_subject_id');
 ALTER TABLE OUTPUTEVENTS
 ADD CONSTRAINT outputevents_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('OUTPUTEVENTS', 'outputevents_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('OUTPUTEVENTS', 'outputevents_fk_hadm_id');
 ALTER TABLE OUTPUTEVENTS
 ADD CONSTRAINT outputevents_fk_hadm_id
   FOREIGN KEY (HADM_ID)
   REFERENCES ADMISSIONS(HADM_ID);
 
 -- icustay_id
-CALL PROC_DROP_FOREIGN_KEY('OUTPUTEVENTS', 'outputevents_fk_icustay_id')
+CALL PROC_DROP_FOREIGN_KEY('OUTPUTEVENTS', 'outputevents_fk_icustay_id');
 ALTER TABLE OUTPUTEVENTS
 ADD CONSTRAINT outputevents_fk_icustay_id
   FOREIGN KEY (ICUSTAY_ID)
   REFERENCES ICUSTAYS(ICUSTAY_ID);
 
 -- cgid
-CALL PROC_DROP_FOREIGN_KEY('OUTPUTEVENTS', 'outputevents_fk_cgid')
+CALL PROC_DROP_FOREIGN_KEY('OUTPUTEVENTS', 'outputevents_fk_cgid');
 ALTER TABLE OUTPUTEVENTS
 ADD CONSTRAINT outputevents_fk_cgid
   FOREIGN KEY (CGID)
@@ -394,21 +394,21 @@ ADD CONSTRAINT outputevents_fk_cgid
 -- ---------------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('PRESCRIPTIONS', 'prescriptions_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('PRESCRIPTIONS', 'prescriptions_fk_subject_id');
 ALTER TABLE PRESCRIPTIONS
 ADD CONSTRAINT prescriptions_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('PRESCRIPTIONS', 'prescriptions_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('PRESCRIPTIONS', 'prescriptions_fk_hadm_id');
 ALTER TABLE PRESCRIPTIONS
 ADD CONSTRAINT prescriptions_fk_hadm_id
   FOREIGN KEY (HADM_ID)
   REFERENCES ADMISSIONS(HADM_ID);
 
 -- icustay_id
-CALL PROC_DROP_FOREIGN_KEY('PRESCRIPTIONS', 'prescriptions_fk_icustay_id')
+CALL PROC_DROP_FOREIGN_KEY('PRESCRIPTIONS', 'prescriptions_fk_icustay_id');
 ALTER TABLE PRESCRIPTIONS
 ADD CONSTRAINT prescriptions_fk_icustay_id
   FOREIGN KEY (ICUSTAY_ID)
@@ -419,28 +419,28 @@ ADD CONSTRAINT prescriptions_fk_icustay_id
 -- ----------------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('PROCEDUREEVENTS_MV', 'procedureevents_mv_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('PROCEDUREEVENTS_MV', 'procedureevents_mv_fk_subject_id');
 ALTER TABLE PROCEDUREEVENTS_MV
 ADD CONSTRAINT procedureevents_mv_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('PROCEDUREEVENTS_MV', 'procedureevents_mv_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('PROCEDUREEVENTS_MV', 'procedureevents_mv_fk_hadm_id');
 ALTER TABLE PROCEDUREEVENTS_MV
 ADD CONSTRAINT procedureevents_mv_fk_hadm_id
   FOREIGN KEY (HADM_ID)
   REFERENCES ADMISSIONS(HADM_ID);
 
 -- itemid
-CALL PROC_DROP_FOREIGN_KEY('PROCEDUREEVENTS_MV', 'procedureevents_mv_fk_icustay_id')
+CALL PROC_DROP_FOREIGN_KEY('PROCEDUREEVENTS_MV', 'procedureevents_mv_fk_icustay_id');
 ALTER TABLE PROCEDUREEVENTS_MV
 ADD CONSTRAINT procedureevents_mv_fk_icustay_id
   FOREIGN KEY (ICUSTAY_ID)
   REFERENCES ICUSTAYS(ICUSTAY_ID);
 
 -- cgid
-CALL PROC_DROP_FOREIGN_KEY('PROCEDUREEVENTS_MV', 'procedureevents_mv_fk_cgid')
+CALL PROC_DROP_FOREIGN_KEY('PROCEDUREEVENTS_MV', 'procedureevents_mv_fk_cgid');
 ALTER TABLE PROCEDUREEVENTS_MV
 ADD CONSTRAINT procedureevents_mv_fk_cgid
   FOREIGN KEY (CGID)
@@ -451,14 +451,14 @@ ADD CONSTRAINT procedureevents_mv_fk_cgid
 -- ----------------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('PROCEDURES_ICD', 'procedures_icd_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('PROCEDURES_ICD', 'procedures_icd_fk_subject_id');
 ALTER TABLE PROCEDURES_ICD
 ADD CONSTRAINT procedures_icd_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('PROCEDURES_ICD', 'procedures_icd_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('PROCEDURES_ICD', 'procedures_icd_fk_hadm_id');
 ALTER TABLE PROCEDURES_ICD
 ADD CONSTRAINT procedures_icd_fk_hadm_id
   FOREIGN KEY (HADM_ID)
@@ -467,7 +467,7 @@ ADD CONSTRAINT procedures_icd_fk_hadm_id
 -- ICD9_code
 -- Cannot impose this constraint because icd9_code contains 1238 codes not in c_icd_diagnoses
 -- See https://github.com/MIT-LCP/mimic-code/issues/20, by analogy
--- CALL PROC_DROP_FOREIGN_KEY('PROCEDURES_ICD', 'procedures_icd_fk_icd9')
+-- CALL PROC_DROP_FOREIGN_KEY('PROCEDURES_ICD', 'procedures_icd_fk_icd9');
 -- ALTER TABLE PROCEDURES_ICD
 -- ADD CONSTRAINT procedures_icd_fk_icd9
 --   FOREIGN KEY (icd9_code)
@@ -478,14 +478,14 @@ ADD CONSTRAINT procedures_icd_fk_hadm_id
 -- ----------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('SERVICES', 'services_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('SERVICES', 'services_fk_subject_id');
 ALTER TABLE SERVICES
 ADD CONSTRAINT services_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('SERVICES', 'services_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('SERVICES', 'services_fk_hadm_id');
 ALTER TABLE SERVICES
 ADD CONSTRAINT services_fk_hadm_id
   FOREIGN KEY (HADM_ID)
@@ -496,21 +496,21 @@ ADD CONSTRAINT services_fk_hadm_id
 -- -----------
 
 -- subject_id
-CALL PROC_DROP_FOREIGN_KEY('TRANSFERS', 'transfers_fk_subject_id')
+CALL PROC_DROP_FOREIGN_KEY('TRANSFERS', 'transfers_fk_subject_id');
 ALTER TABLE TRANSFERS
 ADD CONSTRAINT transfers_fk_subject_id
   FOREIGN KEY (SUBJECT_ID)
   REFERENCES PATIENTS(SUBJECT_ID);
 
 -- hadm_id
-CALL PROC_DROP_FOREIGN_KEY('TRANSFERS', 'transfers_fk_hadm_id')
+CALL PROC_DROP_FOREIGN_KEY('TRANSFERS', 'transfers_fk_hadm_id');
 ALTER TABLE TRANSFERS
 ADD CONSTRAINT transfers_fk_hadm_id
   FOREIGN KEY (HADM_ID)
   REFERENCES ADMISSIONS(HADM_ID);
 
 -- icustay_id
-CALL PROC_DROP_FOREIGN_KEY('TRANSFERS', 'transfers_fk_icustay_id')
+CALL PROC_DROP_FOREIGN_KEY('TRANSFERS', 'transfers_fk_icustay_id');
 ALTER TABLE TRANSFERS
 ADD CONSTRAINT transfers_fk_icustay_id
   FOREIGN KEY (ICUSTAY_ID)


### PR DESCRIPTION
Add ";" at  the end of the "CALL..." sentences. Example: CALL PROC_DROP_FOREIGN_KEY('ADMISSIONS', 'admissions_fk_subject_id') ;