### PR TITLE
add workflow to generate tables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: Generate tables on BigQuery
+
+on:
+  release:
+    types: [published]
+    branches: ["main"]
+
+jobs:
+  create-tables:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Run make_concepts
+        run: |
+            echo "Generating tables on BigQuery"
+            cd mimic-iv/concepts
+            bash make_concepts.sh > /dev/null


### PR DESCRIPTION
This adds a GitHub action workflow which regenerates tables on the BigQuery `mimic_derived` dataset when a release is published on GitHub.