### PR TITLE
Include BNP in cardiac markers concept

### DIFF
--- a/mimic-iv/concepts/measurement/cardiac_marker.sql
+++ b/mimic-iv/concepts/measurement/cardiac_marker.sql
@@ -5,16 +5,18 @@ SELECT
   , MAX(charttime) AS charttime
   , le.specimen_id
   -- convert from itemid into a meaningful column
-  , MAX(CASE WHEN itemid = 51002 THEN value ELSE NULL END) AS troponin_i
   , MAX(CASE WHEN itemid = 51003 THEN value ELSE NULL END) AS troponin_t
   , MAX(CASE WHEN itemid = 50911 THEN valuenum ELSE NULL END) AS ck_mb
+  , MAX(CASE WHEN itemid = 50963 THEN valuenum ELSE NULL END) AS ntprobnp
 FROM mimic_hosp.labevents le
 WHERE le.itemid IN
 (
     -- 51002, -- Troponin I (troponin-I is not measured in MIMIC-IV)
     -- 52598, -- Troponin I, point of care, rare/poor quality
     51003, -- Troponin T
-    50911  -- Creatinine Kinase, MB isoenzyme
+    50911,  -- Creatinine Kinase, MB isoenzyme
+    50963 -- N-terminal (NT)-pro hormone BNP (NT-proBNP) 
 )
+AND valuenum IS NOT NULL
 GROUP BY le.specimen_id
 ;


### PR DESCRIPTION
Includes SQL query to fetch ntprobnb lab results in cardiac markers concept. 
Also, removed reference to troponin I, since it is not registered in mimic-iv.