### PR TITLE
Create view for code_status in MIMIC-IV

### DIFF
--- a/mimic-iv/concepts/treatment/code_status.sql
+++ b/mimic-iv/concepts/treatment/code_status.sql
@@ -3,9 +3,8 @@
 --    ii) a patient's last code status
 --    iii) the time of the first entry of DNR or CMO
 
-with t1 as
-(
-  /* 
+with t1 as (
+  /*
 There are five distinct values for the code status order in the dataset:
 1 DNR / DNI
 2	DNI (do not intubate)
@@ -13,57 +12,70 @@ There are five distinct values for the code status order in the dataset:
 4	Full code
 5	DNR (do not resuscitate)
  */
-  
-  select stay_id, charttime, value
-  -- use row number to identify first and last code status
-  , ROW_NUMBER() over (PARTITION BY stay_id order by charttime) as rnfirst
-  , ROW_NUMBER() over (PARTITION BY stay_id order by charttime desc) as rnlast
-  -- coalesce the values
-  , case
-      when value in ('Full code') then 1
-    else 0 end as fullcode
-  , case
-      when value in ('Comfort measures only') then 1
-    else 0 end as cmo
-  , case
-      when value in ('DNI (do not intubate)','DNR / DNI') then 1
-    else 0 end as dni
-  , case
-      when value in ('DNR (do not resuscitate)','DNR / DNI') then 1
-    else 0 end as dnr
-  FROM `physionet-data.mimic_icu.chartevents`
-  where itemid in (223758)
+
+    select
+        stay_id,
+        charttime,
+        value,
+        -- use row number to identify first and last code status
+        ROW_NUMBER() over (partition by stay_id order by charttime) as rnfirst,
+        ROW_NUMBER() over (
+            partition by stay_id order by charttime desc
+        ) as rnlast,
+        -- coalesce the values
+        case
+            when value in ('Full code') then 1
+            else 0 end as fullcode,
+        case
+            when value in ('Comfort measures only') then 1
+            else 0 end as cmo,
+        case
+            when value in ('DNI (do not intubate)', 'DNR / DNI') then 1
+            else 0 end as dni,
+        case
+            when value in ('DNR (do not resuscitate)', 'DNR / DNI') then 1
+            else 0 end as dnr
+    from `physionet-data.mimic_icu.chartevents`
+    where itemid in (223758)
 )
-select ie.subject_id, ie.hadm_id, ie.stay_id
-  -- first recorded code status
-  , max(case when rnfirst = 1 then t1.fullcode else null end) as fullcode_first
-  , max(case when rnfirst = 1 then t1.cmo else null end) as cmo_first
-  , max(case when rnfirst = 1 then t1.dnr else null end) as dnr_first
-  , max(case when rnfirst = 1 then t1.dni else null end) as dni_first
 
-  -- last recorded code status
-  , max(case when  rnlast = 1 then t1.fullcode else null end) as fullcode_last
-  , max(case when  rnlast = 1 then t1.cmo else null end) as cmo_last
-  , max(case when  rnlast = 1 then t1.dnr else null end) as dnr_last
-  , max(case when  rnlast = 1 then t1.dni else null end) as dni_last
+select
+    ie.subject_id,
+    ie.hadm_id,
+    ie.stay_id,
+    -- first recorded code status
+    MAX(
+        case when rnfirst = 1 then t1.fullcode end
+    ) as fullcode_first,
+    MAX(case when rnfirst = 1 then t1.cmo end) as cmo_first,
+    MAX(case when rnfirst = 1 then t1.dnr end) as dnr_first,
+    MAX(case when rnfirst = 1 then t1.dni end) as dni_first,
 
-  -- were they *at any time* given a certain code status
-  , max(t1.fullcode) as fullcode
-  , max(t1.cmo) as cmo
-  , max(t1.dnr) as dnr
-  , max(t1.dni) as dni
+    -- last recorded code status
+    MAX(
+        case when rnlast = 1 then t1.fullcode end
+    ) as fullcode_last,
+    MAX(case when rnlast = 1 then t1.cmo end) as cmo_last,
+    MAX(case when rnlast = 1 then t1.dnr end) as dnr_last,
+    MAX(case when rnlast = 1 then t1.dni end) as dni_last,
 
-  -- time until their first DNR
-  , min(case when t1.dnr = 1 then t1.charttime else null end)
-        as dnr_first_charttime
-  , min(case when t1.dni = 1 then t1.charttime else null end)
-        as dni_first_charttime
+    -- were they *at any time* given a certain code status
+    MAX(t1.fullcode) as fullcode,
+    MAX(t1.cmo) as cmo,
+    MAX(t1.dnr) as dnr,
+    MAX(t1.dni) as dni,
 
