### PR TITLE
Fix matching GCS with previous GCS

### DIFF
--- a/mimic-iv/concepts/measurement/gcs.sql
+++ b/mimic-iv/concepts/measurement/gcs.sql
@@ -84,7 +84,7 @@ with base as
   left join base b2
     on b.stay_id = b2.stay_id
     and b.rn = b2.rn+1
-    and b2.charttime > DATETIME_ADD(b.charttime, INTERVAL '6' HOUR)
+    and b2.charttime > DATETIME_SUB(b.charttime, INTERVAL '6' HOUR)
 )
 -- combine components with previous within 6 hours
 -- filter down to cohort which is not excluded

--- a/mimic-iv/concepts/postgres/measurement/gcs.sql
+++ b/mimic-iv/concepts/postgres/measurement/gcs.sql
@@ -86,7 +86,7 @@ with base as
   left join base b2
     on b.stay_id = b2.stay_id
     and b.rn = b2.rn+1
-    and b2.charttime > DATETIME_ADD(b.charttime, INTERVAL '6' HOUR)
+    and b2.charttime > DATETIME_SUB(b.charttime, INTERVAL '6' HOUR)
 )
 -- combine components with previous within 6 hours
 -- filter down to cohort which is not excluded


### PR DESCRIPTION
### Problem

I believe there is a minor error in the GCS concept. When looking for previous GCS measurements, it currently looks in the previous row `where b.rn = b2.rn+1` but then requires the previous row to be recorded more than 6 hours **after** the following row. Since rows are ordered by time, this is impossible and no previous measurements are found (this can be verified with running the adapted reproducible example below). 

### Solution
Change `DATETIME_ADD` to `DATETIME_SUB` in order to obtain the intended behaviour. 

### Additional question
While looking at GCS, I was also wondering why GCS is replaced with `15` when the patient is intubated and verbal is missing. This does not seem an appropriate imputation and also --- contra to what the ascertation in the notes --- does not seem 

> in line with how the data is meant to be collected. e.g., from the SAPS II publication

Maybe the code's creator could comment on this choice?

### Reprex
**Current behaviour**
<details>
<summary>Click to expand</summary>

```sql

with base as
(
  select
    subject_id
  , ce.stay_id, ce.charttime
  -- pivot each value into its own column
  , max(case when ce.ITEMID = 223901 then ce.valuenum else null end) as GCSMotor
  , max(case
      when ce.ITEMID = 223900 and ce.VALUE = 'No Response-ETT' then 0
      when ce.ITEMID = 223900 then ce.valuenum
      else null
    end) as GCSVerbal
  , max(case when ce.ITEMID = 220739 then ce.valuenum else null end) as GCSEyes
  -- convert the data into a number, reserving a value of 0 for ET/Trach
  , max(case
      -- endotrach/vent is assigned a value of 0
      -- flag it here to later parse specially
      when ce.ITEMID = 223900 and ce.VALUE = 'No Response-ETT' then 1 -- metavision
    else 0 end)
    as endotrachflag
  , ROW_NUMBER ()
          OVER (PARTITION BY ce.stay_id ORDER BY ce.charttime ASC) as rn
  from mimic_icu.chartevents ce
  -- Isolate the desired GCS variables
  where ce.ITEMID in
  (
    -- GCS components, Metavision
    223900, 223901, 220739
  )
  group by ce.subject_id, ce.stay_id, ce.charttime
)
, gcs as (
  select b.*
  , b2.GCSVerbal as GCSVerbalPrev
  , b2.GCSMotor as GCSMotorPrev
  , b2.GCSEyes as GCSEyesPrev
  , b2.charttime as charttimePrev
  -- Calculate GCS, factoring in special case when they are intubated and prev vals
  -- note that the coalesce are used to implement the following if:
  --  if current value exists, use it
  --  if previous value exists, use it
  --  otherwise, default to normal
  , case
      -- replace GCS during sedation with 15
      when b.GCSVerbal = 0
        then 15
      when b.GCSVerbal is null and b2.GCSVerbal = 0
        then 15
      -- if previously they were intub, but they aren't now, do not use previous GCS values
      when b2.GCSVerbal = 0
        then
            coalesce(b.GCSMotor,6)
          + coalesce(b.GCSVerbal,5)
          + coalesce(b.GCSEyes,4)
      -- otherwise, add up score normally, imputing previous value if none available at current time
      else
            coalesce(b.GCSMotor,coalesce(b2.GCSMotor,6))
          + coalesce(b.GCSVerbal,coalesce(b2.GCSVerbal,5))
          + coalesce(b.GCSEyes,coalesce(b2.GCSEyes,4))
      end as GCS

  from base b
  -- join to itself within 6 hours to get previous value
  left join base b2
    on b.stay_id = b2.stay_id
    and b.rn = b2.rn+1
    and b2.charttime > DATETIME_ADD(b.charttime, INTERVAL '6' HOUR)
)
select count(*) as n_matched
from gcs
where charttimePrev is not null;

-- n_matched
--         0
```
</details>

