### PR TITLE
Fix kdigo_stages.sql in BigQuery for cases where one of the inputs to GREATEST is null. Ref #917 

### DIFF
--- a/mimic-iv/concepts/organfailure/kdigo_stages.sql
+++ b/mimic-iv/concepts/organfailure/kdigo_stages.sql
@@ -79,7 +79,10 @@ select
   , uo.uo_rt_24hr
   , uo.aki_stage_uo
   -- Classify AKI using both creatinine/urine output criteria
-  , GREATEST(cr.aki_stage_creat, uo.aki_stage_uo) AS aki_stage
+  , GREATEST(
+        COALESCE(cr.aki_stage_creat,0),
+        COALESCE(uo.aki_stage_uo,0)
+        ) AS aki_stage
 FROM `physionet-data.mimic_icu.icustays` ie
 -- get all possible charttimes as listed in tm_stg
 LEFT JOIN tm_stg tm


### PR DESCRIPTION
As noted in #917, Postgres and BigQuery handle `greatest(null,x)` differently. BigQuery returns Null, Postgres returns x. 

It looks like this is addressed in most queries with `COALESCE` but [mimic-iv/concepts/organfailure/kdigo_stages.sql](https://github.com/MIT-LCP/mimic-code/blob/0edce4cea6e3b6ffc4062b64f5b4a32c376b8918/mimic-iv/concepts/organfailure/kdigo_stages.sql#L81-L82) seems to have been missed.

This pull request fixes `GREATEST(cr.aki_stage_creat, uo.aki_stage_uo)` for BigQuery by  adding the COALESCE.