### PR TITLE
update github links to new default branch name (master -> main)

### DIFF
--- a/mimic-iii/buildmimic/README.md
+++ b/mimic-iii/buildmimic/README.md
@@ -4,5 +4,5 @@ This directory contains scripts that can be used to create a new instance of the
 
 ## Automated tests (PostgreSQL scripts only)
 
-Pushing to this repository triggers [a simple set of tests](https://github.com/MIT-LCP/mimic-code/tree/master/tests) to run on [Travis CI](https://travis-ci.org/). The status of the tests is [![Build Status](https://travis-ci.org/MIT-LCP/mimic-code.svg?branch=master)](https://travis-ci.org/MIT-LCP/mimic-code)
+Pushing to this repository triggers [a simple set of tests](https://github.com/MIT-LCP/mimic-code/tree/main/mimic-iii/tests) to run on [Travis CI](https://travis-ci.org/). The status of the tests is [![Build Status](https://travis-ci.org/MIT-LCP/mimic-code.svg?branch=main)](https://travis-ci.org/MIT-LCP/mimic-code)
 

--- a/mimic-iii/buildmimic/bigquery/README.md
+++ b/mimic-iii/buildmimic/bigquery/README.md
@@ -138,7 +138,7 @@ BigQuery schemas are defined by JSON files. These files are an array of dictiona
 
 The information about the columns are compiled from several sources:
 
-1. [The PostgreSQL build scripts](https://github.com/MIT-LCP/mimic-code/tree/master/buildmimic/postgres)
+1. [The PostgreSQL build scripts](https://github.com/MIT-LCP/mimic-code/tree/main/mimic-iii/buildmimic/postgres)
 2. [The MIMIC-III online documentation](https://mimic.physionet.org/about/mimic/)
 3. [A schematic of the MIMIC-III database](https://mit-lcp.github.io/mimic-schema-spy/)
 

--- a/mimic-iii/concepts/README.md
+++ b/mimic-iii/concepts/README.md
@@ -36,7 +36,7 @@ This can be done as follows:
     * This file runs the scripts after applying a few regular expressions which convert table references and date calculations appropriately.
     * This file generates all concepts on the `public` schema.
 
-If you do not have access to a PostgreSQL database with MIMIC, you can read more about building the data within one in the [buildmimic/postgres](https://github.com/MIT-LCP/mimic-code/tree/master/buildmimic/postgres) folder.
+If you do not have access to a PostgreSQL database with MIMIC, you can read more about building the data within one in the [buildmimic/postgres](https://github.com/MIT-LCP/mimic-code/tree/main/mimic-iii/buildmimic/postgres) folder.
 
 ## Generating the concepts in PostgreSQL (Windows)
 

--- a/mimic-iii/tutorials/sql-intro.md
+++ b/mimic-iii/tutorials/sql-intro.md
@@ -603,13 +603,13 @@ AND serv.rank = 1;
 
 # Using other concepts available in the MIMIC Code Repository
 
-The MIMIC Code Repository is a repository of code shared by the research community - it's where this tutorial is hosted! It is intended to be a central hub for sharing, refining, and reusing code used for analysis of the MIMIC critical care database. For example, you may be interested in identifying which patients have severe sepsis according to the [Angus Criteria](https://github.com/MIT-LCP/mimic-code/blob/master/concepts/sepsis/angus2001.pdf). Rather than re-implementing the criteria, you can make use of existing code in the MIMIC Code Repository.
+The MIMIC Code Repository is a repository of code shared by the research community - it's where this tutorial is hosted! It is intended to be a central hub for sharing, refining, and reusing code used for analysis of the MIMIC critical care database. For example, you may be interested in identifying which patients have severe sepsis according to the [Angus Criteria](https://github.com/MIT-LCP/mimic-code/blob/main/mimic-iii/concepts/sepsis/angus2001.pdf). Rather than re-implementing the criteria, you can make use of existing code in the MIMIC Code Repository.
 
-A materialised view for the Angus Criteria is available at: https://github.com/MIT-LCP/mimic-code/blob/master/concepts/sepsis/angus.sql. Running this query will generate a table with columns for `subject_id`,`hadm_id`, and `angus` status.
+A materialised view for the Angus Criteria is available at: https://github.com/MIT-LCP/mimic-code/tree/main/mimic-iii/concepts/sepsis/angus.sql. Running this query will generate a table with columns for `subject_id`,`hadm_id`, and `angus` status.
 
 ## Exercise 10
 
-Build a materialized view of the Angus criteria on your local database using the code at: https://github.com/MIT-LCP/mimic-code/blob/master/concepts/sepsis/angus.sql
+Build a materialized view of the Angus criteria on your local database using the code at: https://github.com/MIT-LCP/mimic-code/tree/main/mimic-iii/concepts/sepsis/angus.sql
 
 ## Solution 10
 


### PR DESCRIPTION
- Fixes some markdown links broken by the moving the mimic-iii code into a subdirectory
- Removes a couple of references to the old 'master' default branch