**New behaviour**
<details>
<summary>Click to expand</summary>

```sql

with base as
(
  select
    subject_id
  , ce.stay_id, ce.charttime
  -- pivot each value into its own column
  , max(case when ce.ITEMID = 223901 then ce.valuenum else null end) as GCSMotor
  , max(case
      when ce.ITEMID = 223900 and ce.VALUE = 'No Response-ETT' then 0
      when ce.ITEMID = 223900 then ce.valuenum
      else null
    end) as GCSVerbal
  , max(case when ce.ITEMID = 220739 then ce.valuenum else null end) as GCSEyes
  -- convert the data into a number, reserving a value of 0 for ET/Trach
  , max(case
      -- endotrach/vent is assigned a value of 0
      -- flag it here to later parse specially
      when ce.ITEMID = 223900 and ce.VALUE = 'No Response-ETT' then 1 -- metavision
    else 0 end)
    as endotrachflag
  , ROW_NUMBER ()
          OVER (PARTITION BY ce.stay_id ORDER BY ce.charttime ASC) as rn
  from mimic_icu.chartevents ce
  -- Isolate the desired GCS variables
  where ce.ITEMID in
  (
    -- GCS components, Metavision
    223900, 223901, 220739
  )
  group by ce.subject_id, ce.stay_id, ce.charttime
)
, gcs as (
  select b.*
  , b2.GCSVerbal as GCSVerbalPrev
  , b2.GCSMotor as GCSMotorPrev
  , b2.GCSEyes as GCSEyesPrev
  , b2.charttime as charttimePrev
  -- Calculate GCS, factoring in special case when they are intubated and prev vals
  -- note that the coalesce are used to implement the following if:
  --  if current value exists, use it
  --  if previous value exists, use it
  --  otherwise, default to normal
  , case
      -- replace GCS during sedation with 15
      when b.GCSVerbal = 0
        then 15
      when b.GCSVerbal is null and b2.GCSVerbal = 0
        then 15
      -- if previously they were intub, but they aren't now, do not use previous GCS values
      when b2.GCSVerbal = 0
        then
            coalesce(b.GCSMotor,6)
          + coalesce(b.GCSVerbal,5)
          + coalesce(b.GCSEyes,4)
      -- otherwise, add up score normally, imputing previous value if none available at current time
      else
            coalesce(b.GCSMotor,coalesce(b2.GCSMotor,6))
          + coalesce(b.GCSVerbal,coalesce(b2.GCSVerbal,5))
          + coalesce(b.GCSEyes,coalesce(b2.GCSEyes,4))
      end as GCS

  from base b
  -- join to itself within 6 hours to get previous value
  left join base b2
    on b.stay_id = b2.stay_id
    and b.rn = b2.rn+1
    and b2.charttime > DATETIME_SUB(b.charttime, INTERVAL '6' HOUR)
)
select count(*) as n_matched
from gcs
where charttimePrev is not null;

-- n_matched
-- 1,508,296
```
</details>

**Edits:** typos
