### PR TITLE
Update vasopressin_durations.sql

### DIFF
--- a/concepts/durations/vasopressin_durations.sql
+++ b/concepts/durations/vasopressin_durations.sql
@@ -207,7 +207,7 @@ select
   -- generate a sequential integer for convenience
   , ROW_NUMBER() over (partition by icustay_id order by starttime) as vasonum
   , starttime, endtime
-  , DATETIME_DIFF(endtime, starttime, HOUR) AS duration_hours
+  , DATETIME_DIFF(endtime, starttime, 'HOUR') AS duration_hours
   -- add durations
 from
   vasocv
@@ -218,7 +218,7 @@ select
   icustay_id
   , ROW_NUMBER() over (partition by icustay_id order by starttime) as vasonum
   , starttime, endtime
-  , DATETIME_DIFF(endtime, starttime, HOUR) AS duration_hours
+  , DATETIME_DIFF(endtime, starttime, 'HOUR') AS duration_hours
   -- add durations
 from
   vasomv


### PR DESCRIPTION
fix `DATETIME_DIFF` error