-  -- first code status of CMO
-  , min(case when t1.cmo = 1 then t1.charttime else null end)
-        as timecmo_chart
+    -- time until their first DNR
+    MIN(case when t1.dnr = 1 then t1.charttime end)
+    as dnr_first_charttime,
+    MIN(case when t1.dni = 1 then t1.charttime end)
+    as dni_first_charttime,
 
-FROM `physionet-data.mimic_icu.icustays` ie
+    -- first code status of CMO
+    MIN(case when t1.cmo = 1 then t1.charttime end)
+    as timecmo_chart
+
+from `physionet-data.mimic_icu.icustays` as ie
 left join t1
-  on ie.stay_id = t1.stay_id
+          on ie.stay_id = t1.stay_id
 group by ie.subject_id, ie.hadm_id, ie.stay_id, ie.intime;

--- a/mimic-iv/concepts/treatment/code_status.sql
+++ b/mimic-iv/concepts/treatment/code_status.sql
@@ -1,0 +1,69 @@
+-- This query extracts:
+--    i) a patient's first code status
+--    ii) a patient's last code status
+--    iii) the time of the first entry of DNR or CMO
+
+with t1 as
+(
+  /* 
+There are five distinct values for the code status order in the dataset:
+1 DNR / DNI
+2	DNI (do not intubate)
+3	Comfort measures only
+4	Full code
+5	DNR (do not resuscitate)
+ */
+  
+  select stay_id, charttime, value
+  -- use row number to identify first and last code status
+  , ROW_NUMBER() over (PARTITION BY stay_id order by charttime) as rnfirst
+  , ROW_NUMBER() over (PARTITION BY stay_id order by charttime desc) as rnlast
+  -- coalesce the values
+  , case
+      when value in ('Full code') then 1
+    else 0 end as fullcode
+  , case
+      when value in ('Comfort measures only') then 1
+    else 0 end as cmo
+  , case
+      when value in ('DNI (do not intubate)','DNR / DNI') then 1
+    else 0 end as dni
+  , case
+      when value in ('DNR (do not resuscitate)','DNR / DNI') then 1
+    else 0 end as dnr
+  FROM `physionet-data.mimic_icu.chartevents`
+  where itemid in (223758)
+)
+select ie.subject_id, ie.hadm_id, ie.stay_id
+  -- first recorded code status
+  , max(case when rnfirst = 1 then t1.fullcode else null end) as fullcode_first
+  , max(case when rnfirst = 1 then t1.cmo else null end) as cmo_first
+  , max(case when rnfirst = 1 then t1.dnr else null end) as dnr_first
+  , max(case when rnfirst = 1 then t1.dni else null end) as dni_first
+
+  -- last recorded code status
+  , max(case when  rnlast = 1 then t1.fullcode else null end) as fullcode_last
+  , max(case when  rnlast = 1 then t1.cmo else null end) as cmo_last
+  , max(case when  rnlast = 1 then t1.dnr else null end) as dnr_last
+  , max(case when  rnlast = 1 then t1.dni else null end) as dni_last
+
+  -- were they *at any time* given a certain code status
+  , max(t1.fullcode) as fullcode
+  , max(t1.cmo) as cmo
+  , max(t1.dnr) as dnr
+  , max(t1.dni) as dni
+
+  -- time until their first DNR
+  , min(case when t1.dnr = 1 then t1.charttime else null end)
+        as dnr_first_charttime
+  , min(case when t1.dni = 1 then t1.charttime else null end)
+        as dni_first_charttime
+
+  -- first code status of CMO
+  , min(case when t1.cmo = 1 then t1.charttime else null end)
+        as timecmo_chart
+
+FROM `physionet-data.mimic_icu.icustays` ie
+left join t1
+  on ie.stay_id = t1.stay_id
+group by ie.subject_id, ie.hadm_id, ie.stay_id, ie.intime;

--- a/mimic-iv/concepts/treatment/code_status.sql
+++ b/mimic-iv/concepts/treatment/code_status.sql
@@ -1,11 +1,9 @@
--- This query extracts:
---    i) a patient's first code status
---    ii) a patient's last code status
---    iii) the time of the first entry of DNR or CMO
+-- This query extracts code status with the time at which the
+-- code status was documented.
 
 WITH t1 AS (
   /*
-There are five distinct values for the code status order in the dataset:
+There are five distinct values for the code status order in the ICU data:
 1 DNR / DNI
 2	DNI (do not intubate)
 3	Comfort measures only
@@ -14,14 +12,10 @@ There are five distinct values for the code status order in the dataset:
  */
 
     SELECT
-        stay_id
+        subject_id
+        , hadm_id
+        , stay_id
         , charttime
-        , value
-        -- use row number to identify first and last code status
-        , ROW_NUMBER() OVER (PARTITION BY stay_id ORDER BY charttime) AS rnfirst
-        , ROW_NUMBER() OVER (
-            PARTITION BY stay_id ORDER BY charttime DESC
-        ) AS rnlast
         -- coalesce the values
         , CASE
             WHEN value IN ('Full code') THEN 1
@@ -39,43 +33,46 @@ There are five distinct values for the code status order in the dataset:
     WHERE itemid IN (223758)
 )
 
