### PR TITLE
Remove request for users to add a MIMIC-III, MIMIC-IV, or MIMIC-CXR label when creating an issue

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -10,15 +10,3 @@ Description of the issue, including:
 * what you have tried
 * references to similar issues
 * queries demonstrating your question (if applicable)
-
-### Labels
-* Please add one or more of these labels to your issue after creating it: 
-  * mimic-iv
-  * mimic-iii
-  * mimic-cxr
-* If your issue applies to more than one of these please feel free to select multiple labels as appropriate.
-
-* Instructions for how to add a label to an issue:
-  * From this page, click the gear icon next to Labels on the right side of the page.
-  * Type mimic-iv, mimic-iii, or mimic-cxr in the Filter labels box, or scroll down.
-  * Click on the appropriate label(s); a check mark should appear next to the label(s).


### PR DESCRIPTION
Users need to have triage or write access to able to add a label.  We will need to manually add labels to incoming issues internally until an automated method can be implemented.  