### PR TITLE
Update vasopressor_durations.sql

### DIFF
--- a/concepts/durations/vasopressor_durations.sql
+++ b/concepts/durations/vasopressor_durations.sql
@@ -295,7 +295,7 @@ select
   -- generate a sequential integer for convenience
   , ROW_NUMBER() over (partition by icustay_id order by starttime) as vasonum
   , starttime, endtime
-  , DATETIME_DIFF(endtime, starttime, HOUR) AS duration_hours
+  , DATETIME_DIFF(endtime, starttime, 'HOUR') AS duration_hours
   -- add durations
 from
   vasocv_grp
@@ -306,7 +306,7 @@ select
   icustay_id
   , ROW_NUMBER() over (partition by icustay_id order by starttime) as vasonum
   , starttime, endtime
-  , DATETIME_DIFF(endtime, starttime, HOUR) AS duration_hours
+  , DATETIME_DIFF(endtime, starttime, 'HOUR') AS duration_hours
   -- add durations
 from
   vasomv_grp


### PR DESCRIPTION
fix `DATETIME_DIFF` error