### PR TITLE
Added mimic_derived schema creation logic for Postgres

### DIFF
--- a/mimic-iv/buildmimic/postgres/create.sql
+++ b/mimic-iv/buildmimic/postgres/create.sql
@@ -12,6 +12,8 @@ DROP SCHEMA IF EXISTS mimic_hosp CASCADE;
 CREATE SCHEMA mimic_hosp;
 DROP SCHEMA IF EXISTS mimic_icu CASCADE;
 CREATE SCHEMA mimic_icu;
+DROP SCHEMA IF EXISTS mimic_derived CASCADE;
+CREATE SCHEMA mimic_derived;
 
 ---------------------
 -- Creating tables --


### PR DESCRIPTION
This commit adds logic for creating the `mimic_derived` schema for building MIMIC in Postgres. This step is necessary to extract concepts using `postgres-make-concepts.sql` to `mimic_derived`; currently, the concept tables are erroneously created in `mimic_core`. 