### PR TITLE
Add import.sh, a shell script to import MIMIC into SQLite

### DIFF
--- a/mimic-iii/buildmimic/sqlite/README.md
+++ b/mimic-iii/buildmimic/sqlite/README.md
@@ -10,6 +10,8 @@ into memory. It only needs three things to run:
 2. [SQLite]([https://sqlite.org/index.html)
 3. gzip (which is installed by default on any Linux/BSD/Mac variant)
 
+**Note:** The `import.sh` script will set all data fields to *text*.
+
 `import.py` is a python script. It requires the following to run:
 
 1. Python 3 installed

--- a/mimic-iii/buildmimic/sqlite/README.md
+++ b/mimic-iii/buildmimic/sqlite/README.md
@@ -1,19 +1,56 @@
 # Building the MIMIC database with SQLite
 
-`import.py` can be used to generate an SQLite database file from the MIMIC-III. We recommend that you test the process first with the MIMIC-III demo files available at: https://doi.org/10.13026/C2HM2Q
+Either `import.sh` or `import.py` can be used to generate a [SQLite]([https://sqlite.org/index.html) database file from the MIMIC-III demo or full dataset.
+
+`import.sh` is a shell script that will work with any POSIX compliant shell.
+It is memory efficient and does not require loading entire data files
+into memory. It only needs three things to run:
+
+1. A POSIX compliant shell (e.g., dash, bash, zsh, ksh, etc.)
+2. [SQLite]([https://sqlite.org/index.html)
+3. gzip (which is installed by default on any Linux/BSD/Mac variant)
+
+`import.py` is a python script. It requires the following to run:
+
+1. Python 3 installed
+2. SQLite
+3. [pandas](https://pandas.pydata.org/)
+
+We recommend that you test the process first with the MIMIC-III demo files available at: https://doi.org/10.13026/C2HM2Q
 
 ## Step 1: Download the CSV or CSV.GZ files.
 
 - Downlod the MIMIC-III demo from https://doi.org/10.13026/C2HM2Q or the full MIMIC-III dataset from: https://doi.org/10.13026/C2XW26
-- Place the files in the same folder as the `import.py` script.
+- Place `import.sh` or `import.py` into the same folder as the `csv` or `csv.gz` files
 
 ## Step 2: Edit the script if needed.
 
-It may be necessary to make minor edits to the `import.py` script. For example:
+`import.sh` does **not** need edits to work with either the demo or full dataset.
+Please continue to Step 3.
+
+If you are using the `import.py` script,
+it may be necessary to make minor edits to the `import.py` script. For example:
 
 - If you are loading the demo, you may need to change `ROW_ID` to lowercase.
-- If your files are `.CSV` rather than `CSV.GZ`, you will need to change `CSV.GZ` to `CSV`.
+- If your files are `.csv` rather than `csv.gz`, you will need to change `csv.gz` to `csv`.
 
-## Step 3: Generate the SQLite file with `import.py`
+## Step 3: Generate the SQLite file
 
-To generate the SQLite file, run `import.py` from the command line with: `python import.py`. The script should generate a database file called "mimic3.db".
+To generate the SQLite file:
+
+If you are using `import.sh`, run on the command-line:
+
+```
+$ ./import.sh
+```
+
+If you are using `import.py`, run on the command-line:
+
+```
+$ python import.py
+```
+
+If loading the full dataset, this will take some time,
+particularly the `CHARTEVENTS` table.
+
+The scripts will ultimately generate an SQLite database file called `mimic3.db`.

--- a/mimic-iii/buildmimic/sqlite/import.sh
+++ b/mimic-iii/buildmimic/sqlite/import.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Copyright (c) 2021 Thomas Ward <thomas@thomasward.com>
+# 
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+OUTFILE=mimic3.db
+
+if [ -s "$OUTFILE" ]; then
+    echo "File \"$OUTFILE\" already exists." >&2
+    exit 111
+fi
+
+for FILE in *; do
+    # skip loop if glob didn't match an actual file
+    [ -f "$FILE" ] || continue
+    # trim off extension and lowercase file stem (e.g., HELLO.csv -> hello)
+    TABLE_NAME=$(echo "${FILE%%.*}" | tr "[:upper:]" "[:lower:]")
+    case "$FILE" in
+        *csv)
+            IMPORT_CMD=".import $FILE $TABLE_NAME"
+        ;;
+        # need to decompress csv before load
+        *csv.gz)
+            IMPORT_CMD=".import \"|gzip -dc $FILE\" $TABLE_NAME"
+        ;;
+        # not a data file so skip
+        *)
+            continue
+        ;;
+    esac
+    echo "Loading $FILE."
+    sqlite3 $OUTFILE <<EOF
+.headers on
+.mode csv
+$IMPORT_CMD
+EOF
+    echo "Finished loading $FILE."
+done
+
+echo "Finished loading data into $OUTFILE."


### PR DESCRIPTION
Hi,

Thank you for this fantastic dataset. The level of documentation for all the tables/variables is amazing, and I really appreciate your commitment to open-sourcing all the software.

I noticed that your python to SQLite import script needed pandas, data-chunking (since pandas loads all the data by default into RAM for a single table), and manual editing to run (e.g., changing .csv.gz to .csv) if the user wanted to load the demo dataset.

I therefore made a light, shell-only, script called "import.sh" that only needs SQLite, a POSIX-compliant shell, and gzip.

It follows the naming conventions of the pre-existing import.py, so the output file is "mimic3.db" and tables are named in all lower-case from the file name. For example, the data in "ADMISSIONS.csv" is saved in the "admissions" table.

It works both with the demo dataset (.csv files) and the full dataset (.csv.gz files) with no modification.

RAM and disk utilization is low, as it uses gzip to stream files directly to the sqlite3 binary for loading. It also works quickly: on my
system it took 11 minutes for the full dataset (after a reboot and the caches cleared) and under 5 seconds for the demo dataset.

The shell script was linted with "shellcheck" with no warnings/errors.

I also updated the README to instruct the user on using either import.py or import.sh.

Thanks!

Thomas