### PR TITLE
Adds executing kdigo-stages.sql into make_concepts.sql

### DIFF
--- a/concepts/make-concepts.sql
+++ b/concepts/make-concepts.sql
@@ -72,6 +72,7 @@
 \echo 'Directory 8 of 9: organfailure'
 \i organfailure/kdigo-creatinine.sql
 \i organfailure/kdigo-uo.sql
+\i organfailure/kdigo-stages.sql
 \i organfailure/kdigo-stages-7day.sql
 \i organfailure/kdigo-stages-48hr.sql
 \i organfailure/meld.sql


### PR DESCRIPTION
Adds `kdigo-stages.sql` before kdigo-stages-7day.sql to fix the error below

```
psql:organfailure/kdigo-stages-7day.sql:66: ERROR:  relation "kdigo_stages" does not exist
LINE 12:   INNER JOIN kdigo_stages k
```