### PR TITLE
fix psql error: function round(double precision, integer) doesn't exist

### DIFF
--- a/concepts/fluid_balance/ffp_transfusion.sql
+++ b/concepts/fluid_balance/ffp_transfusion.sql
@@ -77,13 +77,13 @@ cumulative AS (
 SELECT
     cm.icustay_id
   , cm.charttime
-  , ROUND(cm.amount::numeric - CASE
-      WHEN ROW_NUMBER() OVER w = 1 THEN 0::numeric
-      ELSE cast(lag(cm.amount) OVER w as numeric)
+  , ROUND(CAST(cm.amount AS numeric) - CASE
+      WHEN ROW_NUMBER() OVER w = 1 THEN CAST(0 AS numeric)
+      ELSE cast(lag(cm.amount) OVER w AS numeric)
     END, 2) AS amount
-  , ROUND(cm.amount::numeric + CASE
-      WHEN pre.amount IS NULL THEN 0::numeric
-      ELSE pre.amount::numeric
+  , ROUND(CAST(cm.amount AS numeric) + CASE
+      WHEN pre.amount IS NULL THEN CAST(0 AS numeric)
+      ELSE CAST(pre.amount AS numeric)
     END, 2) AS totalamount
   , cm.amountuom
 FROM cumulative AS cm

--- a/concepts/fluid_balance/ffp_transfusion.sql
+++ b/concepts/fluid_balance/ffp_transfusion.sql
@@ -77,13 +77,13 @@ cumulative AS (
 SELECT
     cm.icustay_id
   , cm.charttime
-  , ROUND(cm.amount - CASE
-      WHEN ROW_NUMBER() OVER w = 1 THEN 0
-      ELSE lag(cm.amount) OVER w
+  , ROUND(cm.amount::numeric - CASE
+      WHEN ROW_NUMBER() OVER w = 1 THEN 0::numeric
+      ELSE cast(lag(cm.amount) OVER w as numeric)
     END, 2) AS amount
-  , ROUND(cm.amount + CASE
-      WHEN pre.amount IS NULL THEN 0
-      ELSE pre.amount
+  , ROUND(cm.amount::numeric + CASE
+      WHEN pre.amount IS NULL THEN 0::numeric
+      ELSE pre.amount::numeric
     END, 2) AS totalamount
   , cm.amountuom
 FROM cumulative AS cm

--- a/concepts/fluid_balance/rbc_transfusion.sql
+++ b/concepts/fluid_balance/rbc_transfusion.sql
@@ -72,13 +72,13 @@ cumulative AS (
 SELECT
     cm.icustay_id
   , cm.charttime
-  , ROUND(cm.amount::numeric - CASE
-      WHEN ROW_NUMBER() OVER w = 1 THEN 0::numeric
-      ELSE cast(lag(cm.amount) OVER w as numeric)
+  , ROUND(CAST(cm.amount AS numeric) - CASE
+      WHEN ROW_NUMBER() OVER w = 1 THEN CAST(0 AS numeric)
+      ELSE CAST(lag(cm.amount) OVER w AS numeric)
     END, 2) AS amount
-  , ROUND(cm.amount::numeric + CASE
-      WHEN pre.amount::numeric IS NULL THEN 0::numeric
-      ELSE pre.amount::numeric
+  , ROUND(CAST(cm.amount AS numeric) + CASE
+      WHEN CAST(pre.amount AS numeric) IS NULL THEN CAST(0 AS numeric)
+      ELSE CAST(pre.amount AS numeric)
     END, 2) AS totalamount
   , cm.amountuom
 FROM cumulative AS cm

--- a/concepts/fluid_balance/rbc_transfusion.sql
+++ b/concepts/fluid_balance/rbc_transfusion.sql
@@ -72,13 +72,13 @@ cumulative AS (
 SELECT
     cm.icustay_id
   , cm.charttime
-  , ROUND(cm.amount - CASE
-      WHEN ROW_NUMBER() OVER w = 1 THEN 0
-      ELSE lag(cm.amount) OVER w
+  , ROUND(cm.amount::numeric - CASE
+      WHEN ROW_NUMBER() OVER w = 1 THEN 0::numeric
+      ELSE cast(lag(cm.amount) OVER w as numeric)
     END, 2) AS amount
-  , ROUND(cm.amount + CASE
-      WHEN pre.amount IS NULL THEN 0
-      ELSE pre.amount
+  , ROUND(cm.amount::numeric + CASE
+      WHEN pre.amount::numeric IS NULL THEN 0::numeric
+      ELSE pre.amount::numeric
     END, 2) AS totalamount
   , cm.amountuom
 FROM cumulative AS cm


### PR DESCRIPTION
Postgres complains about "ERROR:  function round(double precision, integer) does not exist", I don't know if this is the proper fix but it works. Feel free to correct, I am just PRing this to raise the issue here.