### PR TITLE
Change travis.yml to run on main instead of master since it is the new default branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-  - master
+  - main
 
 addons:
   postgresql: '9.4'


### PR DESCRIPTION
For now switch from master -> main in the travis.yml.  Eventually this will be replaced with a Github action.