### PR TITLE
Update adenosine_durations.sql

### DIFF
--- a/concepts/durations/adenosine_durations.sql
+++ b/concepts/durations/adenosine_durations.sql
@@ -210,7 +210,7 @@ select
   -- generate a sequential integer for convenience
   , ROW_NUMBER() over (partition by icustay_id order by starttime) as vasonum
   , starttime, endtime
-  , DATETIME_DIFF(endtime, starttime, HOUR) AS duration_hours
+  , DATETIME_DIFF(endtime, starttime, 'HOUR') AS duration_hours
   -- add durations
 from
   vasocv
@@ -221,7 +221,7 @@ select
   icustay_id
   , ROW_NUMBER() over (partition by icustay_id order by starttime) as vasonum
   , starttime, endtime
-  , DATETIME_DIFF(endtime, starttime, HOUR) AS duration_hours
+  , DATETIME_DIFF(endtime, starttime, 'HOUR') AS duration_hours
   -- add durations
 from
   vasomv


### PR DESCRIPTION
According to the `DATETIME_DIFF` function definition in file /mimic-code/concepts/postgres-functions.sql, time scale indicators should be wrapped in single quotes.
Otherwise, error will occurs that the field, for example "Hour", does not exist.