-SELECT
-    ie.subject_id
-    , ie.hadm_id
-    , ie.stay_id
-    -- first recorded code status
-    , MAX(
-        CASE WHEN rnfirst = 1 THEN t1.fullcode END
-    ) AS fullcode_first
-    , MAX(CASE WHEN rnfirst = 1 THEN t1.cmo END) AS cmo_first
-    , MAX(CASE WHEN rnfirst = 1 THEN t1.dnr END) AS dnr_first
-    , MAX(CASE WHEN rnfirst = 1 THEN t1.dni END) AS dni_first
+-- Provider order entry contains hospital wide orders for code status changes
+-- Interestingly, it does not contain comfort measures only orders
+, poe AS (
+    SELECT p.subject_id
+        , p.hadm_id
+        , ie.stay_id
+        , p.order_time
+        , CASE
+            WHEN pd.field_value = 'Resuscitate (Full code)' THEN 1
+            WHEN pd.field_value = 'Full code  (attempt resuscitation)' THEN 1
+            ELSE 0 END AS fullcode
+        , CASE
+            WHEN
 
-    -- last recorded code status
-    , MAX(
-        CASE WHEN rnlast = 1 THEN t1.fullcode END
-    ) AS fullcode_last
-    , MAX(CASE WHEN rnlast = 1 THEN t1.cmo END) AS cmo_last
-    , MAX(CASE WHEN rnlast = 1 THEN t1.dnr END) AS dnr_last
-    , MAX(CASE WHEN rnlast = 1 THEN t1.dni END) AS dni_last
+                pd.field_value = 'DNAR (DO NOT attempt resuscitation for cardiac arrest) ' THEN 1 -- noqa
+            WHEN pd.field_value = 'Do not resuscitate (DNR/DNI)' THEN 1
+            ELSE 0 END AS dnr
+        , CASE
+            WHEN pd.field_value = 'Do not resuscitate (DNR/DNI)' THEN 1
+            ELSE 0 END AS dni
+    FROM `physionet-data.mimiciv_hosp.poe` p
+    INNER JOIN `physionet-data.mimiciv_hosp.poe_detail` pd
+        ON p.poe_id = pd.poe_id
+    LEFT JOIN `physiont-data.mimiciv_icu.icustays` ie
+        ON p.hadm_id = ie.hadm_id
+            AND p.order_time >= ie.intime
+            AND p.order_time <= ie.outtime
+    WHERE p.order_type = 'General Care'
+        AND order_subtype = 'Code status'
+)
 
-    -- were they *at any time* given a certain code status
-    , MAX(t1.fullcode) AS fullcode
-    , MAX(t1.cmo) AS cmo
-    , MAX(t1.dnr) AS dnr
-    , MAX(t1.dni) AS dni
-
-    -- time until their first DNR
-    , MIN(CASE WHEN t1.dnr = 1 THEN t1.charttime END)
-    AS dnr_first_charttime
-    , MIN(CASE WHEN t1.dni = 1 THEN t1.charttime END)
-    AS dni_first_charttime
-
-    -- first code status of CMO
-    , MIN(CASE WHEN t1.cmo = 1 THEN t1.charttime END)
-    AS timecmo_chart
-
-FROM `physionet-data.mimic_icu.icustays` AS ie
-LEFT JOIN t1
-          ON ie.stay_id = t1.stay_id
-GROUP BY ie.subject_id, ie.hadm_id, ie.stay_id, ie.intime;
+-- Merge together code status from ICU data
+-- with code status from provider order entry
+SELECT t1.subject_id, t1.hadm_id, t1.stay_id
+    , t1.charttime
+    , t1.fullcode, t1.cmo, t1.dni, t1.dnr
+FROM t1
+UNION ALL
+SELECT poe.subject_id, poe.hadm_id, poe.stay_id
+    , poe.order_time AS charttime
+    , poe.fullcode, 0 AS cmo, poe.dni, poe.dnr
+FROM poe
+;


### PR DESCRIPTION
Create a new view with code status orders for MIMIC-IV data:
* Started with mimic-iii/concepts/code_status.sql 
* Changed icustay_id references to stay_id
* Removed carevue specific itemid and logic (DNCPR)