### PR TITLE
changed weightdurations to weight_durations in durations/*_dose.sql

### DIFF
--- a/concepts/demographics/heightweight.sql
+++ b/concepts/demographics/heightweight.sql
@@ -66,7 +66,7 @@ SELECT
   ROUND(CAST(ht.height_min AS NUMERIC), 2) AS height_min,
   ROUND(CAST(ht.height_max AS NUMERIC), 2) AS height_max
 FROM `physionet-data.mimiciii_clinical.icustays` ie
--- get weight from weightdurations table
+-- get weight from weight_durations table
 LEFT JOIN
 (
   SELECT icustay_id,
@@ -79,7 +79,7 @@ LEFT JOIN
       icustay_id,
       weight,
       ROW_NUMBER() OVER (PARTITION BY icustay_id ORDER BY starttime) as rn
-    FROM `physionet-data.mimiciii_derived.weightdurations`
+    FROM `physionet-data.mimiciii_derived.weight_durations`
   ) wt_stg
   GROUP BY icustay_id
 ) wt

--- a/concepts/durations/epinephrine_dose.sql
+++ b/concepts/durations/epinephrine_dose.sql
@@ -24,7 +24,7 @@ with vasocv1 as
     , max(case when itemid in (30044,30119,30309) then amount else null end) as vaso_amount
 
   FROM `physionet-data.mimiciii_clinical.inputevents_cv` cv
-  left join `physionet-data.mimiciii_clinical.weightdurations` wd
+  left join `physionet-data.mimiciii_clinical.weight_durations` wd
     on cv.icustay_id = wd.icustay_id
     and cv.charttime between wd.starttime and wd.endtime
   where itemid in

--- a/concepts/durations/norepinephrine_dose.sql
+++ b/concepts/durations/norepinephrine_dose.sql
@@ -24,7 +24,7 @@ with vasocv1 as
     , max(case when itemid in (30047,30120) then amount else null end) as vaso_amount
 
   FROM `physionet-data.mimiciii_clinical.inputevents_cv` cv
-  left join `physionet-data.mimiciii_clinical.weightdurations` wd
+  left join `physionet-data.mimiciii_clinical.weight_durations` wd
     on cv.icustay_id = wd.icustay_id
     and cv.charttime between wd.starttime and wd.endtime
   where itemid in (30047,30120) -- norepinephrine


### PR DESCRIPTION
The calls to the weight_durations table for doses (epinephrine and norepinephrine) missed a _ . 
It would be better for these calls to be consistent with the table name at creation in make-concepts.sh and postgres_make_concepts.sh. 