### PR TITLE
Update derived concepts for mimic-iv

### DIFF
--- a/mimic-iv/concepts/comorbidity/charlson.sql
+++ b/mimic-iv/concepts/comorbidity/charlson.sql
@@ -253,7 +253,7 @@ WITH diag AS
             SUBSTR(icd10_code, 1, 3) IN ('B20','B21','B22','B24')
             THEN 1 
             ELSE 0 END) AS aids
-    FROM `physionet-data.mimic_core.admissions` ad
+    FROM `physionet-data.mimic_hosp.admissions` ad
     LEFT JOIN diag
     ON ad.hadm_id = diag.hadm_id
     GROUP BY ad.hadm_id
@@ -303,7 +303,7 @@ SELECT
     + 2*paraplegia + 2*renal_disease 
     + 6*aids
     AS charlson_comorbidity_index
-FROM `physionet-data.mimic_core.admissions` ad
+FROM `physionet-data.mimic_hosp.admissions` ad
 LEFT JOIN com
 ON ad.hadm_id = com.hadm_id
 LEFT JOIN ag

--- a/mimic-iv/concepts/comorbidity/charlson.sql
+++ b/mimic-iv/concepts/comorbidity/charlson.sql
@@ -19,7 +19,7 @@ WITH diag AS
         hadm_id
         , CASE WHEN icd_version = 9 THEN icd_code ELSE NULL END AS icd9_code
         , CASE WHEN icd_version = 10 THEN icd_code ELSE NULL END AS icd10_code
-    FROM `physionet-data.mimic_hosp.diagnoses_icd` diag
+    FROM `physionet-data.mimiciv_hosp.diagnoses_icd` diag
 )
 , com AS
 (
@@ -253,7 +253,7 @@ WITH diag AS
             SUBSTR(icd10_code, 1, 3) IN ('B20','B21','B22','B24')
             THEN 1 
             ELSE 0 END) AS aids
-    FROM `physionet-data.mimic_hosp.admissions` ad
+    FROM `physionet-data.mimiciv_hosp.admissions` ad
     LEFT JOIN diag
     ON ad.hadm_id = diag.hadm_id
     GROUP BY ad.hadm_id
@@ -268,7 +268,7 @@ WITH diag AS
     WHEN age <= 60 THEN 2
     WHEN age <= 70 THEN 3
     ELSE 4 END AS age_score
-    FROM `physionet-data.mimic_derived.age`
+    FROM `physionet-data.mimiciv_derived.age`
 )
 SELECT 
     ad.subject_id
@@ -303,7 +303,7 @@ SELECT
     + 2*paraplegia + 2*renal_disease 
     + 6*aids
     AS charlson_comorbidity_index
-FROM `physionet-data.mimic_hosp.admissions` ad
+FROM `physionet-data.mimiciv_hosp.admissions` ad
 LEFT JOIN com
 ON ad.hadm_id = com.hadm_id
 LEFT JOIN ag

--- a/mimic-iv/concepts/convert_bigquery_to_postgres.sh
+++ b/mimic-iv/concepts/convert_bigquery_to_postgres.sh
@@ -2,12 +2,12 @@
 # This shell script converts BigQuery .sql files into PostgreSQL .sql files.
 
 # String replacements are necessary for some queries.
-export REGEX_SCHEMA='s/`physionet-data.(mimic_core|mimic_icu|mimic_derived|mimic_hosp).(.+?)`/\1.\2/g'
+export REGEX_SCHEMA='s/`physionet-data.(mimiciv_hosp|mimiciv_icu|mimiciv_derived).([A-Za-z0-9_-]+)`/\1.\2/g'
 # Note that these queries are very senstive to changes, e.g. adding whitespaces after comma can already change the behavior.
-export REGEX_DATETIME_DIFF="s/DATETIME_DIFF\((.+?),\s?(.+?),\s?(DAY|MINUTE|SECOND|HOUR|YEAR)\)/DATETIME_DIFF(\1,\2,'\3')/g"
-export REGEX_DATETIME_TRUNC="s/DATETIME_TRUNC\((.+?),\s?(DAY|MINUTE|SECOND|HOUR|YEAR)\)/DATE_TRUNC('\2', \1)/g"
+export REGEX_DATETIME_DIFF="s/DATETIME_DIFF\(([^,]+), ?([^,]+), ?(DAY|MINUTE|SECOND|HOUR|YEAR)\)/DATETIME_DIFF(\1, \2, '\3')/g"
+export REGEX_DATETIME_TRUNC="s/DATETIME_TRUNC\(([^,]+), ?(DAY|MINUTE|SECOND|HOUR|YEAR)\)/DATE_TRUNC('\2', \1)/g"
 # Add necessary quotes to INTERVAL, e.g. "INTERVAL 5 hour" to "INTERVAL '5' hour"
-export REGEX_INTERVAL="s/interval\s([[:digit:]]+)\s(hour|day|month|year)/INTERVAL '\1' \2/gI"
+export REGEX_INTERVAL="s/interval ([[:digit:]]+) (hour|day|month|year)/INTERVAL '\1' \2/gI"
 # Add numeric cast to ROUND(), e.g. "ROUND(1.234, 2)" to "ROUND( CAST(1.234 as numeric), 2)".
 export PERL_REGEX_ROUND='s/ROUND\(((.|\n)*?)\, /ROUND\( CAST\( \1 as numeric\)\,/g'
 # Specific queries for some problems that arose with some files.
@@ -83,7 +83,7 @@ do
         # only run SQL queries
         if [[ "${fn: -4}" == ".sql" ]]; then
             # table name is file name minus extension
-            tbl="${fn::-4}"
+            tbl="${fn%????}"
 
             # skip first_day_sofa as it depends on other firstday queries, we'll generate it later
             # we also skipped tables generated in the "Dependencies" loop above.

--- a/mimic-iv/concepts/demographics/age.sql
+++ b/mimic-iv/concepts/demographics/age.sql
@@ -22,7 +22,7 @@ SELECT
 	, pa.anchor_age
 	, pa.anchor_year
 	, DATETIME_DIFF(ad.admittime, DATETIME(pa.anchor_year, 1, 1, 0, 0, 0), YEAR) + pa.anchor_age AS age
-FROM `physionet-data.mimic_hosp.admissions` ad
-INNER JOIN `physionet-data.mimic_hosp.patients` pa
+FROM `physionet-data.mimiciv_hosp.admissions` ad
+INNER JOIN `physionet-data.mimiciv_hosp.patients` pa
 ON ad.subject_id = pa.subject_id
 ;

--- a/mimic-iv/concepts/demographics/age.sql
+++ b/mimic-iv/concepts/demographics/age.sql
@@ -22,7 +22,7 @@ SELECT
 	, pa.anchor_age
 	, pa.anchor_year
 	, DATETIME_DIFF(ad.admittime, DATETIME(pa.anchor_year, 1, 1, 0, 0, 0), YEAR) + pa.anchor_age AS age
-FROM `physionet-data.mimic_core.admissions` ad
-INNER JOIN `physionet-data.mimic_core.patients` pa
+FROM `physionet-data.mimic_hosp.admissions` ad
+INNER JOIN `physionet-data.mimic_hosp.patients` pa
 ON ad.subject_id = pa.subject_id
 ;

--- a/mimic-iv/concepts/demographics/icustay_detail.sql
+++ b/mimic-iv/concepts/demographics/icustay_detail.sql
@@ -7,7 +7,7 @@ SELECT ie.subject_id, ie.hadm_id, ie.stay_id
 , adm.admittime, adm.dischtime
 , DATETIME_DIFF(adm.dischtime, adm.admittime, DAY) as los_hospital
 , DATETIME_DIFF(adm.admittime, DATETIME(pat.anchor_year, 1, 1, 0, 0, 0), YEAR) + pat.anchor_age as admission_age
-, adm.ethnicity
+, adm.race
 , adm.hospital_expire_flag
 , DENSE_RANK() OVER (PARTITION BY adm.subject_id ORDER BY adm.admittime) AS hospstay_seq
 , CASE

--- a/mimic-iv/concepts/demographics/icustay_detail.sql
+++ b/mimic-iv/concepts/demographics/icustay_detail.sql
@@ -25,7 +25,7 @@ SELECT ie.subject_id, ie.hadm_id, ie.stay_id
     ELSE False END AS first_icu_stay
 
 FROM `physionet-data.mimic_icu.icustays` ie
-INNER JOIN `physionet-data.mimic_core.admissions` adm
+INNER JOIN `physionet-data.mimic_hosp.admissions` adm
     ON ie.hadm_id = adm.hadm_id
-INNER JOIN `physionet-data.mimic_core.patients` pat
+INNER JOIN `physionet-data.mimic_hosp.patients` pat
     ON ie.subject_id = pat.subject_id

--- a/mimic-iv/concepts/demographics/icustay_detail.sql
+++ b/mimic-iv/concepts/demographics/icustay_detail.sql
@@ -24,8 +24,8 @@ SELECT ie.subject_id, ie.hadm_id, ie.stay_id
     WHEN DENSE_RANK() OVER (PARTITION BY ie.hadm_id ORDER BY ie.intime) = 1 THEN True
     ELSE False END AS first_icu_stay
 
-FROM `physionet-data.mimic_icu.icustays` ie
-INNER JOIN `physionet-data.mimic_hosp.admissions` adm
+FROM `physionet-data.mimiciv_icu.icustays` ie
+INNER JOIN `physionet-data.mimiciv_hosp.admissions` adm
     ON ie.hadm_id = adm.hadm_id
-INNER JOIN `physionet-data.mimic_hosp.patients` pat
+INNER JOIN `physionet-data.mimiciv_hosp.patients` pat
     ON ie.subject_id = pat.subject_id

--- a/mimic-iv/concepts/demographics/icustay_hourly.sql
+++ b/mimic-iv/concepts/demographics/icustay_hourly.sql
@@ -27,7 +27,7 @@ select
   --  we allow 24 hours before ICU admission (to grab labs before admit)
   , GENERATE_ARRAY(-24, CEIL(DATETIME_DIFF(it.outtime_hr, it.intime_hr, HOUR))) as hrs
 
-  from `physionet-data.mimic_derived.icustay_times` it
+  from `physionet-data.mimiciv_derived.icustay_times` it
 )
 SELECT stay_id
 , CAST(hr AS INT64) as hr

--- a/mimic-iv/concepts/demographics/icustay_times.sql
+++ b/mimic-iv/concepts/demographics/icustay_times.sql
@@ -6,7 +6,7 @@ WITH t1 AS
     select ce.stay_id
     , min(charttime) as intime_hr
     , max(charttime) as outtime_hr
-    FROM `physionet-data.mimic_icu.chartevents` ce
+    FROM `physionet-data.mimiciv_icu.chartevents` ce
     -- only look at heart rate
     where ce.itemid = 220045
     group by ce.stay_id
@@ -16,6 +16,6 @@ select
   ie.subject_id, ie.hadm_id, ie.stay_id
   , t1.intime_hr
   , t1.outtime_hr
-FROM `physionet-data.mimic_icu.icustays` ie
+FROM `physionet-data.mimiciv_icu.icustays` ie
 left join t1
   on ie.stay_id = t1.stay_id;

--- a/mimic-iv/concepts/demographics/weight_durations.sql
+++ b/mimic-iv/concepts/demographics/weight_durations.sql
@@ -9,7 +9,7 @@ WITH wt_stg as
           else 'daily' end as weight_type
       -- TODO: eliminate obvious outliers if there is a reasonable weight
       , c.valuenum as weight
-    FROM `physionet-data.mimic_icu.chartevents` c
+    FROM `physionet-data.mimiciv_icu.chartevents` c
     WHERE c.valuenum IS NOT NULL
       AND c.itemid in
       (
@@ -42,7 +42,7 @@ WITH wt_stg as
       else wt_stg1.charttime end as starttime
     , wt_stg1.weight
   from wt_stg1
-  INNER JOIN `physionet-data.mimic_icu.icustays` ie
+  INNER JOIN `physionet-data.mimiciv_icu.icustays` ie
     on ie.stay_id = wt_stg1.stay_id
 )
 , wt_stg3 as
@@ -87,7 +87,7 @@ WITH wt_stg as
     , wt.starttime as endtime
     , wt.weight
     , wt.weight_type
-  from `physionet-data.mimic_icu.icustays` ie
+  from `physionet-data.mimiciv_icu.icustays` ie
   inner join
   -- the below subquery returns one row for each unique stay_id
   -- the row contains: the first starttime and the corresponding weight

--- a/mimic-iv/concepts/firstday/first_day_bg.sql
+++ b/mimic-iv/concepts/firstday/first_day_bg.sql
@@ -23,8 +23,8 @@ select
     , MIN(glucose) AS glucose_min, MAX(glucose) AS glucose_max
     , MIN(potassium) AS potassium_min, MAX(potassium) AS potassium_max
     , MIN(sodium) AS sodium_min, MAX(sodium) AS sodium_max
-FROM `physionet-data.mimic_icu.icustays` ie
-LEFT JOIN `physionet-data.mimic_derived.bg` bg
+FROM `physionet-data.mimiciv_icu.icustays` ie
+LEFT JOIN `physionet-data.mimiciv_derived.bg` bg
     ON ie.subject_id = bg.subject_id
     AND bg.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND bg.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)

--- a/mimic-iv/concepts/firstday/first_day_bg_art.sql
+++ b/mimic-iv/concepts/firstday/first_day_bg_art.sql
@@ -23,8 +23,8 @@ select
     , MIN(glucose) AS glucose_min, MAX(glucose) AS glucose_max
     , MIN(potassium) AS potassium_min, MAX(potassium) AS potassium_max
     , MIN(sodium) AS sodium_min, MAX(sodium) AS sodium_max
-FROM `physionet-data.mimic_icu.icustays` ie
-LEFT JOIN `physionet-data.mimic_derived.bg` bg
+FROM `physionet-data.mimiciv_icu.icustays` ie
+LEFT JOIN `physionet-data.mimiciv_derived.bg` bg
     ON ie.subject_id = bg.subject_id
     AND bg.specimen = 'ART.'
     AND bg.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)

--- a/mimic-iv/concepts/firstday/first_day_gcs.sql
+++ b/mimic-iv/concepts/firstday/first_day_gcs.sql
@@ -21,7 +21,7 @@ WITH gcs_final AS
             PARTITION BY gcs.stay_id
             ORDER BY gcs.GCS
         ) as gcs_seq
-    FROM `physionet-data.mimic_derived.gcs` gcs
+    FROM `physionet-data.mimiciv_derived.gcs` gcs
 )
 SELECT
     ie.subject_id
@@ -33,7 +33,7 @@ SELECT
     , gcs_verbal
     , gcs_eyes
     , gcs_unable
-FROM `physionet-data.mimic_icu.icustays` ie
+FROM `physionet-data.mimiciv_icu.icustays` ie
 LEFT JOIN gcs_final gs
     ON ie.stay_id = gs.stay_id
     AND gs.gcs_seq = 1

--- a/mimic-iv/concepts/firstday/first_day_height.sql
+++ b/mimic-iv/concepts/firstday/first_day_height.sql
@@ -9,8 +9,8 @@ WITH ce AS
     SELECT
       c.stay_id
       , AVG(valuenum) as Height_chart
-    FROM `physionet-data.mimic_icu.chartevents` c
-    INNER JOIN `physionet-data.mimic_icu.icustays` ie ON
+    FROM `physionet-data.mimiciv_icu.chartevents` c
+    INNER JOIN `physionet-data.mimiciv_icu.icustays` ie ON
         c.stay_id = ie.stay_id
         AND c.charttime BETWEEN DATETIME_SUB(ie.intime, INTERVAL '1' DAY) AND DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
     WHERE c.valuenum IS NOT NULL
@@ -22,8 +22,8 @@ SELECT
     ie.subject_id
     , ie.stay_id
     , ROUND(AVG(height), 2) AS height
-FROM `physionet-data.mimic_icu.icustays` ie
-LEFT JOIN `physionet-data.mimic_derived.height` ht
+FROM `physionet-data.mimiciv_icu.icustays` ie
+LEFT JOIN `physionet-data.mimiciv_derived.height` ht
     ON ie.stay_id = ht.stay_id
     AND ht.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND ht.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)

--- a/mimic-iv/concepts/firstday/first_day_lab.sql
+++ b/mimic-iv/concepts/firstday/first_day_lab.sql
@@ -10,8 +10,8 @@ WITH cbc AS
     , MAX(platelet) as platelets_max
     , MIN(wbc) as wbc_min
     , MAX(wbc) as wbc_max
-    FROM `physionet-data.mimic_icu.icustays` ie
-    LEFT JOIN `physionet-data.mimic_derived.complete_blood_count` le
+    FROM `physionet-data.mimiciv_icu.icustays` ie
+    LEFT JOIN `physionet-data.mimiciv_derived.complete_blood_count` le
         ON le.subject_id = ie.subject_id
         AND le.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
         AND le.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -33,8 +33,8 @@ WITH cbc AS
     , MIN(glucose) AS glucose_min, MAX(glucose) AS glucose_max
     , MIN(sodium) AS sodium_min, MAX(sodium) AS sodium_max
     , MIN(potassium) AS potassium_min, MAX(potassium) AS potassium_max
-    FROM `physionet-data.mimic_icu.icustays` ie
-    LEFT JOIN `physionet-data.mimic_derived.chemistry` le
+    FROM `physionet-data.mimiciv_icu.icustays` ie
+    LEFT JOIN `physionet-data.mimiciv_derived.chemistry` le
         ON le.subject_id = ie.subject_id
         AND le.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
         AND le.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -54,8 +54,8 @@ WITH cbc AS
     , MIN(immature_granulocytes) AS imm_granulocytes_min, MAX(immature_granulocytes) AS imm_granulocytes_max
     , MIN(metamyelocytes) AS metas_min, MAX(metamyelocytes) AS metas_max
     , MIN(nrbc) AS nrbc_min, MAX(nrbc) AS nrbc_max
-    FROM `physionet-data.mimic_icu.icustays` ie
-    LEFT JOIN `physionet-data.mimic_derived.blood_differential` le
+    FROM `physionet-data.mimiciv_icu.icustays` ie
+    LEFT JOIN `physionet-data.mimiciv_derived.blood_differential` le
         ON le.subject_id = ie.subject_id
         AND le.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
         AND le.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -71,8 +71,8 @@ WITH cbc AS
     , MIN(inr) AS inr_min, MAX(inr) AS inr_max
     , MIN(pt) AS pt_min, MAX(pt) AS pt_max
     , MIN(ptt) AS ptt_min, MAX(ptt) AS ptt_max
-    FROM `physionet-data.mimic_icu.icustays` ie
-    LEFT JOIN `physionet-data.mimic_derived.coagulation` le
+    FROM `physionet-data.mimiciv_icu.icustays` ie
+    LEFT JOIN `physionet-data.mimiciv_derived.coagulation` le
         ON le.subject_id = ie.subject_id
         AND le.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
         AND le.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -94,8 +94,8 @@ WITH cbc AS
     , MIN(ck_mb) AS ck_mb_min, MAX(ck_mb) AS ck_mb_max
     , MIN(ggt) AS ggt_min, MAX(ggt) AS ggt_max
     , MIN(ld_ldh) AS ld_ldh_min, MAX(ld_ldh) AS ld_ldh_max
-    FROM `physionet-data.mimic_icu.icustays` ie
-    LEFT JOIN `physionet-data.mimic_derived.enzyme` le
+    FROM `physionet-data.mimiciv_icu.icustays` ie
+    LEFT JOIN `physionet-data.mimiciv_derived.enzyme` le
         ON le.subject_id = ie.subject_id
         AND le.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
         AND le.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -152,7 +152,7 @@ ie.subject_id
 , ck_mb_min, ck_mb_max
 , ggt_min, ggt_max
 , ld_ldh_min, ld_ldh_max
-FROM `physionet-data.mimic_icu.icustays` ie
+FROM `physionet-data.mimiciv_icu.icustays` ie
 LEFT JOIN cbc
     ON ie.stay_id = cbc.stay_id
 LEFT JOIN chem

--- a/mimic-iv/concepts/firstday/first_day_rrt.sql
+++ b/mimic-iv/concepts/firstday/first_day_rrt.sql
@@ -6,8 +6,8 @@ select
     , MAX(dialysis_present) AS dialysis_present
     , MAX(dialysis_active) AS dialysis_active
     , STRING_AGG(DISTINCT dialysis_type, ', ') AS dialysis_type
-FROM `physionet-data.mimic_icu.icustays` ie
-LEFT JOIN `physionet-data.mimic_derived.rrt` rrt
+FROM `physionet-data.mimiciv_icu.icustays` ie
+LEFT JOIN `physionet-data.mimiciv_derived.rrt` rrt
 	ON ie.stay_id = rrt.stay_id
 	AND rrt.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
 	AND rrt.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)

--- a/mimic-iv/concepts/firstday/first_day_sofa.sql
+++ b/mimic-iv/concepts/firstday/first_day_sofa.sql
@@ -29,29 +29,29 @@
 with vaso_stg as
 (
   select ie.stay_id, 'norepinephrine' AS treatment, vaso_rate as rate
-  FROM `physionet-data.mimic_icu.icustays` ie
-  INNER JOIN `physionet-data.mimic_derived.norepinephrine` mv
+  FROM `physionet-data.mimiciv_icu.icustays` ie
+  INNER JOIN `physionet-data.mimiciv_derived.norepinephrine` mv
     ON ie.stay_id = mv.stay_id
     AND mv.starttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND mv.starttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
   UNION ALL
   select ie.stay_id, 'epinephrine' AS treatment, vaso_rate as rate
-  FROM `physionet-data.mimic_icu.icustays` ie
-  INNER JOIN `physionet-data.mimic_derived.epinephrine` mv
+  FROM `physionet-data.mimiciv_icu.icustays` ie
+  INNER JOIN `physionet-data.mimiciv_derived.epinephrine` mv
     ON ie.stay_id = mv.stay_id
     AND mv.starttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND mv.starttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
   UNION ALL
   select ie.stay_id, 'dobutamine' AS treatment, vaso_rate as rate
-  FROM `physionet-data.mimic_icu.icustays` ie
-  INNER JOIN `physionet-data.mimic_derived.dobutamine` mv
+  FROM `physionet-data.mimiciv_icu.icustays` ie
+  INNER JOIN `physionet-data.mimiciv_derived.dobutamine` mv
     ON ie.stay_id = mv.stay_id
     AND mv.starttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND mv.starttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
   UNION ALL
   select ie.stay_id, 'dopamine' AS treatment, vaso_rate as rate
-  FROM `physionet-data.mimic_icu.icustays` ie
-  INNER JOIN `physionet-data.mimic_derived.dopamine` mv
+  FROM `physionet-data.mimiciv_icu.icustays` ie
+  INNER JOIN `physionet-data.mimiciv_derived.dopamine` mv
     ON ie.stay_id = mv.stay_id
     AND mv.starttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND mv.starttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -64,7 +64,7 @@ with vaso_stg as
     , max(CASE WHEN treatment = 'epinephrine' THEN rate ELSE NULL END) as rate_epinephrine
     , max(CASE WHEN treatment = 'dopamine' THEN rate ELSE NULL END) as rate_dopamine
     , max(CASE WHEN treatment = 'dobutamine' THEN rate ELSE NULL END) as rate_dobutamine
-  from `physionet-data.mimic_icu.icustays` ie
+  from `physionet-data.mimiciv_icu.icustays` ie
   LEFT JOIN vaso_stg v
       ON ie.stay_id = v.stay_id
   GROUP BY ie.stay_id
@@ -75,12 +75,12 @@ with vaso_stg as
   select ie.stay_id, bg.charttime
   , bg.pao2fio2ratio
   , case when vd.stay_id is not null then 1 else 0 end as IsVent
-  from `physionet-data.mimic_icu.icustays` ie
-  LEFT JOIN `physionet-data.mimic_derived.bg` bg
+  from `physionet-data.mimiciv_icu.icustays` ie
+  LEFT JOIN `physionet-data.mimiciv_derived.bg` bg
       ON ie.subject_id = bg.subject_id
       AND bg.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
       AND bg.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
-  LEFT JOIN `physionet-data.mimic_derived.ventilation` vd
+  LEFT JOIN `physionet-data.mimiciv_derived.ventilation` vd
     ON ie.stay_id = vd.stay_id
     AND bg.charttime >= vd.starttime
     AND bg.charttime <= vd.endtime
@@ -117,18 +117,18 @@ select ie.stay_id
   , uo.UrineOutput
 
   , gcs.gcs_min
-from `physionet-data.mimic_icu.icustays` ie
+from `physionet-data.mimiciv_icu.icustays` ie
 left join vaso_mv mv
   on ie.stay_id = mv.stay_id
 left join pafi2 pf
  on ie.stay_id = pf.stay_id
-left join `physionet-data.mimic_derived.first_day_vitalsign` v
+left join `physionet-data.mimiciv_derived.first_day_vitalsign` v
   on ie.stay_id = v.stay_id
-left join `physionet-data.mimic_derived.first_day_lab` l
+left join `physionet-data.mimiciv_derived.first_day_lab` l
   on ie.stay_id = l.stay_id
-left join `physionet-data.mimic_derived.first_day_urine_output` uo
+left join `physionet-data.mimiciv_derived.first_day_urine_output` uo
   on ie.stay_id = uo.stay_id
-left join `physionet-data.mimic_derived.first_day_gcs` gcs
+left join `physionet-data.mimiciv_derived.first_day_gcs` gcs
   on ie.stay_id = gcs.stay_id
 )
 , scorecalc as
@@ -217,7 +217,7 @@ select ie.subject_id, ie.hadm_id, ie.stay_id
 , cardiovascular
 , cns
 , renal
-from `physionet-data.mimic_icu.icustays` ie
+from `physionet-data.mimiciv_icu.icustays` ie
 left join scorecalc s
   on ie.stay_id = s.stay_id
 ;

--- a/mimic-iv/concepts/firstday/first_day_urine_output.sql
+++ b/mimic-iv/concepts/firstday/first_day_urine_output.sql
@@ -4,9 +4,9 @@ SELECT
   ie.subject_id
   , ie.stay_id
   , SUM(urineoutput) AS urineoutput
-FROM `physionet-data.mimic_icu.icustays` ie
+FROM `physionet-data.mimiciv_icu.icustays` ie
 -- Join to the outputevents table to get urine output
-LEFT JOIN `physionet-data.mimic_derived.urine_output` uo
+LEFT JOIN `physionet-data.mimiciv_derived.urine_output` uo
     ON ie.stay_id = uo.stay_id
     -- ensure the data occurs during the first day
     AND uo.charttime >= ie.intime

--- a/mimic-iv/concepts/firstday/first_day_vitalsign.sql
+++ b/mimic-iv/concepts/firstday/first_day_vitalsign.sql
@@ -27,8 +27,8 @@ ie.subject_id
 , MIN(glucose) AS glucose_min
 , MAX(glucose) AS glucose_max
 , AVG(glucose) AS glucose_mean
-FROM `physionet-data.mimic_icu.icustays` ie
-LEFT JOIN `physionet-data.mimic_derived.vitalsign` ce
+FROM `physionet-data.mimiciv_icu.icustays` ie
+LEFT JOIN `physionet-data.mimiciv_derived.vitalsign` ce
     ON ie.stay_id = ce.stay_id
     AND ce.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND ce.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)

--- a/mimic-iv/concepts/firstday/first_day_weight.sql
+++ b/mimic-iv/concepts/firstday/first_day_weight.sql
@@ -9,9 +9,9 @@ SELECT
   , AVG(ce.weight) AS weight
   , MIN(ce.weight) AS weight_min
   , MAX(ce.weight) AS weight_max
-FROM `physionet-data.mimic_icu.icustays` ie
+FROM `physionet-data.mimiciv_icu.icustays` ie
   -- admission weight
-LEFT JOIN `physionet-data.mimic_derived.weight_durations` ce
+LEFT JOIN `physionet-data.mimiciv_derived.weight_durations` ce
     ON ie.stay_id = ce.stay_id
     -- we filter to weights documented during or before the 1st day
     AND ce.starttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)

--- a/mimic-iv/concepts/make_concepts.sh
+++ b/mimic-iv/concepts/make_concepts.sh
@@ -4,7 +4,7 @@ export TARGET_DATASET=mimic_derived
 
 # specify bigquery query command options
 # note: max_rows=1 *displays* only one row, but all rows are inserted into the destination table
-BQ_OPTIONS='--quiet --headless --max_rows=1 --use_legacy_sql=False --replace'
+BQ_OPTIONS='--quiet --headless --max_rows=0 --use_legacy_sql=False --replace'
 
 # generate tables in subfolders
 # order is important for a few tables here:

--- a/mimic-iv/concepts/make_concepts.sh
+++ b/mimic-iv/concepts/make_concepts.sh
@@ -35,7 +35,7 @@ do
 
             # not skipping - so generate the table on bigquery
             echo "Generating ${TARGET_DATASET}.${tbl}"
-            bq query "${BQ_OPTIONS}" --destination_table=${TARGET_DATASET}.${tbl} < ${d}/${fn}
+            bq query ${BQ_OPTIONS} --destination_table=${TARGET_DATASET}.${tbl} < ${d}/${fn}
         fi
     done
 done
@@ -47,5 +47,5 @@ do
   table=`echo $table_path | rev | cut -d/ -f1 | rev`
 
   echo "Generating ${TARGET_DATASET}.${table}"
-  bq query "${BQ_OPTIONS}" --destination_table=${TARGET_DATASET}.${table} < ${table_path}.sql
+  bq query ${BQ_OPTIONS} --destination_table=${TARGET_DATASET}.${table} < ${table_path}.sql
 done

--- a/mimic-iv/concepts/make_concepts.sh
+++ b/mimic-iv/concepts/make_concepts.sh
@@ -1,17 +1,25 @@
 #!/bin/bash
 # This script generates the concepts in the BigQuery table mimic_derived.
-export TARGET_DATASET=mimic_derived
+export TARGET_DATASET=mimiciv_derived
 
 # specify bigquery query command options
 # note: max_rows=1 *displays* only one row, but all rows are inserted into the destination table
 BQ_OPTIONS='--quiet --headless --max_rows=0 --use_legacy_sql=False --replace'
+
+# generate a few tables first as the desired order isn't alphabetical
+for table_path in demographics/icustay_times;
+do
+  table=`echo $table_path | rev | cut -d/ -f1 | rev`
+  echo "Generating ${TARGET_DATASET}.${table}"
+  bq query ${BQ_OPTIONS} --destination_table=${TARGET_DATASET}.${table} < ${table_path}.sql
+done
 
 # generate tables in subfolders
 # order is important for a few tables here:
 # * firstday should go last
 # * sepsis depends on score (sofa.sql in particular)
 # * organfailure depends on measurement
-for d in comorbidity demographics measurement medication organfailure treatment score sepsis firstday;
+for d in demographics comorbidity measurement medication organfailure treatment firstday score sepsis;
 do
     for fn in `ls $d`;
     do
@@ -20,9 +28,9 @@ do
             # table name is file name minus extension
             tbl=`echo $fn | rev | cut -d. -f2- | rev`
 
-            # skip certain tables where order matters - generated at the end of the script
+            # skip certain tables where order matters
             skip=0
-            for skip_table in first_day_sofa kdigo_stages vasoactive_agent norepinephrine_eqivalent_dose
+            for skip_table in meld icustay_times first_day_sofa kdigo_stages vasoactive_agent norepinephrine_eqivalent_dose
             do
               if [[ "${tbl}" == "${skip_table}" ]]; then
                 skip=1
@@ -42,7 +50,7 @@ done
 
 echo "Now generating tables which were skipped due to depending on other tables."
 # generate tables after the above, and in a specific order to ensure dependencies are met
-for table_path in firstday/first_day_sofa organfailure/kdigo_stages medication/vasoactive_agent medication/norepinephrine_equivalent_dose;
+for table_path in firstday/first_day_sofa organfailure/kdigo_stages organfailure/meld medication/vasoactive_agent medication/norepinephrine_equivalent_dose;
 do
   table=`echo $table_path | rev | cut -d/ -f1 | rev`
 

--- a/mimic-iv/concepts/measurement/bg.sql
+++ b/mimic-iv/concepts/measurement/bg.sql
@@ -44,7 +44,7 @@ select
   , MAX(CASE WHEN itemid = 50824 THEN valuenum ELSE NULL END) AS sodium
   , MAX(CASE WHEN itemid = 50825 THEN valuenum ELSE NULL END) AS temperature
   , MAX(CASE WHEN itemid = 50807 THEN value ELSE NULL END) AS comments
-FROM `physionet-data.mimic_hosp.labevents` le
+FROM `physionet-data.mimiciv_hosp.labevents` le
 where le.ITEMID in
 -- blood gases
 (
@@ -84,7 +84,7 @@ GROUP BY le.specimen_id
   select subject_id, charttime
     -- avg here is just used to group SpO2 by charttime
     , AVG(valuenum) as SpO2
-  FROM `physionet-data.mimic_icu.chartevents`
+  FROM `physionet-data.mimiciv_icu.chartevents`
   where ITEMID = 220277 -- O2 saturation pulseoxymetry
   and valuenum > 0 and valuenum <= 100
   group by subject_id, charttime
@@ -104,7 +104,7 @@ GROUP BY le.specimen_id
             then valuenum
       else null end
     ) as fio2_chartevents
-  FROM `physionet-data.mimic_icu.chartevents`
+  FROM `physionet-data.mimiciv_icu.chartevents`
   where ITEMID = 223835 -- Inspired O2 Fraction (FiO2)
   and valuenum > 0 and valuenum <= 100
   group by subject_id, charttime

--- a/mimic-iv/concepts/measurement/bg.sql
+++ b/mimic-iv/concepts/measurement/bg.sql
@@ -44,7 +44,7 @@ select
   , MAX(CASE WHEN itemid = 50824 THEN valuenum ELSE NULL END) AS sodium
   , MAX(CASE WHEN itemid = 50825 THEN valuenum ELSE NULL END) AS temperature
   , MAX(CASE WHEN itemid = 50807 THEN value ELSE NULL END) AS comments
-FROM mimic_hosp.labevents le
+FROM `physionet-data.mimic_hosp.labevents` le
 where le.ITEMID in
 -- blood gases
 (
@@ -84,7 +84,7 @@ GROUP BY le.specimen_id
   select subject_id, charttime
     -- avg here is just used to group SpO2 by charttime
     , AVG(valuenum) as SpO2
-  FROM mimic_icu.chartevents
+  FROM `physionet-data.mimic_icu.chartevents`
   where ITEMID = 220277 -- O2 saturation pulseoxymetry
   and valuenum > 0 and valuenum <= 100
   group by subject_id, charttime
@@ -104,7 +104,7 @@ GROUP BY le.specimen_id
             then valuenum
       else null end
     ) as fio2_chartevents
-  FROM mimic_icu.chartevents
+  FROM `physionet-data.mimic_icu.chartevents`
   where ITEMID = 223835 -- Inspired O2 Fraction (FiO2)
   and valuenum > 0 and valuenum <= 100
   group by subject_id, charttime

--- a/mimic-iv/concepts/measurement/blood_differential.sql
+++ b/mimic-iv/concepts/measurement/blood_differential.sql
@@ -47,7 +47,7 @@ SELECT
     AND SUM(CASE WHEN itemid IN (51146, 51200, 51244, 51245, 51254, 51256) THEN valuenum ELSE NULL END) > 0
     THEN 1 ELSE 0 END AS impute_abs
 
-FROM mimic_hosp.labevents le
+FROM `physionet-data.mimic_hosp.labevents` le
 WHERE le.itemid IN
 (
     51146, -- basophils

--- a/mimic-iv/concepts/measurement/blood_differential.sql
+++ b/mimic-iv/concepts/measurement/blood_differential.sql
@@ -47,7 +47,7 @@ SELECT
     AND SUM(CASE WHEN itemid IN (51146, 51200, 51244, 51245, 51254, 51256) THEN valuenum ELSE NULL END) > 0
     THEN 1 ELSE 0 END AS impute_abs
 
-FROM `physionet-data.mimic_hosp.labevents` le
+FROM `physionet-data.mimiciv_hosp.labevents` le
 WHERE le.itemid IN
 (
     51146, -- basophils

--- a/mimic-iv/concepts/measurement/cardiac_marker.sql
+++ b/mimic-iv/concepts/measurement/cardiac_marker.sql
@@ -8,7 +8,7 @@ SELECT
   , MAX(CASE WHEN itemid = 51003 THEN value ELSE NULL END) AS troponin_t
   , MAX(CASE WHEN itemid = 50911 THEN valuenum ELSE NULL END) AS ck_mb
   , MAX(CASE WHEN itemid = 50963 THEN valuenum ELSE NULL END) AS ntprobnp
-FROM `physionet-data.mimic_hosp.labevents` le
+FROM `physionet-data.mimiciv_hosp.labevents` le
 WHERE le.itemid IN
 (
     -- 51002, -- Troponin I (troponin-I is not measured in MIMIC-IV)

--- a/mimic-iv/concepts/measurement/cardiac_marker.sql
+++ b/mimic-iv/concepts/measurement/cardiac_marker.sql
@@ -8,7 +8,7 @@ SELECT
   , MAX(CASE WHEN itemid = 51003 THEN value ELSE NULL END) AS troponin_t
   , MAX(CASE WHEN itemid = 50911 THEN valuenum ELSE NULL END) AS ck_mb
   , MAX(CASE WHEN itemid = 50963 THEN valuenum ELSE NULL END) AS ntprobnp
-FROM mimic_hosp.labevents le
+FROM `physionet-data.mimic_hosp.labevents` le
 WHERE le.itemid IN
 (
     -- 51002, -- Troponin I (troponin-I is not measured in MIMIC-IV)

--- a/mimic-iv/concepts/measurement/chemistry.sql
+++ b/mimic-iv/concepts/measurement/chemistry.sql
@@ -20,7 +20,7 @@ SELECT
   , MAX(CASE WHEN itemid = 50931 AND valuenum <= 10000 THEN valuenum ELSE NULL END) AS glucose
   , MAX(CASE WHEN itemid = 50983 AND valuenum <=   200 THEN valuenum ELSE NULL END) AS sodium
   , MAX(CASE WHEN itemid = 50971 AND valuenum <=    30 THEN valuenum ELSE NULL END) AS potassium
-FROM `physionet-data.mimic_hosp.labevents` le
+FROM `physionet-data.mimiciv_hosp.labevents` le
 WHERE le.itemid IN
 (
   -- comment is: LABEL | CATEGORY | FLUID | NUMBER OF ROWS IN LABEVENTS

--- a/mimic-iv/concepts/measurement/chemistry.sql
+++ b/mimic-iv/concepts/measurement/chemistry.sql
@@ -20,7 +20,7 @@ SELECT
   , MAX(CASE WHEN itemid = 50931 AND valuenum <= 10000 THEN valuenum ELSE NULL END) AS glucose
   , MAX(CASE WHEN itemid = 50983 AND valuenum <=   200 THEN valuenum ELSE NULL END) AS sodium
   , MAX(CASE WHEN itemid = 50971 AND valuenum <=    30 THEN valuenum ELSE NULL END) AS potassium
-FROM mimic_hosp.labevents le
+FROM `physionet-data.mimic_hosp.labevents` le
 WHERE le.itemid IN
 (
   -- comment is: LABEL | CATEGORY | FLUID | NUMBER OF ROWS IN LABEVENTS

--- a/mimic-iv/concepts/measurement/coagulation.sql
+++ b/mimic-iv/concepts/measurement/coagulation.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(CASE WHEN itemid = 51237 THEN valuenum ELSE NULL END) AS inr
   , MAX(CASE WHEN itemid = 51274 THEN valuenum ELSE NULL END) AS pt
   , MAX(CASE WHEN itemid = 51275 THEN valuenum ELSE NULL END) AS ptt
-FROM mimic_hosp.labevents le
+FROM `physionet-data.mimic_hosp.labevents` le
 WHERE le.itemid IN
 (
     -- 51149, 52750, 52072, 52073 -- Bleeding Time, no data as of MIMIC-IV v0.4

--- a/mimic-iv/concepts/measurement/coagulation.sql
+++ b/mimic-iv/concepts/measurement/coagulation.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(CASE WHEN itemid = 51237 THEN valuenum ELSE NULL END) AS inr
   , MAX(CASE WHEN itemid = 51274 THEN valuenum ELSE NULL END) AS pt
   , MAX(CASE WHEN itemid = 51275 THEN valuenum ELSE NULL END) AS ptt
-FROM `physionet-data.mimic_hosp.labevents` le
+FROM `physionet-data.mimiciv_hosp.labevents` le
 WHERE le.itemid IN
 (
     -- 51149, 52750, 52072, 52073 -- Bleeding Time, no data as of MIMIC-IV v0.4

--- a/mimic-iv/concepts/measurement/complete_blood_count.sql
+++ b/mimic-iv/concepts/measurement/complete_blood_count.sql
@@ -15,7 +15,7 @@ SELECT
   , MAX(CASE WHEN itemid = 51277 THEN valuenum ELSE NULL END) AS rdw
   , MAX(CASE WHEN itemid = 52159 THEN valuenum ELSE NULL END) AS rdwsd
   , MAX(CASE WHEN itemid = 51301 THEN valuenum ELSE NULL END) AS wbc
-FROM `physionet-data.mimic_hosp.labevents` le
+FROM `physionet-data.mimiciv_hosp.labevents` le
 WHERE le.itemid IN
 (
     51221, -- hematocrit

--- a/mimic-iv/concepts/measurement/complete_blood_count.sql
+++ b/mimic-iv/concepts/measurement/complete_blood_count.sql
@@ -15,7 +15,7 @@ SELECT
   , MAX(CASE WHEN itemid = 51277 THEN valuenum ELSE NULL END) AS rdw
   , MAX(CASE WHEN itemid = 52159 THEN valuenum ELSE NULL END) AS rdwsd
   , MAX(CASE WHEN itemid = 51301 THEN valuenum ELSE NULL END) AS wbc
-FROM mimic_hosp.labevents le
+FROM `physionet-data.mimic_hosp.labevents` le
 WHERE le.itemid IN
 (
     51221, -- hematocrit

--- a/mimic-iv/concepts/measurement/creatinine_baseline.sql
+++ b/mimic-iv/concepts/measurement/creatinine_baseline.sql
@@ -34,7 +34,7 @@ WITH p as
 , ckd as 
 (
     SELECT hadm_id, MAX(1) AS CKD_flag
-    FROM mimic_hosp.diagnoses_icd
+    FROM `physionet-data.mimic_hosp.diagnoses_icd`
     WHERE 
         (
             SUBSTR(icd_code, 1, 3) = '585'

--- a/mimic-iv/concepts/measurement/creatinine_baseline.sql
+++ b/mimic-iv/concepts/measurement/creatinine_baseline.sql
@@ -19,7 +19,7 @@ WITH p as
             END 
             AS MDRD_est
     FROM `physionet-data.mimic_derived.age` ag
-    LEFT JOIN `physionet-data.mimic_core.patients` p
+    LEFT JOIN `physionet-data.mimic_hosp.patients` p
     ON ag.subject_id = p.subject_id
     WHERE ag.age >= 18
 )

--- a/mimic-iv/concepts/measurement/creatinine_baseline.sql
+++ b/mimic-iv/concepts/measurement/creatinine_baseline.sql
@@ -18,8 +18,8 @@ WITH p as
             POWER(75.0 / 186.0 / POWER(ag.age, -0.203), -1/1.154)
             END 
             AS MDRD_est
-    FROM `physionet-data.mimic_derived.age` ag
-    LEFT JOIN `physionet-data.mimic_hosp.patients` p
+    FROM `physionet-data.mimiciv_derived.age` ag
+    LEFT JOIN `physionet-data.mimiciv_hosp.patients` p
     ON ag.subject_id = p.subject_id
     WHERE ag.age >= 18
 )
@@ -28,13 +28,13 @@ WITH p as
     SELECT 
         hadm_id
         , MIN(creatinine) AS scr_min
-    FROM `physionet-data.mimic_derived.chemistry`
+    FROM `physionet-data.mimiciv_derived.chemistry`
     GROUP BY hadm_id
 )
 , ckd as 
 (
     SELECT hadm_id, MAX(1) AS CKD_flag
-    FROM `physionet-data.mimic_hosp.diagnoses_icd`
+    FROM `physionet-data.mimiciv_hosp.diagnoses_icd`
     WHERE 
         (
             SUBSTR(icd_code, 1, 3) = '585'

--- a/mimic-iv/concepts/measurement/enzyme.sql
+++ b/mimic-iv/concepts/measurement/enzyme.sql
@@ -16,7 +16,7 @@ SELECT
   , MAX(CASE WHEN itemid = 50911 THEN valuenum ELSE NULL END) AS ck_mb
   , MAX(CASE WHEN itemid = 50927 THEN valuenum ELSE NULL END) AS ggt
   , MAX(CASE WHEN itemid = 50954 THEN valuenum ELSE NULL END) AS ld_ldh
-FROM mimic_hosp.labevents le
+FROM `physionet-data.mimic_hosp.labevents` le
 WHERE le.itemid IN
 (
     50861, -- Alanine transaminase (ALT)

--- a/mimic-iv/concepts/measurement/enzyme.sql
+++ b/mimic-iv/concepts/measurement/enzyme.sql
@@ -16,7 +16,7 @@ SELECT
   , MAX(CASE WHEN itemid = 50911 THEN valuenum ELSE NULL END) AS ck_mb
   , MAX(CASE WHEN itemid = 50927 THEN valuenum ELSE NULL END) AS ggt
   , MAX(CASE WHEN itemid = 50954 THEN valuenum ELSE NULL END) AS ld_ldh
-FROM `physionet-data.mimic_hosp.labevents` le
+FROM `physionet-data.mimiciv_hosp.labevents` le
 WHERE le.itemid IN
 (
     50861, -- Alanine transaminase (ALT)

--- a/mimic-iv/concepts/measurement/gcs.sql
+++ b/mimic-iv/concepts/measurement/gcs.sql
@@ -41,7 +41,7 @@ with base as
     as endotrachflag
   , ROW_NUMBER ()
           OVER (PARTITION BY ce.stay_id ORDER BY ce.charttime ASC) as rn
-  from `physionet-data.mimic_icu.chartevents` ce
+  from `physionet-data.mimiciv_icu.chartevents` ce
   -- Isolate the desired GCS variables
   where ce.ITEMID in
   (

--- a/mimic-iv/concepts/measurement/gcs.sql
+++ b/mimic-iv/concepts/measurement/gcs.sql
@@ -41,7 +41,7 @@ with base as
     as endotrachflag
   , ROW_NUMBER ()
           OVER (PARTITION BY ce.stay_id ORDER BY ce.charttime ASC) as rn
-  from mimic_icu.chartevents ce
+  from `physionet-data.mimic_icu.chartevents` ce
   -- Isolate the desired GCS variables
   where ce.ITEMID in
   (

--- a/mimic-iv/concepts/measurement/height.sql
+++ b/mimic-iv/concepts/measurement/height.sql
@@ -6,7 +6,7 @@ WITH ht_in AS
     -- Ensure that all heights are in centimeters
     , ROUND(c.valuenum * 2.54, 2) AS height
     , c.valuenum as height_orig
-  FROM `physionet-data.mimic_icu.chartevents` c
+  FROM `physionet-data.mimiciv_icu.chartevents` c
   WHERE c.valuenum IS NOT NULL
   -- Height (measured in inches)
   AND c.itemid = 226707
@@ -17,7 +17,7 @@ WITH ht_in AS
     c.subject_id, c.stay_id, c.charttime
     -- Ensure that all heights are in centimeters
     , ROUND(c.valuenum, 2) AS height
-  FROM `physionet-data.mimic_icu.chartevents` c
+  FROM `physionet-data.mimiciv_icu.chartevents` c
   WHERE c.valuenum IS NOT NULL
   -- Height cm
   AND c.itemid = 226730

--- a/mimic-iv/concepts/measurement/icp.sql
+++ b/mimic-iv/concepts/measurement/icp.sql
@@ -6,7 +6,7 @@ with ce as
   , ce.charttime
   -- TODO: handle high ICPs when monitoring two ICPs
   , case when valuenum > 0 and valuenum < 100 then valuenum else null end as icp
-  FROM `physionet-data.mimic_icu.chartevents` ce
+  FROM `physionet-data.mimiciv_icu.chartevents` ce
   -- exclude rows marked as error
   where ce.itemid in
   (

--- a/mimic-iv/concepts/measurement/inflammation.sql
+++ b/mimic-iv/concepts/measurement/inflammation.sql
@@ -7,7 +7,7 @@ SELECT
   , MAX(CASE WHEN itemid = 50889 THEN valuenum ELSE NULL END) AS crp
   -- , CAST(NULL AS NUMERIC) AS il6
   -- , CAST(NULL AS NUMERIC) AS procalcitonin
-FROM mimic_hosp.labevents le
+FROM `physionet-data.mimic_hosp.labevents` le
 WHERE le.itemid IN
 (
     50889 -- crp

--- a/mimic-iv/concepts/measurement/inflammation.sql
+++ b/mimic-iv/concepts/measurement/inflammation.sql
@@ -7,7 +7,7 @@ SELECT
   , MAX(CASE WHEN itemid = 50889 THEN valuenum ELSE NULL END) AS crp
   -- , CAST(NULL AS NUMERIC) AS il6
   -- , CAST(NULL AS NUMERIC) AS procalcitonin
-FROM `physionet-data.mimic_hosp.labevents` le
+FROM `physionet-data.mimiciv_hosp.labevents` le
 WHERE le.itemid IN
 (
     50889 -- crp

--- a/mimic-iv/concepts/measurement/oxygen_delivery.sql
+++ b/mimic-iv/concepts/measurement/oxygen_delivery.sql
@@ -12,7 +12,7 @@ with ce_stg1 as
     , valuenum
     , valueuom
     , storetime
-  FROM `physionet-data.mimic_icu.chartevents` ce
+  FROM `physionet-data.mimiciv_icu.chartevents` ce
   WHERE ce.value IS NOT NULL
   AND ce.itemid IN
   (

--- a/mimic-iv/concepts/measurement/oxygen_delivery.sql
+++ b/mimic-iv/concepts/measurement/oxygen_delivery.sql
@@ -12,7 +12,7 @@ with ce_stg1 as
     , valuenum
     , valueuom
     , storetime
-  FROM mimic_icu.chartevents ce
+  FROM `physionet-data.mimic_icu.chartevents` ce
   WHERE ce.value IS NOT NULL
   AND ce.itemid IN
   (

--- a/mimic-iv/concepts/measurement/rhythm.sql
+++ b/mimic-iv/concepts/measurement/rhythm.sql
@@ -7,7 +7,7 @@ select
   , MAX(case when itemid = 224651 THEN value ELSE NULL END) AS ectopy_frequency
   , MAX(case when itemid = 226479 THEN value ELSE NULL END) AS ectopy_type_secondary
   , MAX(case when itemid = 226480 THEN value ELSE NULL END) AS ectopy_frequency_secondary
-FROM mimic_icu.chartevents ce
+FROM `physionet-data.mimic_icu.chartevents` ce
 where ce.stay_id IS NOT NULL
 and ce.itemid in
 (

--- a/mimic-iv/concepts/measurement/rhythm.sql
+++ b/mimic-iv/concepts/measurement/rhythm.sql
@@ -7,7 +7,7 @@ select
   , MAX(case when itemid = 224651 THEN value ELSE NULL END) AS ectopy_frequency
   , MAX(case when itemid = 226479 THEN value ELSE NULL END) AS ectopy_type_secondary
   , MAX(case when itemid = 226480 THEN value ELSE NULL END) AS ectopy_frequency_secondary
-FROM `physionet-data.mimic_icu.chartevents` ce
+FROM `physionet-data.mimiciv_icu.chartevents` ce
 where ce.stay_id IS NOT NULL
 and ce.itemid in
 (

--- a/mimic-iv/concepts/measurement/urine_output.sql
+++ b/mimic-iv/concepts/measurement/urine_output.sql
@@ -16,7 +16,7 @@ from
         when oe.itemid = 227488 and oe.value > 0 then -1*oe.value
         else oe.value
     end as urineoutput
-    from `physionet-data.mimic_icu.outputevents` oe
+    from `physionet-data.mimiciv_icu.outputevents` oe
     where itemid in
     (
     226559, -- Foley

--- a/mimic-iv/concepts/measurement/urine_output_rate.sql
+++ b/mimic-iv/concepts/measurement/urine_output_rate.sql
@@ -7,8 +7,8 @@ WITH tm AS
     SELECT ie.stay_id
       , min(charttime) AS intime_hr
       , max(charttime) AS outtime_hr
-    FROM `physionet-data.mimic_icu.icustays` ie
-    INNER JOIN `physionet-data.mimic_icu.chartevents` ce
+    FROM `physionet-data.mimiciv_icu.icustays` ie
+    INNER JOIN `physionet-data.mimiciv_icu.chartevents` ce
       ON ie.stay_id = ce.stay_id
       AND ce.itemid = 220045
       AND ce.charttime > DATETIME_SUB(ie.intime, interval '1' MONTH)
@@ -27,7 +27,7 @@ WITH tm AS
     , uo.charttime
     , uo.urineoutput
     FROM tm
-    INNER JOIN `physionet-data.mimic_derived.urine_output` uo
+    INNER JOIN `physionet-data.mimiciv_derived.urine_output` uo
         ON tm.stay_id = uo.stay_id
     WINDOW W AS (PARTITION BY tm.stay_id ORDER BY charttime)
 )
@@ -85,7 +85,7 @@ select
 , ROUND(uo_tm_12hr, 2) AS uo_tm_12hr
 , ROUND(uo_tm_24hr, 2) AS uo_tm_24hr
 from ur_stg ur
-LEFT JOIN `physionet-data.mimic_derived.weight_durations` wd
+LEFT JOIN `physionet-data.mimiciv_derived.weight_durations` wd
     ON ur.stay_id = wd.stay_id
     AND ur.charttime > wd.starttime
     AND ur.charttime <= wd.endtime

--- a/mimic-iv/concepts/measurement/ventilator_setting.sql
+++ b/mimic-iv/concepts/measurement/ventilator_setting.sql
@@ -32,7 +32,7 @@ with ce as
     ELSE valuenum END AS valuenum
     , valueuom
     , storetime
-  FROM mimic_icu.chartevents ce
+  FROM `physionet-data.mimic_icu.chartevents` ce
   where ce.value IS NOT NULL
   AND ce.stay_id IS NOT NULL
   AND ce.itemid IN

--- a/mimic-iv/concepts/measurement/ventilator_setting.sql
+++ b/mimic-iv/concepts/measurement/ventilator_setting.sql
@@ -32,7 +32,7 @@ with ce as
     ELSE valuenum END AS valuenum
     , valueuom
     , storetime
-  FROM `physionet-data.mimic_icu.chartevents` ce
+  FROM `physionet-data.mimiciv_icu.chartevents` ce
   where ce.value IS NOT NULL
   AND ce.stay_id IS NOT NULL
   AND ce.itemid IN

--- a/mimic-iv/concepts/measurement/vitalsign.sql
+++ b/mimic-iv/concepts/measurement/vitalsign.sql
@@ -19,7 +19,7 @@ select
   , MAX(CASE WHEN itemid = 224642 THEN value ELSE NULL END) AS temperature_site
   , AVG(case when itemid in (220277) and valuenum > 0 and valuenum <= 100 then valuenum else null end) as spo2
   , AVG(case when itemid in (225664,220621,226537) and valuenum > 0 then valuenum else null end) as glucose
-  FROM `physionet-data.mimic_icu.chartevents` ce
+  FROM `physionet-data.mimiciv_icu.chartevents` ce
   where ce.stay_id IS NOT NULL
   and ce.itemid in
   (

--- a/mimic-iv/concepts/measurement/vitalsign.sql
+++ b/mimic-iv/concepts/measurement/vitalsign.sql
@@ -19,7 +19,7 @@ select
   , MAX(CASE WHEN itemid = 224642 THEN value ELSE NULL END) AS temperature_site
   , AVG(case when itemid in (220277) and valuenum > 0 and valuenum <= 100 then valuenum else null end) as spo2
   , AVG(case when itemid in (225664,220621,226537) and valuenum > 0 then valuenum else null end) as glucose
-  FROM mimic_icu.chartevents ce
+  FROM `physionet-data.mimic_icu.chartevents` ce
   where ce.stay_id IS NOT NULL
   and ce.itemid in
   (

--- a/mimic-iv/concepts/medication/antibiotic.sql
+++ b/mimic-iv/concepts/medication/antibiotic.sql
@@ -160,7 +160,7 @@ with abx as
       when lower(drug) like '%zyvox%' then 1
     else 0
     end as antibiotic
-  from `physionet-data.mimic_hosp.prescriptions`
+  from `physionet-data.mimiciv_hosp.prescriptions`
   -- excludes vials/syringe/normal saline, etc
   where drug_type not in ('BASE')
   -- we exclude routes via the eye, ears, or topically
@@ -186,7 +186,7 @@ pr.subject_id, pr.hadm_id
 , pr.route
 , pr.starttime
 , pr.stoptime
-from `physionet-data.mimic_hosp.prescriptions` pr
+from `physionet-data.mimiciv_hosp.prescriptions` pr
 -- inner join to subselect to only antibiotic prescriptions
 inner join abx
     on pr.drug = abx.drug
@@ -194,7 +194,7 @@ inner join abx
     -- only ~4000 null rows in prescriptions total.
     AND pr.route = abx.route
 -- add in stay_id as we use this table for sepsis-3
-LEFT JOIN `physionet-data.mimic_icu.icustays` ie
+LEFT JOIN `physionet-data.mimiciv_icu.icustays` ie
     ON pr.hadm_id = ie.hadm_id
     AND pr.starttime >= ie.intime
     AND pr.starttime < ie.outtime

--- a/mimic-iv/concepts/medication/dobutamine.sql
+++ b/mimic-iv/concepts/medication/dobutamine.sql
@@ -6,5 +6,5 @@ stay_id, linkorderid
 , amount as vaso_amount
 , starttime
 , endtime
-from `physionet-data.mimic_icu.inputevents`
+from `physionet-data.mimiciv_icu.inputevents`
 where itemid = 221653 -- dobutamine

--- a/mimic-iv/concepts/medication/dopamine.sql
+++ b/mimic-iv/concepts/medication/dopamine.sql
@@ -6,5 +6,5 @@ stay_id, linkorderid
 , amount as vaso_amount
 , starttime
 , endtime
-from `physionet-data.mimic_icu.inputevents`
+from `physionet-data.mimiciv_icu.inputevents`
 where itemid = 221662 -- dopamine

--- a/mimic-iv/concepts/medication/epinephrine.sql
+++ b/mimic-iv/concepts/medication/epinephrine.sql
@@ -6,5 +6,5 @@ stay_id, linkorderid
 , amount as vaso_amount
 , starttime
 , endtime
-from `physionet-data.mimic_icu.inputevents`
+from `physionet-data.mimiciv_icu.inputevents`
 where itemid = 221289 -- epinephrine

--- a/mimic-iv/concepts/medication/milrinone.sql
+++ b/mimic-iv/concepts/medication/milrinone.sql
@@ -6,5 +6,5 @@ stay_id, linkorderid
 , amount as vaso_amount
 , starttime
 , endtime
-from `physionet-data.mimic_icu.inputevents`
+from `physionet-data.mimiciv_icu.inputevents`
 where itemid = 221986 -- milrinone

--- a/mimic-iv/concepts/medication/neuroblock.sql
+++ b/mimic-iv/concepts/medication/neuroblock.sql
@@ -5,7 +5,7 @@ select
   , amount as drug_amount
   , starttime
   , endtime
-from `physionet-data.mimic_icu.inputevents`
+from `physionet-data.mimiciv_icu.inputevents`
 where itemid in
 (
     222062 -- Vecuronium (664 rows, 154 infusion rows)

--- a/mimic-iv/concepts/medication/norepinephrine.sql
+++ b/mimic-iv/concepts/medication/norepinephrine.sql
@@ -10,5 +10,5 @@ select
   , amount as vaso_amount
   , starttime
   , endtime
-from `physionet-data.mimic_icu.inputevents`
+from `physionet-data.mimiciv_icu.inputevents`
 where itemid = 221906 -- norepinephrine

--- a/mimic-iv/concepts/medication/norepinephrine_equivalent_dose.sql
+++ b/mimic-iv/concepts/medication/norepinephrine_equivalent_dose.sql
@@ -14,7 +14,7 @@ SELECT stay_id, starttime, endtime
   , 4) AS norepinephrine_equivalent_dose
   -- angotensin_ii*10 -- angitensin ii rarely used, currently not incorporated
   -- (it could be included due to norepinephrine sparing effects)
-FROM `physionet-data.mimic_derived.vasoactive_agent`
+FROM `physionet-data.mimiciv_derived.vasoactive_agent`
 WHERE norepinephrine IS NOT NULL
 OR epinephrine IS NOT NULL
 OR phenylephrine IS NOT NULL

--- a/mimic-iv/concepts/medication/norepinephrine_equivalent_dose.sql
+++ b/mimic-iv/concepts/medication/norepinephrine_equivalent_dose.sql
@@ -14,7 +14,7 @@ SELECT stay_id, starttime, endtime
   , 4) AS norepinephrine_equivalent_dose
   -- angotensin_ii*10 -- angitensin ii rarely used, currently not incorporated
   -- (it could be included due to norepinephrine sparing effects)
-FROM mimic_derived.vasoactive_agent
+FROM `physionet-data.mimic_derived.vasoactive_agent`
 WHERE norepinephrine IS NOT NULL
 OR epinephrine IS NOT NULL
 OR phenylephrine IS NOT NULL

--- a/mimic-iv/concepts/medication/phenylephrine.sql
+++ b/mimic-iv/concepts/medication/phenylephrine.sql
@@ -7,5 +7,5 @@ select
   , amount as vaso_amount
   , starttime
   , endtime
-from `physionet-data.mimic_icu.inputevents`
+from `physionet-data.mimiciv_icu.inputevents`
 where itemid = 221749 -- phenylephrine

--- a/mimic-iv/concepts/medication/vasoactive_agent.sql
+++ b/mimic-iv/concepts/medication/vasoactive_agent.sql
@@ -6,34 +6,34 @@
 -- create a single table with these as start/stop times
 WITH tm AS
 (
-    SELECT stay_id, starttime AS vasotime FROM mimic_derived.dobutamine
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.dobutamine`
     UNION DISTINCT
-    SELECT stay_id, starttime AS vasotime FROM mimic_derived.dopamine
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.dopamine`
     UNION DISTINCT
-    SELECT stay_id, starttime AS vasotime FROM mimic_derived.epinephrine
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.epinephrine`
     UNION DISTINCT
-    SELECT stay_id, starttime AS vasotime FROM mimic_derived.norepinephrine
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.norepinephrine`
     UNION DISTINCT
-    SELECT stay_id, starttime AS vasotime FROM mimic_derived.phenylephrine
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.phenylephrine`
     UNION DISTINCT
-    SELECT stay_id, starttime AS vasotime FROM mimic_derived.vasopressin
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.vasopressin`
     UNION DISTINCT
-    SELECT stay_id, starttime AS vasotime FROM mimic_derived.milrinone
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.milrinone`
     UNION DISTINCT
     -- combine end times from the same tables
-    SELECT stay_id, endtime AS vasotime FROM mimic_derived.dobutamine
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.dobutamine`
     UNION DISTINCT
-    SELECT stay_id, endtime AS vasotime FROM mimic_derived.dopamine
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.dopamine`
     UNION DISTINCT
-    SELECT stay_id, endtime AS vasotime FROM mimic_derived.epinephrine
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.epinephrine`
     UNION DISTINCT
-    SELECT stay_id, endtime AS vasotime FROM mimic_derived.norepinephrine
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.norepinephrine`
     UNION DISTINCT
-    SELECT stay_id, endtime AS vasotime FROM mimic_derived.phenylephrine
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.phenylephrine`
     UNION DISTINCT
-    SELECT stay_id, endtime AS vasotime FROM mimic_derived.vasopressin
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.vasopressin`
     UNION DISTINCT
-    SELECT stay_id, endtime AS vasotime FROM mimic_derived.milrinone
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.milrinone`
 )
 -- create starttime/endtime from all possible times collected
 , tm_lag AS

--- a/mimic-iv/concepts/medication/vasoactive_agent.sql
+++ b/mimic-iv/concepts/medication/vasoactive_agent.sql
@@ -6,34 +6,34 @@
 -- create a single table with these as start/stop times
 WITH tm AS
 (
-    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.dobutamine`
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimiciv_derived.dobutamine`
     UNION DISTINCT
-    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.dopamine`
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimiciv_derived.dopamine`
     UNION DISTINCT
-    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.epinephrine`
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimiciv_derived.epinephrine`
     UNION DISTINCT
-    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.norepinephrine`
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimiciv_derived.norepinephrine`
     UNION DISTINCT
-    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.phenylephrine`
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimiciv_derived.phenylephrine`
     UNION DISTINCT
-    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.vasopressin`
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimiciv_derived.vasopressin`
     UNION DISTINCT
-    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimic_derived.milrinone`
+    SELECT stay_id, starttime AS vasotime FROM `physionet-data.mimiciv_derived.milrinone`
     UNION DISTINCT
     -- combine end times from the same tables
-    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.dobutamine`
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimiciv_derived.dobutamine`
     UNION DISTINCT
-    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.dopamine`
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimiciv_derived.dopamine`
     UNION DISTINCT
-    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.epinephrine`
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimiciv_derived.epinephrine`
     UNION DISTINCT
-    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.norepinephrine`
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimiciv_derived.norepinephrine`
     UNION DISTINCT
-    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.phenylephrine`
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimiciv_derived.phenylephrine`
     UNION DISTINCT
-    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.vasopressin`
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimiciv_derived.vasopressin`
     UNION DISTINCT
-    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimic_derived.milrinone`
+    SELECT stay_id, endtime AS vasotime FROM `physionet-data.mimiciv_derived.milrinone`
 )
 -- create starttime/endtime from all possible times collected
 , tm_lag AS
@@ -62,31 +62,31 @@ SELECT t.stay_id, t.starttime, t.endtime
 -- other drugs not included here but (rarely) used in the BIDMC:
 -- angiotensin II, methylene blue
 FROM tm_lag t
-LEFT JOIN `physionet-data.mimic_derived.dobutamine` dob
+LEFT JOIN `physionet-data.mimiciv_derived.dobutamine` dob
     ON t.stay_id = dob.stay_id
     AND t.starttime >= dob.starttime
     AND t.endtime <= dob.endtime
-LEFT JOIN `physionet-data.mimic_derived.dopamine` dop
+LEFT JOIN `physionet-data.mimiciv_derived.dopamine` dop
     ON t.stay_id = dop.stay_id
     AND t.starttime >= dop.starttime
     AND t.endtime <= dop.endtime
-LEFT JOIN `physionet-data.mimic_derived.epinephrine` epi
+LEFT JOIN `physionet-data.mimiciv_derived.epinephrine` epi
     ON t.stay_id = epi.stay_id
     AND t.starttime >= epi.starttime
     AND t.endtime <= epi.endtime
-LEFT JOIN `physionet-data.mimic_derived.norepinephrine` nor
+LEFT JOIN `physionet-data.mimiciv_derived.norepinephrine` nor
     ON t.stay_id = nor.stay_id
     AND t.starttime >= nor.starttime
     AND t.endtime <= nor.endtime
-LEFT JOIN `physionet-data.mimic_derived.phenylephrine` phe
+LEFT JOIN `physionet-data.mimiciv_derived.phenylephrine` phe
     ON t.stay_id = phe.stay_id
     AND t.starttime >= phe.starttime
     AND t.endtime <= phe.endtime
-LEFT JOIN `physionet-data.mimic_derived.vasopressin` vas
+LEFT JOIN `physionet-data.mimiciv_derived.vasopressin` vas
     ON t.stay_id = vas.stay_id
     AND t.starttime >= vas.starttime
     AND t.endtime <= vas.endtime
-LEFT JOIN `physionet-data.mimic_derived.milrinone` mil
+LEFT JOIN `physionet-data.mimiciv_derived.milrinone` mil
     ON t.stay_id = mil.stay_id
     AND t.starttime >= mil.starttime
     AND t.endtime <= mil.endtime

--- a/mimic-iv/concepts/medication/vasoactive_agent.sql
+++ b/mimic-iv/concepts/medication/vasoactive_agent.sql
@@ -62,31 +62,31 @@ SELECT t.stay_id, t.starttime, t.endtime
 -- other drugs not included here but (rarely) used in the BIDMC:
 -- angiotensin II, methylene blue
 FROM tm_lag t
-LEFT JOIN mimic_derived.dobutamine dob
+LEFT JOIN `physionet-data.mimic_derived.dobutamine` dob
     ON t.stay_id = dob.stay_id
     AND t.starttime >= dob.starttime
     AND t.endtime <= dob.endtime
-LEFT JOIN mimic_derived.dopamine dop
+LEFT JOIN `physionet-data.mimic_derived.dopamine` dop
     ON t.stay_id = dop.stay_id
     AND t.starttime >= dop.starttime
     AND t.endtime <= dop.endtime
-LEFT JOIN mimic_derived.epinephrine epi
+LEFT JOIN `physionet-data.mimic_derived.epinephrine` epi
     ON t.stay_id = epi.stay_id
     AND t.starttime >= epi.starttime
     AND t.endtime <= epi.endtime
-LEFT JOIN mimic_derived.norepinephrine nor
+LEFT JOIN `physionet-data.mimic_derived.norepinephrine` nor
     ON t.stay_id = nor.stay_id
     AND t.starttime >= nor.starttime
     AND t.endtime <= nor.endtime
-LEFT JOIN mimic_derived.phenylephrine phe
+LEFT JOIN `physionet-data.mimic_derived.phenylephrine` phe
     ON t.stay_id = phe.stay_id
     AND t.starttime >= phe.starttime
     AND t.endtime <= phe.endtime
-LEFT JOIN mimic_derived.vasopressin vas
+LEFT JOIN `physionet-data.mimic_derived.vasopressin` vas
     ON t.stay_id = vas.stay_id
     AND t.starttime >= vas.starttime
     AND t.endtime <= vas.endtime
-LEFT JOIN mimic_derived.milrinone mil
+LEFT JOIN `physionet-data.mimic_derived.milrinone` mil
     ON t.stay_id = mil.stay_id
     AND t.starttime >= mil.starttime
     AND t.endtime <= mil.endtime

--- a/mimic-iv/concepts/medication/vasopressin.sql
+++ b/mimic-iv/concepts/medication/vasopressin.sql
@@ -8,5 +8,5 @@ select
   , amount as vaso_amount
   , starttime
   , endtime
-from `physionet-data.mimic_icu.inputevents`
+from `physionet-data.mimiciv_icu.inputevents`
 where itemid = 222315 -- vasopressin

--- a/mimic-iv/concepts/organfailure/kdigo_creatinine.sql
+++ b/mimic-iv/concepts/organfailure/kdigo_creatinine.sql
@@ -6,8 +6,8 @@ WITH cr AS
         , ie.stay_id
         , le.charttime
         , AVG(le.valuenum) AS creat
-    FROM `physionet-data.mimic_icu.icustays` ie
-    LEFT JOIN `physionet-data.mimic_hosp.labevents` le
+    FROM `physionet-data.mimiciv_icu.icustays` ie
+    LEFT JOIN `physionet-data.mimiciv_hosp.labevents` le
     ON ie.subject_id = le.subject_id
     AND le.ITEMID = 50912
     AND le.VALUENUM IS NOT NULL

--- a/mimic-iv/concepts/organfailure/kdigo_stages.sql
+++ b/mimic-iv/concepts/organfailure/kdigo_stages.sql
@@ -26,7 +26,7 @@ with cr_stg AS
         when cr.creat >= (cr.creat_low_past_48hr+0.3) then 1
         when cr.creat >= (cr.creat_low_past_7day*1.5) then 1
     else 0 end as aki_stage_creat
-  FROM `physionet-data.mimic_derived.kdigo_creatinine` cr
+  FROM `physionet-data.mimiciv_derived.kdigo_creatinine` cr
 )
 -- stages for UO / creat
 , uo_stg as
@@ -50,8 +50,8 @@ with cr_stg AS
         WHEN uo.uo_tm_12hr >= 5 AND uo.uo_rt_12hr < 0.5 THEN 2
         WHEN uo.uo_tm_6hr >= 2 AND uo.uo_rt_6hr  < 0.5 THEN 1
     ELSE 0 END AS aki_stage_uo
-  from `physionet-data.mimic_derived.kdigo_uo` uo
-  INNER JOIN `physionet-data.mimic_icu.icustays` ie
+  from `physionet-data.mimiciv_derived.kdigo_uo` uo
+  INNER JOIN `physionet-data.mimiciv_icu.icustays` ie
     ON uo.stay_id = ie.stay_id
 )
 -- get all charttimes documented
@@ -83,7 +83,7 @@ select
         COALESCE(cr.aki_stage_creat,0),
         COALESCE(uo.aki_stage_uo,0)
         ) AS aki_stage
-FROM `physionet-data.mimic_icu.icustays` ie
+FROM `physionet-data.mimiciv_icu.icustays` ie
 -- get all possible charttimes as listed in tm_stg
 LEFT JOIN tm_stg tm
   ON ie.stay_id = tm.stay_id

--- a/mimic-iv/concepts/organfailure/kdigo_uo.sql
+++ b/mimic-iv/concepts/organfailure/kdigo_uo.sql
@@ -43,9 +43,9 @@ with ur_stg as
   , ROUND(CAST(
       DATETIME_DIFF(io.charttime, MIN(iosum.charttime), SECOND)
    AS NUMERIC)/3600.0, 4) AS uo_tm_24hr
-  from `physionet-data.mimic_derived.urine_output` io
+  from `physionet-data.mimiciv_derived.urine_output` io
   -- this join gives all UO measurements over the 24 hours preceding this row
-  left join `physionet-data.mimic_derived.urine_output` iosum
+  left join `physionet-data.mimiciv_derived.urine_output` iosum
     on  io.stay_id = iosum.stay_id
     and iosum.charttime <= io.charttime
     and iosum.charttime >= DATETIME_SUB(io.charttime, interval '23' hour)
@@ -67,7 +67,7 @@ select
 , uo_tm_12hr
 , uo_tm_24hr
 from ur_stg ur
-left join `physionet-data.mimic_derived.weight_durations` wd
+left join `physionet-data.mimiciv_derived.weight_durations` wd
   on  ur.stay_id = wd.stay_id
   and ur.charttime >= wd.starttime
   and ur.charttime <  wd.endtime

--- a/mimic-iv/concepts/organfailure/meld.sql
+++ b/mimic-iv/concepts/organfailure/meld.sql
@@ -56,11 +56,11 @@ SELECT
 
     , r.dialysis_present AS rrt
 
-FROM `physionet-data.mimic_icu.icustays` ie
+FROM `physionet-data.mimiciv_icu.icustays` ie
 -- join to custom tables to get more data....
-LEFT JOIN `physionet-data.mimic_derived.first_day_lab` labs
+LEFT JOIN `physionet-data.mimiciv_derived.first_day_lab` labs
   ON ie.stay_id = labs.stay_id
-LEFT JOIN `physionet-data.mimic_derived.first_day_rrt` r
+LEFT JOIN `physionet-data.mimiciv_derived.first_day_rrt` r
   ON ie.stay_id = r.stay_id
 )
 , score as

--- a/mimic-iv/concepts/postgres/comorbidity/charlson.sql
+++ b/mimic-iv/concepts/postgres/comorbidity/charlson.sql
@@ -21,7 +21,7 @@ WITH diag AS
         hadm_id
         , CASE WHEN icd_version = 9 THEN icd_code ELSE NULL END AS icd9_code
         , CASE WHEN icd_version = 10 THEN icd_code ELSE NULL END AS icd10_code
-    FROM mimic_hosp.diagnoses_icd diag
+    FROM mimiciv_hosp.diagnoses_icd diag
 )
 , com AS
 (
@@ -255,7 +255,7 @@ WITH diag AS
             SUBSTR(icd10_code, 1, 3) IN ('B20','B21','B22','B24')
             THEN 1 
             ELSE 0 END) AS aids
-    FROM mimic_core.admissions ad
+    FROM mimiciv_hosp.admissions ad
     LEFT JOIN diag
     ON ad.hadm_id = diag.hadm_id
     GROUP BY ad.hadm_id
@@ -270,7 +270,7 @@ WITH diag AS
     WHEN age <= 60 THEN 2
     WHEN age <= 70 THEN 3
     ELSE 4 END AS age_score
-    FROM mimic_derived.age
+    FROM mimiciv_derived.age
 )
 SELECT 
     ad.subject_id
@@ -305,7 +305,7 @@ SELECT
     + 2*paraplegia + 2*renal_disease 
     + 6*aids
     AS charlson_comorbidity_index
-FROM mimic_core.admissions ad
+FROM mimiciv_hosp.admissions ad
 LEFT JOIN com
 ON ad.hadm_id = com.hadm_id
 LEFT JOIN ag

--- a/mimic-iv/concepts/postgres/demographics/age.sql
+++ b/mimic-iv/concepts/postgres/demographics/age.sql
@@ -23,8 +23,8 @@ SELECT
 	, ad.admittime
 	, pa.anchor_age
 	, pa.anchor_year
-	, DATETIME_DIFF(ad.admittime, DATETIME(pa.anchor_year, 1, 1, 0, 0,0),'YEAR') + pa.anchor_age AS age
-FROM mimic_core.admissions ad
-INNER JOIN mimic_core.patients pa
+	, DATETIME_DIFF(ad.admittime, DATETIME(pa.anchor_year, 1, 1, 0, 0, 0), YEAR) + pa.anchor_age AS age
+FROM mimiciv_hosp.admissions ad
+INNER JOIN mimiciv_hosp.patients pa
 ON ad.subject_id = pa.subject_id
 ;

--- a/mimic-iv/concepts/postgres/demographics/icustay_detail.sql
+++ b/mimic-iv/concepts/postgres/demographics/icustay_detail.sql
@@ -7,9 +7,9 @@ SELECT ie.subject_id, ie.hadm_id, ie.stay_id
 
 -- hospital level factors
 , adm.admittime, adm.dischtime
-, DATETIME_DIFF(adm.dischtime,adm.admittime,'DAY') as los_hospital
-, DATETIME_DIFF(adm.admittime, DATETIME(pat.anchor_year, 1, 1, 0, 0,0),'YEAR') + pat.anchor_age as admission_age
-, adm.ethnicity
+, DATETIME_DIFF(adm.dischtime, adm.admittime, 'DAY') as los_hospital
+, DATETIME_DIFF(adm.admittime, DATETIME(pat.anchor_year, 1, 1, 0, 0, 0), YEAR) + pat.anchor_age as admission_age
+, adm.race
 , adm.hospital_expire_flag
 , DENSE_RANK() OVER (PARTITION BY adm.subject_id ORDER BY adm.admittime) AS hospstay_seq
 , CASE
@@ -18,7 +18,7 @@ SELECT ie.subject_id, ie.hadm_id, ie.stay_id
 
 -- icu level factors
 , ie.intime as icu_intime, ie.outtime as icu_outtime
-, ROUND( CAST( DATETIME_DIFF(ie.outtime,ie.intime,'HOUR')/24.0 as numeric),2) as los_icu
+, ROUND( CAST( DATETIME_DIFF(ie.outtime as numeric),ie.intime, 'HOUR')/24.0, 2) as los_icu
 , DENSE_RANK() OVER (PARTITION BY ie.hadm_id ORDER BY ie.intime) AS icustay_seq
 
 -- first ICU stay *for the current hospitalization*
@@ -26,8 +26,8 @@ SELECT ie.subject_id, ie.hadm_id, ie.stay_id
     WHEN DENSE_RANK() OVER (PARTITION BY ie.hadm_id ORDER BY ie.intime) = 1 THEN True
     ELSE False END AS first_icu_stay
 
-FROM mimic_icu.icustays ie
-INNER JOIN mimic_core.admissions adm
+FROM mimiciv_icu.icustays ie
+INNER JOIN mimiciv_hosp.admissions adm
     ON ie.hadm_id = adm.hadm_id
-INNER JOIN mimic_core.patients pat
+INNER JOIN mimiciv_hosp.patients pat
     ON ie.subject_id = pat.subject_id

--- a/mimic-iv/concepts/postgres/demographics/icustay_hourly.sql
+++ b/mimic-iv/concepts/postgres/demographics/icustay_hourly.sql
@@ -27,9 +27,9 @@ select
   -- create integers for each charttime in hours from admission
   -- so 0 is admission time, 1 is one hour after admission, etc, up to ICU disch
   --  we allow 24 hours before ICU admission (to grab labs before admit)
-  , ARRAY(SELECT * FROM generate_series(-24, CEIL(DATETIME_DIFF(it.outtime_hr,it.intime_hr,'HOUR')))) as hrs
+  , ARRAY(SELECT * FROM generate_series(-24, CEIL(DATETIME_DIFF(it.outtime_hr, it.intime_hr, 'HOUR')))) as hrs
 
-  from mimic_derived.icustay_times it
+  from mimiciv_derived.icustay_times it
 )
 SELECT stay_id
 , CAST(hr AS bigint) as hr

--- a/mimic-iv/concepts/postgres/demographics/icustay_times.sql
+++ b/mimic-iv/concepts/postgres/demographics/icustay_times.sql
@@ -8,7 +8,7 @@ WITH t1 AS
     select ce.stay_id
     , min(charttime) as intime_hr
     , max(charttime) as outtime_hr
-    FROM mimic_icu.chartevents ce
+    FROM mimiciv_icu.chartevents ce
     -- only look at heart rate
     where ce.itemid = 220045
     group by ce.stay_id
@@ -18,6 +18,6 @@ select
   ie.subject_id, ie.hadm_id, ie.stay_id
   , t1.intime_hr
   , t1.outtime_hr
-FROM mimic_icu.icustays ie
+FROM mimiciv_icu.icustays ie
 left join t1
   on ie.stay_id = t1.stay_id;

--- a/mimic-iv/concepts/postgres/demographics/weight_durations.sql
+++ b/mimic-iv/concepts/postgres/demographics/weight_durations.sql
@@ -11,7 +11,7 @@ WITH wt_stg as
           else 'daily' end as weight_type
       -- TODO: eliminate obvious outliers if there is a reasonable weight
       , c.valuenum as weight
-    FROM mimic_icu.chartevents c
+    FROM mimiciv_icu.chartevents c
     WHERE c.valuenum IS NOT NULL
       AND c.itemid in
       (
@@ -44,7 +44,7 @@ WITH wt_stg as
       else wt_stg1.charttime end as starttime
     , wt_stg1.weight
   from wt_stg1
-  INNER JOIN mimic_icu.icustays ie
+  INNER JOIN mimiciv_icu.icustays ie
     on ie.stay_id = wt_stg1.stay_id
 )
 , wt_stg3 as
@@ -89,7 +89,7 @@ WITH wt_stg as
     , wt.starttime as endtime
     , wt.weight
     , wt.weight_type
-  from mimic_icu.icustays ie
+  from mimiciv_icu.icustays ie
   inner join
   -- the below subquery returns one row for each unique stay_id
   -- the row contains: the first starttime and the corresponding weight

--- a/mimic-iv/concepts/postgres/firstday/first_day_bg.sql
+++ b/mimic-iv/concepts/postgres/firstday/first_day_bg.sql
@@ -25,8 +25,8 @@ select
     , MIN(glucose) AS glucose_min, MAX(glucose) AS glucose_max
     , MIN(potassium) AS potassium_min, MAX(potassium) AS potassium_max
     , MIN(sodium) AS sodium_min, MAX(sodium) AS sodium_max
-FROM mimic_icu.icustays ie
-LEFT JOIN mimic_derived.bg bg
+FROM mimiciv_icu.icustays ie
+LEFT JOIN mimiciv_derived.bg bg
     ON ie.subject_id = bg.subject_id
     AND bg.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND bg.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)

--- a/mimic-iv/concepts/postgres/firstday/first_day_bg_art.sql
+++ b/mimic-iv/concepts/postgres/firstday/first_day_bg_art.sql
@@ -25,8 +25,8 @@ select
     , MIN(glucose) AS glucose_min, MAX(glucose) AS glucose_max
     , MIN(potassium) AS potassium_min, MAX(potassium) AS potassium_max
     , MIN(sodium) AS sodium_min, MAX(sodium) AS sodium_max
-FROM mimic_icu.icustays ie
-LEFT JOIN mimic_derived.bg bg
+FROM mimiciv_icu.icustays ie
+LEFT JOIN mimiciv_derived.bg bg
     ON ie.subject_id = bg.subject_id
     AND bg.specimen = 'ART.'
     AND bg.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)

--- a/mimic-iv/concepts/postgres/firstday/first_day_gcs.sql
+++ b/mimic-iv/concepts/postgres/firstday/first_day_gcs.sql
@@ -23,7 +23,7 @@ WITH gcs_final AS
             PARTITION BY gcs.stay_id
             ORDER BY gcs.GCS
         ) as gcs_seq
-    FROM mimic_derived.gcs gcs
+    FROM mimiciv_derived.gcs gcs
 )
 SELECT
     ie.subject_id
@@ -35,7 +35,7 @@ SELECT
     , gcs_verbal
     , gcs_eyes
     , gcs_unable
-FROM mimic_icu.icustays ie
+FROM mimiciv_icu.icustays ie
 LEFT JOIN gcs_final gs
     ON ie.stay_id = gs.stay_id
     AND gs.gcs_seq = 1

--- a/mimic-iv/concepts/postgres/firstday/first_day_height.sql
+++ b/mimic-iv/concepts/postgres/firstday/first_day_height.sql
@@ -11,8 +11,8 @@ WITH ce AS
     SELECT
       c.stay_id
       , AVG(valuenum) as Height_chart
-    FROM mimic_icu.chartevents c
-    INNER JOIN mimic_icu.icustays ie ON
+    FROM mimiciv_icu.chartevents c
+    INNER JOIN mimiciv_icu.icustays ie ON
         c.stay_id = ie.stay_id
         AND c.charttime BETWEEN DATETIME_SUB(ie.intime, INTERVAL '1' DAY) AND DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
     WHERE c.valuenum IS NOT NULL
@@ -24,8 +24,8 @@ SELECT
     ie.subject_id
     , ie.stay_id
     , ROUND( CAST( AVG(height) as numeric),2) AS height
-FROM mimic_icu.icustays ie
-LEFT JOIN mimic_derived.height ht
+FROM mimiciv_icu.icustays ie
+LEFT JOIN mimiciv_derived.height ht
     ON ie.stay_id = ht.stay_id
     AND ht.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND ht.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)

--- a/mimic-iv/concepts/postgres/firstday/first_day_lab.sql
+++ b/mimic-iv/concepts/postgres/firstday/first_day_lab.sql
@@ -12,8 +12,8 @@ WITH cbc AS
     , MAX(platelet) as platelets_max
     , MIN(wbc) as wbc_min
     , MAX(wbc) as wbc_max
-    FROM mimic_icu.icustays ie
-    LEFT JOIN mimic_derived.complete_blood_count le
+    FROM mimiciv_icu.icustays ie
+    LEFT JOIN mimiciv_derived.complete_blood_count le
         ON le.subject_id = ie.subject_id
         AND le.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
         AND le.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -35,8 +35,8 @@ WITH cbc AS
     , MIN(glucose) AS glucose_min, MAX(glucose) AS glucose_max
     , MIN(sodium) AS sodium_min, MAX(sodium) AS sodium_max
     , MIN(potassium) AS potassium_min, MAX(potassium) AS potassium_max
-    FROM mimic_icu.icustays ie
-    LEFT JOIN mimic_derived.chemistry le
+    FROM mimiciv_icu.icustays ie
+    LEFT JOIN mimiciv_derived.chemistry le
         ON le.subject_id = ie.subject_id
         AND le.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
         AND le.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -56,8 +56,8 @@ WITH cbc AS
     , MIN(immature_granulocytes) AS imm_granulocytes_min, MAX(immature_granulocytes) AS imm_granulocytes_max
     , MIN(metamyelocytes) AS metas_min, MAX(metamyelocytes) AS metas_max
     , MIN(nrbc) AS nrbc_min, MAX(nrbc) AS nrbc_max
-    FROM mimic_icu.icustays ie
-    LEFT JOIN mimic_derived.blood_differential le
+    FROM mimiciv_icu.icustays ie
+    LEFT JOIN mimiciv_derived.blood_differential le
         ON le.subject_id = ie.subject_id
         AND le.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
         AND le.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -73,8 +73,8 @@ WITH cbc AS
     , MIN(inr) AS inr_min, MAX(inr) AS inr_max
     , MIN(pt) AS pt_min, MAX(pt) AS pt_max
     , MIN(ptt) AS ptt_min, MAX(ptt) AS ptt_max
-    FROM mimic_icu.icustays ie
-    LEFT JOIN mimic_derived.coagulation le
+    FROM mimiciv_icu.icustays ie
+    LEFT JOIN mimiciv_derived.coagulation le
         ON le.subject_id = ie.subject_id
         AND le.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
         AND le.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -96,8 +96,8 @@ WITH cbc AS
     , MIN(ck_mb) AS ck_mb_min, MAX(ck_mb) AS ck_mb_max
     , MIN(ggt) AS ggt_min, MAX(ggt) AS ggt_max
     , MIN(ld_ldh) AS ld_ldh_min, MAX(ld_ldh) AS ld_ldh_max
-    FROM mimic_icu.icustays ie
-    LEFT JOIN mimic_derived.enzyme le
+    FROM mimiciv_icu.icustays ie
+    LEFT JOIN mimiciv_derived.enzyme le
         ON le.subject_id = ie.subject_id
         AND le.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
         AND le.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -154,7 +154,7 @@ ie.subject_id
 , ck_mb_min, ck_mb_max
 , ggt_min, ggt_max
 , ld_ldh_min, ld_ldh_max
-FROM mimic_icu.icustays ie
+FROM mimiciv_icu.icustays ie
 LEFT JOIN cbc
     ON ie.stay_id = cbc.stay_id
 LEFT JOIN chem

--- a/mimic-iv/concepts/postgres/firstday/first_day_rrt.sql
+++ b/mimic-iv/concepts/postgres/firstday/first_day_rrt.sql
@@ -8,8 +8,8 @@ select
     , MAX(dialysis_present) AS dialysis_present
     , MAX(dialysis_active) AS dialysis_active
     , STRING_AGG(DISTINCT dialysis_type, ', ') AS dialysis_type
-FROM mimic_icu.icustays ie
-LEFT JOIN mimic_derived.rrt rrt
+FROM mimiciv_icu.icustays ie
+LEFT JOIN mimiciv_derived.rrt rrt
 	ON ie.stay_id = rrt.stay_id
 	AND rrt.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
 	AND rrt.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)

--- a/mimic-iv/concepts/postgres/firstday/first_day_sofa.sql
+++ b/mimic-iv/concepts/postgres/firstday/first_day_sofa.sql
@@ -31,29 +31,29 @@ DROP TABLE IF EXISTS first_day_sofa; CREATE TABLE first_day_sofa AS
 with vaso_stg as
 (
   select ie.stay_id, 'norepinephrine' AS treatment, vaso_rate as rate
-  FROM mimic_icu.icustays ie
-  INNER JOIN mimic_derived.norepinephrine mv
+  FROM mimiciv_icu.icustays ie
+  INNER JOIN mimiciv_derived.norepinephrine mv
     ON ie.stay_id = mv.stay_id
     AND mv.starttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND mv.starttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
   UNION ALL
   select ie.stay_id, 'epinephrine' AS treatment, vaso_rate as rate
-  FROM mimic_icu.icustays ie
-  INNER JOIN mimic_derived.epinephrine mv
+  FROM mimiciv_icu.icustays ie
+  INNER JOIN mimiciv_derived.epinephrine mv
     ON ie.stay_id = mv.stay_id
     AND mv.starttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND mv.starttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
   UNION ALL
   select ie.stay_id, 'dobutamine' AS treatment, vaso_rate as rate
-  FROM mimic_icu.icustays ie
-  INNER JOIN mimic_derived.dobutamine mv
+  FROM mimiciv_icu.icustays ie
+  INNER JOIN mimiciv_derived.dobutamine mv
     ON ie.stay_id = mv.stay_id
     AND mv.starttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND mv.starttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
   UNION ALL
   select ie.stay_id, 'dopamine' AS treatment, vaso_rate as rate
-  FROM mimic_icu.icustays ie
-  INNER JOIN mimic_derived.dopamine mv
+  FROM mimiciv_icu.icustays ie
+  INNER JOIN mimiciv_derived.dopamine mv
     ON ie.stay_id = mv.stay_id
     AND mv.starttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND mv.starttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -66,7 +66,7 @@ with vaso_stg as
     , max(CASE WHEN treatment = 'epinephrine' THEN rate ELSE NULL END) as rate_epinephrine
     , max(CASE WHEN treatment = 'dopamine' THEN rate ELSE NULL END) as rate_dopamine
     , max(CASE WHEN treatment = 'dobutamine' THEN rate ELSE NULL END) as rate_dobutamine
-  from mimic_icu.icustays ie
+  from mimiciv_icu.icustays ie
   LEFT JOIN vaso_stg v
       ON ie.stay_id = v.stay_id
   GROUP BY ie.stay_id
@@ -77,12 +77,12 @@ with vaso_stg as
   select ie.stay_id, bg.charttime
   , bg.pao2fio2ratio
   , case when vd.stay_id is not null then 1 else 0 end as IsVent
-  from mimic_icu.icustays ie
-  LEFT JOIN mimic_derived.bg bg
+  from mimiciv_icu.icustays ie
+  LEFT JOIN mimiciv_derived.bg bg
       ON ie.subject_id = bg.subject_id
       AND bg.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
       AND bg.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
-  LEFT JOIN mimic_derived.ventilation vd
+  LEFT JOIN mimiciv_derived.ventilation vd
     ON ie.stay_id = vd.stay_id
     AND bg.charttime >= vd.starttime
     AND bg.charttime <= vd.endtime
@@ -119,18 +119,18 @@ select ie.stay_id
   , uo.UrineOutput
 
   , gcs.gcs_min
-from mimic_icu.icustays ie
+from mimiciv_icu.icustays ie
 left join vaso_mv mv
   on ie.stay_id = mv.stay_id
 left join pafi2 pf
  on ie.stay_id = pf.stay_id
-left join mimic_derived.first_day_vitalsign v
+left join mimiciv_derived.first_day_vitalsign v
   on ie.stay_id = v.stay_id
-left join mimic_derived.first_day_lab l
+left join mimiciv_derived.first_day_lab l
   on ie.stay_id = l.stay_id
-left join mimic_derived.first_day_urine_output uo
+left join mimiciv_derived.first_day_urine_output uo
   on ie.stay_id = uo.stay_id
-left join mimic_derived.first_day_gcs gcs
+left join mimiciv_derived.first_day_gcs gcs
   on ie.stay_id = gcs.stay_id
 )
 , scorecalc as
@@ -219,7 +219,7 @@ select ie.subject_id, ie.hadm_id, ie.stay_id
 , cardiovascular
 , cns
 , renal
-from mimic_icu.icustays ie
+from mimiciv_icu.icustays ie
 left join scorecalc s
   on ie.stay_id = s.stay_id
 ;

--- a/mimic-iv/concepts/postgres/firstday/first_day_urine_output.sql
+++ b/mimic-iv/concepts/postgres/firstday/first_day_urine_output.sql
@@ -6,9 +6,9 @@ SELECT
   ie.subject_id
   , ie.stay_id
   , SUM(urineoutput) AS urineoutput
-FROM mimic_icu.icustays ie
+FROM mimiciv_icu.icustays ie
 -- Join to the outputevents table to get urine output
-LEFT JOIN mimic_derived.urine_output uo
+LEFT JOIN mimiciv_derived.urine_output uo
     ON ie.stay_id = uo.stay_id
     -- ensure the data occurs during the first day
     AND uo.charttime >= ie.intime

--- a/mimic-iv/concepts/postgres/firstday/first_day_vitalsign.sql
+++ b/mimic-iv/concepts/postgres/firstday/first_day_vitalsign.sql
@@ -29,8 +29,8 @@ ie.subject_id
 , MIN(glucose) AS glucose_min
 , MAX(glucose) AS glucose_max
 , AVG(glucose) AS glucose_mean
-FROM mimic_icu.icustays ie
-LEFT JOIN mimic_derived.vitalsign ce
+FROM mimiciv_icu.icustays ie
+LEFT JOIN mimiciv_derived.vitalsign ce
     ON ie.stay_id = ce.stay_id
     AND ce.charttime >= DATETIME_SUB(ie.intime, INTERVAL '6' HOUR)
     AND ce.charttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)

--- a/mimic-iv/concepts/postgres/firstday/first_day_weight.sql
+++ b/mimic-iv/concepts/postgres/firstday/first_day_weight.sql
@@ -11,9 +11,9 @@ SELECT
   , AVG(ce.weight) AS weight
   , MIN(ce.weight) AS weight_min
   , MAX(ce.weight) AS weight_max
-FROM mimic_icu.icustays ie
+FROM mimiciv_icu.icustays ie
   -- admission weight
-LEFT JOIN mimic_derived.weight_durations ce
+LEFT JOIN mimiciv_derived.weight_durations ce
     ON ie.stay_id = ce.stay_id
     -- we filter to weights documented during or before the 1st day
     AND ce.starttime <= DATETIME_ADD(ie.intime, INTERVAL '1' DAY)

--- a/mimic-iv/concepts/postgres/measurement/bg.sql
+++ b/mimic-iv/concepts/postgres/measurement/bg.sql
@@ -46,7 +46,7 @@ select
   , MAX(CASE WHEN itemid = 50824 THEN valuenum ELSE NULL END) AS sodium
   , MAX(CASE WHEN itemid = 50825 THEN valuenum ELSE NULL END) AS temperature
   , MAX(CASE WHEN itemid = 50807 THEN value ELSE NULL END) AS comments
-FROM mimic_hosp.labevents le
+FROM mimiciv_hosp.labevents le
 where le.ITEMID in
 -- blood gases
 (
@@ -86,7 +86,7 @@ GROUP BY le.specimen_id
   select subject_id, charttime
     -- avg here is just used to group SpO2 by charttime
     , AVG(valuenum) as SpO2
-  FROM mimic_icu.chartevents
+  FROM mimiciv_icu.chartevents
   where ITEMID = 220277 -- O2 saturation pulseoxymetry
   and valuenum > 0 and valuenum <= 100
   group by subject_id, charttime
@@ -106,7 +106,7 @@ GROUP BY le.specimen_id
             then valuenum
       else null end
     ) as fio2_chartevents
-  FROM mimic_icu.chartevents
+  FROM mimiciv_icu.chartevents
   where ITEMID = 223835 -- Inspired O2 Fraction (FiO2)
   and valuenum > 0 and valuenum <= 100
   group by subject_id, charttime

--- a/mimic-iv/concepts/postgres/measurement/blood_differential.sql
+++ b/mimic-iv/concepts/postgres/measurement/blood_differential.sql
@@ -49,7 +49,7 @@ SELECT
     AND SUM(CASE WHEN itemid IN (51146, 51200, 51244, 51245, 51254, 51256) THEN valuenum ELSE NULL END) > 0
     THEN 1 ELSE 0 END AS impute_abs
 
-FROM mimic_hosp.labevents le
+FROM mimiciv_hosp.labevents le
 WHERE le.itemid IN
 (
     51146, -- basophils
@@ -98,27 +98,27 @@ subject_id, hadm_id, charttime, specimen_id
 -- impute absolute count if percentage & WBC is available
 , ROUND( CAST( CASE
     WHEN basophils_abs IS NULL AND basophils IS NOT NULL AND impute_abs = 1
-        THEN basophils * wbc
+        THEN basophils * wbc / 100
     ELSE basophils_abs
 END as numeric),4) AS basophils_abs
 , ROUND( CAST( CASE
     WHEN eosinophils_abs IS NULL AND eosinophils IS NOT NULL AND impute_abs = 1
-        THEN eosinophils * wbc
+        THEN eosinophils * wbc / 100
     ELSE eosinophils_abs
 END as numeric),4) AS eosinophils_abs
 , ROUND( CAST( CASE
     WHEN lymphocytes_abs IS NULL AND lymphocytes IS NOT NULL AND impute_abs = 1
-        THEN lymphocytes * wbc
+        THEN lymphocytes * wbc / 100
     ELSE lymphocytes_abs
 END as numeric),4) AS lymphocytes_abs
 , ROUND( CAST( CASE
     WHEN monocytes_abs IS NULL AND monocytes IS NOT NULL AND impute_abs = 1
-        THEN monocytes * wbc
+        THEN monocytes * wbc / 100
     ELSE monocytes_abs
 END as numeric),4) AS monocytes_abs
 , ROUND( CAST( CASE
     WHEN neutrophils_abs IS NULL AND neutrophils IS NOT NULL AND impute_abs = 1
-        THEN neutrophils * wbc
+        THEN neutrophils * wbc / 100
     ELSE neutrophils_abs
 END as numeric),4) AS neutrophils_abs
 

--- a/mimic-iv/concepts/postgres/measurement/cardiac_marker.sql
+++ b/mimic-iv/concepts/postgres/measurement/cardiac_marker.sql
@@ -10,7 +10,7 @@ SELECT
   , MAX(CASE WHEN itemid = 51003 THEN value ELSE NULL END) AS troponin_t
   , MAX(CASE WHEN itemid = 50911 THEN valuenum ELSE NULL END) AS ck_mb
   , MAX(CASE WHEN itemid = 50963 THEN valuenum ELSE NULL END) AS ntprobnp
-FROM mimic_hosp.labevents le
+FROM mimiciv_hosp.labevents le
 WHERE le.itemid IN
 (
     -- 51002, -- Troponin I (troponin-I is not measured in MIMIC-IV)

--- a/mimic-iv/concepts/postgres/measurement/chemistry.sql
+++ b/mimic-iv/concepts/postgres/measurement/chemistry.sql
@@ -22,7 +22,7 @@ SELECT
   , MAX(CASE WHEN itemid = 50931 AND valuenum <= 10000 THEN valuenum ELSE NULL END) AS glucose
   , MAX(CASE WHEN itemid = 50983 AND valuenum <=   200 THEN valuenum ELSE NULL END) AS sodium
   , MAX(CASE WHEN itemid = 50971 AND valuenum <=    30 THEN valuenum ELSE NULL END) AS potassium
-FROM mimic_hosp.labevents le
+FROM mimiciv_hosp.labevents le
 WHERE le.itemid IN
 (
   -- comment is: LABEL | CATEGORY | FLUID | NUMBER OF ROWS IN LABEVENTS

--- a/mimic-iv/concepts/postgres/measurement/coagulation.sql
+++ b/mimic-iv/concepts/postgres/measurement/coagulation.sql
@@ -12,7 +12,7 @@ SELECT
   , MAX(CASE WHEN itemid = 51237 THEN valuenum ELSE NULL END) AS inr
   , MAX(CASE WHEN itemid = 51274 THEN valuenum ELSE NULL END) AS pt
   , MAX(CASE WHEN itemid = 51275 THEN valuenum ELSE NULL END) AS ptt
-FROM mimic_hosp.labevents le
+FROM mimiciv_hosp.labevents le
 WHERE le.itemid IN
 (
     -- 51149, 52750, 52072, 52073 -- Bleeding Time, no data as of MIMIC-IV v0.4

--- a/mimic-iv/concepts/postgres/measurement/complete_blood_count.sql
+++ b/mimic-iv/concepts/postgres/measurement/complete_blood_count.sql
@@ -17,7 +17,7 @@ SELECT
   , MAX(CASE WHEN itemid = 51277 THEN valuenum ELSE NULL END) AS rdw
   , MAX(CASE WHEN itemid = 52159 THEN valuenum ELSE NULL END) AS rdwsd
   , MAX(CASE WHEN itemid = 51301 THEN valuenum ELSE NULL END) AS wbc
-FROM mimic_hosp.labevents le
+FROM mimiciv_hosp.labevents le
 WHERE le.itemid IN
 (
     51221, -- hematocrit

--- a/mimic-iv/concepts/postgres/measurement/creatinine_baseline.sql
+++ b/mimic-iv/concepts/postgres/measurement/creatinine_baseline.sql
@@ -20,8 +20,8 @@ WITH p as
             POWER(75.0 / 186.0 / POWER(ag.age, -0.203), -1/1.154)
             END 
             AS MDRD_est
-    FROM mimic_derived.age ag
-    LEFT JOIN mimic_core.patients p
+    FROM mimiciv_derived.age ag
+    LEFT JOIN mimiciv_hosp.patients p
     ON ag.subject_id = p.subject_id
     WHERE ag.age >= 18
 )
@@ -30,13 +30,13 @@ WITH p as
     SELECT 
         hadm_id
         , MIN(creatinine) AS scr_min
-    FROM mimic_derived.chemistry
+    FROM mimiciv_derived.chemistry
     GROUP BY hadm_id
 )
 , ckd as 
 (
     SELECT hadm_id, MAX(1) AS CKD_flag
-    FROM mimic_hosp.diagnoses_icd
+    FROM mimiciv_hosp.diagnoses_icd
     WHERE 
         (
             SUBSTR(icd_code, 1, 3) = '585'

--- a/mimic-iv/concepts/postgres/measurement/enzyme.sql
+++ b/mimic-iv/concepts/postgres/measurement/enzyme.sql
@@ -18,7 +18,7 @@ SELECT
   , MAX(CASE WHEN itemid = 50911 THEN valuenum ELSE NULL END) AS ck_mb
   , MAX(CASE WHEN itemid = 50927 THEN valuenum ELSE NULL END) AS ggt
   , MAX(CASE WHEN itemid = 50954 THEN valuenum ELSE NULL END) AS ld_ldh
-FROM mimic_hosp.labevents le
+FROM mimiciv_hosp.labevents le
 WHERE le.itemid IN
 (
     50861, -- Alanine transaminase (ALT)

--- a/mimic-iv/concepts/postgres/measurement/gcs.sql
+++ b/mimic-iv/concepts/postgres/measurement/gcs.sql
@@ -43,7 +43,7 @@ with base as
     as endotrachflag
   , ROW_NUMBER ()
           OVER (PARTITION BY ce.stay_id ORDER BY ce.charttime ASC) as rn
-  from mimic_icu.chartevents ce
+  from mimiciv_icu.chartevents ce
   -- Isolate the desired GCS variables
   where ce.ITEMID in
   (
@@ -107,26 +107,6 @@ with base as
   , EndoTrachFlag
   from gcs gs
 )
--- priority is:
---  (i) complete data, (ii) non-sedated GCS, (iii) lowest GCS, (iv) charttime
-, gcs_priority as
-(
-  select
-      subject_id
-    , stay_id
-    , charttime
-    , gcs
-    , gcsmotor
-    , gcsverbal
-    , gcseyes
-    , EndoTrachFlag
-    , ROW_NUMBER() over
-      (
-        PARTITION BY stay_id, charttime
-        ORDER BY components_measured DESC, endotrachflag, gcs, charttime DESC
-      ) as rn
-  from gcs_stg
-)
 select
   gs.subject_id
   , gs.stay_id
@@ -136,6 +116,5 @@ select
   , GCSVerbal AS gcs_verbal
   , GCSEyes AS gcs_eyes
   , EndoTrachFlag AS gcs_unable
-from gcs_priority gs
-where rn = 1
+from gcs_stg gs
 ;

--- a/mimic-iv/concepts/postgres/measurement/height.sql
+++ b/mimic-iv/concepts/postgres/measurement/height.sql
@@ -8,7 +8,7 @@ WITH ht_in AS
     -- Ensure that all heights are in centimeters
     , ROUND( CAST( c.valuenum * 2.54 as numeric),2) AS height
     , c.valuenum as height_orig
-  FROM mimic_icu.chartevents c
+  FROM mimiciv_icu.chartevents c
   WHERE c.valuenum IS NOT NULL
   -- Height (measured in inches)
   AND c.itemid = 226707
@@ -19,7 +19,7 @@ WITH ht_in AS
     c.subject_id, c.stay_id, c.charttime
     -- Ensure that all heights are in centimeters
     , ROUND( CAST( c.valuenum as numeric),2) AS height
-  FROM mimic_icu.chartevents c
+  FROM mimiciv_icu.chartevents c
   WHERE c.valuenum IS NOT NULL
   -- Height cm
   AND c.itemid = 226730

--- a/mimic-iv/concepts/postgres/measurement/icp.sql
+++ b/mimic-iv/concepts/postgres/measurement/icp.sql
@@ -8,7 +8,7 @@ with ce as
   , ce.charttime
   -- TODO: handle high ICPs when monitoring two ICPs
   , case when valuenum > 0 and valuenum < 100 then valuenum else null end as icp
-  FROM mimic_icu.chartevents ce
+  FROM mimiciv_icu.chartevents ce
   -- exclude rows marked as error
   where ce.itemid in
   (

--- a/mimic-iv/concepts/postgres/measurement/inflammation.sql
+++ b/mimic-iv/concepts/postgres/measurement/inflammation.sql
@@ -9,7 +9,7 @@ SELECT
   , MAX(CASE WHEN itemid = 50889 THEN valuenum ELSE NULL END) AS crp
   -- , CAST(NULL AS NUMERIC) AS il6
   -- , CAST(NULL AS NUMERIC) AS procalcitonin
-FROM mimic_hosp.labevents le
+FROM mimiciv_hosp.labevents le
 WHERE le.itemid IN
 (
     50889 -- crp

--- a/mimic-iv/concepts/postgres/measurement/oxygen_delivery.sql
+++ b/mimic-iv/concepts/postgres/measurement/oxygen_delivery.sql
@@ -14,7 +14,7 @@ with ce_stg1 as
     , valuenum
     , valueuom
     , storetime
-  FROM mimic_icu.chartevents ce
+  FROM mimiciv_icu.chartevents ce
   WHERE ce.value IS NOT NULL
   AND ce.itemid IN
   (

--- a/mimic-iv/concepts/postgres/measurement/rhythm.sql
+++ b/mimic-iv/concepts/postgres/measurement/rhythm.sql
@@ -9,7 +9,7 @@ select
   , MAX(case when itemid = 224651 THEN value ELSE NULL END) AS ectopy_frequency
   , MAX(case when itemid = 226479 THEN value ELSE NULL END) AS ectopy_type_secondary
   , MAX(case when itemid = 226480 THEN value ELSE NULL END) AS ectopy_frequency_secondary
-FROM mimic_icu.chartevents ce
+FROM mimiciv_icu.chartevents ce
 where ce.stay_id IS NOT NULL
 and ce.itemid in
 (

--- a/mimic-iv/concepts/postgres/measurement/urine_output.sql
+++ b/mimic-iv/concepts/postgres/measurement/urine_output.sql
@@ -18,7 +18,7 @@ from
         when oe.itemid = 227488 and oe.value > 0 then -1*oe.value
         else oe.value
     end as urineoutput
-    from mimic_icu.outputevents oe
+    from mimiciv_icu.outputevents oe
     where itemid in
     (
     226559, -- Foley

--- a/mimic-iv/concepts/postgres/measurement/ventilator_setting.sql
+++ b/mimic-iv/concepts/postgres/measurement/ventilator_setting.sql
@@ -34,7 +34,7 @@ with ce as
     ELSE valuenum END AS valuenum
     , valueuom
     , storetime
-  FROM mimic_icu.chartevents ce
+  FROM mimiciv_icu.chartevents ce
   where ce.value IS NOT NULL
   AND ce.stay_id IS NOT NULL
   AND ce.itemid IN

--- a/mimic-iv/concepts/postgres/measurement/vitalsign.sql
+++ b/mimic-iv/concepts/postgres/measurement/vitalsign.sql
@@ -21,7 +21,7 @@ select
   , MAX(CASE WHEN itemid = 224642 THEN value ELSE NULL END) AS temperature_site
   , AVG(case when itemid in (220277) and valuenum > 0 and valuenum <= 100 then valuenum else null end) as spo2
   , AVG(case when itemid in (225664,220621,226537) and valuenum > 0 then valuenum else null end) as glucose
-  FROM mimic_icu.chartevents ce
+  FROM mimiciv_icu.chartevents ce
   where ce.stay_id IS NOT NULL
   and ce.itemid in
   (

--- a/mimic-iv/concepts/postgres/medication/antibiotic.sql
+++ b/mimic-iv/concepts/postgres/medication/antibiotic.sql
@@ -162,7 +162,7 @@ with abx as
       when lower(drug) like '%zyvox%' then 1
     else 0
     end as antibiotic
-  from mimic_hosp.prescriptions
+  from mimiciv_hosp.prescriptions
   -- excludes vials/syringe/normal saline, etc
   where drug_type not in ('BASE')
   -- we exclude routes via the eye, ears, or topically
@@ -188,7 +188,7 @@ pr.subject_id, pr.hadm_id
 , pr.route
 , pr.starttime
 , pr.stoptime
-from mimic_hosp.prescriptions pr
+from mimiciv_hosp.prescriptions pr
 -- inner join to subselect to only antibiotic prescriptions
 inner join abx
     on pr.drug = abx.drug
@@ -196,7 +196,7 @@ inner join abx
     -- only ~4000 null rows in prescriptions total.
     AND pr.route = abx.route
 -- add in stay_id as we use this table for sepsis-3
-LEFT JOIN mimic_icu.icustays ie
+LEFT JOIN mimiciv_icu.icustays ie
     ON pr.hadm_id = ie.hadm_id
     AND pr.starttime >= ie.intime
     AND pr.starttime < ie.outtime

--- a/mimic-iv/concepts/postgres/medication/dobutamine.sql
+++ b/mimic-iv/concepts/postgres/medication/dobutamine.sql
@@ -8,5 +8,5 @@ stay_id, linkorderid
 , amount as vaso_amount
 , starttime
 , endtime
-from mimic_icu.inputevents
+from mimiciv_icu.inputevents
 where itemid = 221653 -- dobutamine

--- a/mimic-iv/concepts/postgres/medication/dopamine.sql
+++ b/mimic-iv/concepts/postgres/medication/dopamine.sql
@@ -8,5 +8,5 @@ stay_id, linkorderid
 , amount as vaso_amount
 , starttime
 , endtime
-from mimic_icu.inputevents
+from mimiciv_icu.inputevents
 where itemid = 221662 -- dopamine

--- a/mimic-iv/concepts/postgres/medication/epinephrine.sql
+++ b/mimic-iv/concepts/postgres/medication/epinephrine.sql
@@ -8,5 +8,5 @@ stay_id, linkorderid
 , amount as vaso_amount
 , starttime
 , endtime
-from mimic_icu.inputevents
+from mimiciv_icu.inputevents
 where itemid = 221289 -- epinephrine

--- a/mimic-iv/concepts/postgres/medication/neuroblock.sql
+++ b/mimic-iv/concepts/postgres/medication/neuroblock.sql
@@ -7,7 +7,7 @@ select
   , amount as drug_amount
   , starttime
   , endtime
-from mimic_icu.inputevents
+from mimiciv_icu.inputevents
 where itemid in
 (
     222062 -- Vecuronium (664 rows, 154 infusion rows)

--- a/mimic-iv/concepts/postgres/medication/norepinephrine.sql
+++ b/mimic-iv/concepts/postgres/medication/norepinephrine.sql
@@ -12,5 +12,5 @@ select
   , amount as vaso_amount
   , starttime
   , endtime
-from mimic_icu.inputevents
+from mimiciv_icu.inputevents
 where itemid = 221906 -- norepinephrine

--- a/mimic-iv/concepts/postgres/medication/phenylephrine.sql
+++ b/mimic-iv/concepts/postgres/medication/phenylephrine.sql
@@ -9,5 +9,5 @@ select
   , amount as vaso_amount
   , starttime
   , endtime
-from mimic_icu.inputevents
+from mimiciv_icu.inputevents
 where itemid = 221749 -- phenylephrine

--- a/mimic-iv/concepts/postgres/medication/vasopressin.sql
+++ b/mimic-iv/concepts/postgres/medication/vasopressin.sql
@@ -10,5 +10,5 @@ select
   , amount as vaso_amount
   , starttime
   , endtime
-from mimic_icu.inputevents
+from mimiciv_icu.inputevents
 where itemid = 222315 -- vasopressin

--- a/mimic-iv/concepts/postgres/organfailure/kdigo_creatinine.sql
+++ b/mimic-iv/concepts/postgres/organfailure/kdigo_creatinine.sql
@@ -8,8 +8,8 @@ WITH cr AS
         , ie.stay_id
         , le.charttime
         , AVG(le.valuenum) AS creat
-    FROM mimic_icu.icustays ie
-    LEFT JOIN mimic_hosp.labevents le
+    FROM mimiciv_icu.icustays ie
+    LEFT JOIN mimiciv_hosp.labevents le
     ON ie.subject_id = le.subject_id
     AND le.ITEMID = 50912
     AND le.VALUENUM IS NOT NULL

--- a/mimic-iv/concepts/postgres/organfailure/kdigo_stages.sql
+++ b/mimic-iv/concepts/postgres/organfailure/kdigo_stages.sql
@@ -28,7 +28,7 @@ with cr_stg AS
         when cr.creat >= (cr.creat_low_past_48hr+0.3) then 1
         when cr.creat >= (cr.creat_low_past_7day*1.5) then 1
     else 0 end as aki_stage_creat
-  FROM mimic_derived.kdigo_creatinine cr
+  FROM mimiciv_derived.kdigo_creatinine cr
 )
 -- stages for UO / creat
 , uo_stg as
@@ -52,8 +52,8 @@ with cr_stg AS
         WHEN uo.uo_tm_12hr >= 5 AND uo.uo_rt_12hr < 0.5 THEN 2
         WHEN uo.uo_tm_6hr >= 2 AND uo.uo_rt_6hr  < 0.5 THEN 1
     ELSE 0 END AS aki_stage_uo
-  from mimic_derived.kdigo_uo uo
-  INNER JOIN mimic_icu.icustays ie
+  from mimiciv_derived.kdigo_uo uo
+  INNER JOIN mimiciv_icu.icustays ie
     ON uo.stay_id = ie.stay_id
 )
 -- get all charttimes documented
@@ -85,7 +85,7 @@ select
         COALESCE(cr.aki_stage_creat,0),
         COALESCE(uo.aki_stage_uo,0)
         ) AS aki_stage
-FROM mimic_icu.icustays ie
+FROM mimiciv_icu.icustays ie
 -- get all possible charttimes as listed in tm_stg
 LEFT JOIN tm_stg tm
   ON ie.stay_id = tm.stay_id

--- a/mimic-iv/concepts/postgres/organfailure/kdigo_uo.sql
+++ b/mimic-iv/concepts/postgres/organfailure/kdigo_uo.sql
@@ -43,11 +43,11 @@ with ur_stg as
         'SECOND') AS NUMERIC)/3600.0, 4)
    AS uo_tm_12hr
   , ROUND(CAST(
-      DATETIME_DIFF(io.charttime,MIN(iosum.charttime),'SECOND')
+      DATETIME_DIFF(io.charttime, MIN(iosum.charttime), 'SECOND')
    AS NUMERIC)/3600.0, 4) AS uo_tm_24hr
-  from mimic_derived.urine_output io
+  from mimiciv_derived.urine_output io
   -- this join gives all UO measurements over the 24 hours preceding this row
-  left join mimic_derived.urine_output iosum
+  left join mimiciv_derived.urine_output iosum
     on  io.stay_id = iosum.stay_id
     and iosum.charttime <= io.charttime
     and iosum.charttime >= DATETIME_SUB(io.charttime, interval '23' hour)
@@ -69,7 +69,7 @@ select
 , uo_tm_12hr
 , uo_tm_24hr
 from ur_stg ur
-left join mimic_derived.weight_durations wd
+left join mimiciv_derived.weight_durations wd
   on  ur.stay_id = wd.stay_id
   and ur.charttime >= wd.starttime
   and ur.charttime <  wd.endtime

--- a/mimic-iv/concepts/postgres/organfailure/meld.sql
+++ b/mimic-iv/concepts/postgres/organfailure/meld.sql
@@ -58,11 +58,11 @@ SELECT
 
     , r.dialysis_present AS rrt
 
-FROM mimic_icu.icustays ie
+FROM mimiciv_icu.icustays ie
 -- join to custom tables to get more data....
-LEFT JOIN mimic_derived.first_day_lab labs
+LEFT JOIN mimiciv_derived.first_day_lab labs
   ON ie.stay_id = labs.stay_id
-LEFT JOIN mimic_derived.first_day_rrt r
+LEFT JOIN mimiciv_derived.first_day_rrt r
   ON ie.stay_id = r.stay_id
 )
 , score as

--- a/mimic-iv/concepts/postgres/postgres-make-concepts.sql
+++ b/mimic-iv/concepts/postgres/postgres-make-concepts.sql
@@ -47,10 +47,10 @@
 \i medication/milrinone.sql
 \i medication/neuroblock.sql
 \i medication/norepinephrine.sql
-\i medication/phenylephrine.sql
-\i medication/vasopressin.sql
-\i medication/vasoactive_agent.sql
 \i medication/norepinephrine_equivalent_dose.sql
+\i medication/phenylephrine.sql
+\i medication/vasoactive_agent.sql
+\i medication/vasopressin.sql
 
 -- treatment
 \i treatment/crrt.sql

--- a/mimic-iv/concepts/postgres/score/apsiii.sql
+++ b/mimic-iv/concepts/postgres/score/apsiii.sql
@@ -39,11 +39,11 @@ with pa as
   select ie.stay_id, bg.charttime
   , po2 as PaO2
   , ROW_NUMBER() over (partition by ie.stay_id ORDER BY bg.po2 DESC) as rn
-  from mimic_derived.bg bg
-  INNER JOIN mimic_icu.icustays ie
+  from mimiciv_derived.bg bg
+  INNER JOIN mimiciv_icu.icustays ie
     ON bg.hadm_id = ie.hadm_id
     AND bg.charttime >= ie.intime AND bg.charttime < ie.outtime
-  left join mimic_derived.ventilation vd
+  left join mimiciv_derived.ventilation vd
     on ie.stay_id = vd.stay_id
     and bg.charttime >= vd.starttime
     and bg.charttime <= vd.endtime
@@ -62,11 +62,11 @@ with pa as
   , bg.aado2
   , ROW_NUMBER() over (partition by ie.stay_id ORDER BY bg.aado2 DESC) as rn
   -- row number indicating the highest AaDO2
-  from mimic_derived.bg bg
-  INNER JOIN mimic_icu.icustays ie
+  from mimiciv_derived.bg bg
+  INNER JOIN mimiciv_icu.icustays ie
     ON bg.hadm_id = ie.hadm_id
     AND bg.charttime >= ie.intime AND bg.charttime < ie.outtime
-  INNER JOIN mimic_derived.ventilation vd
+  INNER JOIN mimiciv_derived.ventilation vd
     on ie.stay_id = vd.stay_id
     and bg.charttime >= vd.starttime
     and bg.charttime <= vd.endtime
@@ -127,8 +127,8 @@ with pa as
           else 12
         end
     end as acidbase_score
-  from mimic_derived.bg bg
-  INNER JOIN mimic_icu.icustays ie
+  from mimiciv_derived.bg bg
+  INNER JOIN mimiciv_icu.icustays ie
     ON bg.hadm_id = ie.hadm_id
     AND bg.charttime >= ie.intime AND bg.charttime < ie.outtime
   where ph is not null and pco2 is not null
@@ -156,10 +156,10 @@ with pa as
         and  icd.ckd = 0
           then 1
       else 0 end as arf
-  FROM mimic_icu.icustays ie
-  left join mimic_derived.first_day_urine_output uo
+  FROM mimiciv_icu.icustays ie
+  left join mimiciv_derived.first_day_urine_output uo
     on ie.stay_id = uo.stay_id
-  left join mimic_derived.first_day_lab labs
+  left join mimiciv_derived.first_day_lab labs
     on ie.stay_id = labs.stay_id
   left join
   (
@@ -171,7 +171,7 @@ with pa as
           -- we do not include 5859 as that is sometimes coded for acute-on-chronic ARF
         else 0 end)
       as ckd
-    from mimic_hosp.diagnoses_icd
+    from mimiciv_hosp.diagnoses_icd
     group by hadm_id
   ) icd
     on ie.hadm_id = icd.hadm_id
@@ -183,8 +183,8 @@ with pa as
     , MAX(
         CASE WHEN v.stay_id IS NOT NULL THEN 1 ELSE 0 END
     ) AS vent
-    FROM mimic_icu.icustays ie
-    LEFT JOIN mimic_derived.ventilation v
+    FROM mimiciv_icu.icustays ie
+    LEFT JOIN mimiciv_derived.ventilation v
         ON ie.stay_id = v.stay_id
         AND (
             v.starttime BETWEEN ie.intime AND DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -261,10 +261,10 @@ select ie.subject_id, ie.hadm_id, ie.stay_id
       -- acute renal failure
       , arf.arf as arf
 
-FROM mimic_icu.icustays ie
-inner join mimic_core.admissions adm
+FROM mimiciv_icu.icustays ie
+inner join mimiciv_hosp.admissions adm
   on ie.hadm_id = adm.hadm_id
-inner join mimic_core.patients pat
+inner join mimiciv_hosp.patients pat
   on ie.subject_id = pat.subject_id
 
 -- join to above views - the row number filters to 1 row per stay_id
@@ -283,13 +283,13 @@ left join arf
 -- join to custom tables to get more data....
 left join vent
   on ie.stay_id = vent.stay_id
-left join mimic_derived.first_day_gcs gcs
+left join mimiciv_derived.first_day_gcs gcs
   on ie.stay_id = gcs.stay_id
-left join mimic_derived.first_day_vitalsign vital
+left join mimiciv_derived.first_day_vitalsign vital
   on ie.stay_id = vital.stay_id
-left join mimic_derived.first_day_urine_output uo
+left join mimiciv_derived.first_day_urine_output uo
   on ie.stay_id = uo.stay_id
-left join mimic_derived.first_day_lab labs
+left join mimiciv_derived.first_day_lab labs
   on ie.stay_id = labs.stay_id
 )
 -- First, we calculate the score for the minimum values
@@ -856,7 +856,7 @@ select ie.subject_id, ie.hadm_id, ie.stay_id
 , glucose_score
 , acidbase_score
 , gcs_score
-FROM mimic_icu.icustays ie
+FROM mimiciv_icu.icustays ie
 left join score s
   on ie.stay_id = s.stay_id
 ;

--- a/mimic-iv/concepts/postgres/score/lods.sql
+++ b/mimic-iv/concepts/postgres/score/lods.sql
@@ -34,8 +34,8 @@ with cpap as
           WHEN lower(ce.value) LIKE '%cpap%' THEN 1
           WHEN lower(ce.value) LIKE '%bipap mask%' THEN 1
         else 0 end) as cpap
-  FROM mimic_icu.icustays ie
-  inner join mimic_icu.chartevents ce
+  FROM mimiciv_icu.icustays ie
+  inner join mimiciv_icu.chartevents ce
     on ie.stay_id = ce.stay_id
     and ce.charttime between ie.intime and DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
   where itemid = 226732
@@ -50,11 +50,11 @@ with cpap as
   , pao2fio2ratio
   , case when vd.stay_id is not null then 1 else 0 end as vent
   , case when cp.stay_id is not null then 1 else 0 end as cpap
-  from mimic_derived.bg bg
-  INNER JOIN mimic_icu.icustays ie
+  from mimiciv_derived.bg bg
+  INNER JOIN mimiciv_icu.icustays ie
     ON bg.hadm_id = ie.hadm_id
     AND bg.charttime >= ie.intime AND bg.charttime < ie.outtime
-  left join mimic_derived.ventilation vd
+  left join mimiciv_derived.ventilation vd
     on ie.stay_id = vd.stay_id
     and bg.charttime >= vd.starttime
     and bg.charttime <= vd.endtime
@@ -102,10 +102,10 @@ select  ie.subject_id
 
       , uo.urineoutput
 
-FROM mimic_icu.icustays ie
-inner join mimic_core.admissions adm
+FROM mimiciv_icu.icustays ie
+inner join mimiciv_hosp.admissions adm
   on ie.hadm_id = adm.hadm_id
-inner join mimic_core.patients pat
+inner join mimiciv_hosp.patients pat
   on ie.subject_id = pat.subject_id
 
 -- join to above view to get pao2/fio2 ratio
@@ -113,13 +113,13 @@ left join pafi2 pf
   on ie.stay_id = pf.stay_id
 
 -- join to custom tables to get more data....
-left join mimic_derived.first_day_gcs gcs
+left join mimiciv_derived.first_day_gcs gcs
   on ie.stay_id = gcs.stay_id
-left join mimic_derived.first_day_vitalsign vital
+left join mimiciv_derived.first_day_vitalsign vital
   on ie.stay_id = vital.stay_id
-left join mimic_derived.first_day_urine_output uo
+left join mimiciv_derived.first_day_urine_output uo
   on ie.stay_id = uo.stay_id
-left join mimic_derived.first_day_lab labs
+left join mimiciv_derived.first_day_lab labs
   on ie.stay_id = labs.stay_id
 )
 , scorecomp as
@@ -220,7 +220,7 @@ select ie.subject_id, ie.hadm_id, ie.stay_id
 , pulmonary
 , hematologic
 , hepatic
-FROM mimic_icu.icustays ie
+FROM mimiciv_icu.icustays ie
 left join scorecomp s
   on ie.stay_id = s.stay_id
 ;

--- a/mimic-iv/concepts/postgres/score/oasis.sql
+++ b/mimic-iv/concepts/postgres/score/oasis.sql
@@ -13,11 +13,11 @@ DROP TABLE IF EXISTS oasis; CREATE TABLE oasis AS
 --    Critical care medicine 41, no. 7 (2013): 1711-1718.
 
 -- Variables used in OASIS:
---  Heart rate, GCS, MAP, Temperature, Respiratory rate, Ventilation status (sourced FROM mimic_icu.chartevents)
+--  Heart rate, GCS, MAP, Temperature, Respiratory rate, Ventilation status (sourced FROM mimiciv_icu.chartevents)
 --  Urine output (sourced from OUTPUTEVENTS)
---  Elective surgery (sourced FROM mimic_core.admissions and SERVICES)
---  Pre-ICU in-hospital length of stay (sourced FROM mimic_core.admissions and ICUSTAYS)
---  Age (sourced FROM mimic_core.patients)
+--  Elective surgery (sourced FROM mimiciv_hosp.admissions and SERVICES)
+--  Pre-ICU in-hospital length of stay (sourced FROM mimiciv_hosp.admissions and ICUSTAYS)
+--  Age (sourced FROM mimiciv_hosp.patients)
 
 -- Regarding missing values:
 --  The ventilation flag is always 0/1. It cannot be missing, since VENT=0 if no data is found for vent settings.
@@ -34,8 +34,8 @@ with surgflag as
         when lower(curr_service) like '%surg%' then 1
         when curr_service = 'ORTHO' then 1
     else 0 end) as surgical
-  FROM mimic_icu.icustays ie
-  left join mimic_hosp.services se
+  FROM mimiciv_icu.icustays ie
+  left join mimiciv_hosp.services se
     on ie.hadm_id = se.hadm_id
     and se.transfertime < DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
   group by ie.stay_id
@@ -47,8 +47,8 @@ with surgflag as
     , MAX(
         CASE WHEN v.stay_id IS NOT NULL THEN 1 ELSE 0 END
     ) AS vent
-    FROM mimic_icu.icustays ie
-    LEFT JOIN mimic_derived.ventilation v
+    FROM mimiciv_icu.icustays ie
+    LEFT JOIN mimiciv_derived.ventilation v
         ON ie.stay_id = v.stay_id
         AND (
             v.starttime BETWEEN ie.intime AND DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -64,7 +64,7 @@ select ie.subject_id, ie.hadm_id, ie.stay_id
       , ie.intime
       , ie.outtime
       , adm.deathtime
-      , DATETIME_DIFF(ie.intime,adm.admittime,'MINUTE') as preiculos
+      , DATETIME_DIFF(ie.intime, adm.admittime, 'MINUTE') as preiculos
       , ag.age
       , gcs.gcs_min
       , vital.heart_rate_max
@@ -97,21 +97,21 @@ select ie.subject_id, ie.hadm_id, ie.stay_id
           else 0 end
         as icustay_expire_flag
       , adm.hospital_expire_flag
-FROM mimic_icu.icustays ie
-inner join mimic_core.admissions adm
+FROM mimiciv_icu.icustays ie
+inner join mimiciv_hosp.admissions adm
   on ie.hadm_id = adm.hadm_id
-inner join mimic_core.patients pat
+inner join mimiciv_hosp.patients pat
   on ie.subject_id = pat.subject_id
-LEFT JOIN mimic_derived.age ag
+LEFT JOIN mimiciv_derived.age ag
   ON ie.hadm_id = ag.hadm_id
 left join surgflag sf
   on ie.stay_id = sf.stay_id
 -- join to custom tables to get more data....
-left join mimic_derived.first_day_gcs gcs
+left join mimiciv_derived.first_day_gcs gcs
   on ie.stay_id = gcs.stay_id
-left join mimic_derived.first_day_vitalsign vital
+left join mimiciv_derived.first_day_vitalsign vital
   on ie.stay_id = vital.stay_id
-left join mimic_derived.first_day_urine_output uo
+left join mimiciv_derived.first_day_urine_output uo
   on ie.stay_id = uo.stay_id
 left join vent
   on ie.stay_id = vent.stay_id

--- a/mimic-iv/concepts/postgres/score/sirs.sql
+++ b/mimic-iv/concepts/postgres/score/sirs.sql
@@ -37,12 +37,12 @@ select ie.stay_id
   , l.wbc_min
   , l.wbc_max
   , l.bands_max
-FROM mimic_icu.icustays ie
-left join mimic_derived.first_day_bg_art bg
+FROM mimiciv_icu.icustays ie
+left join mimiciv_derived.first_day_bg_art bg
  on ie.stay_id = bg.stay_id
-left join mimic_derived.first_day_vitalsign v
+left join mimiciv_derived.first_day_vitalsign v
   on ie.stay_id = v.stay_id
-left join mimic_derived.first_day_lab l
+left join mimiciv_derived.first_day_lab l
   on ie.stay_id = l.stay_id
 )
 , scorecalc as
@@ -93,7 +93,7 @@ select
   + coalesce(wbc_score,0)
     as sirs
   , temp_score, heart_rate_score, resp_score, wbc_score
-FROM mimic_icu.icustays ie
+FROM mimiciv_icu.icustays ie
 left join scorecalc s
   on ie.stay_id = s.stay_id
 ;

--- a/mimic-iv/concepts/postgres/sepsis/sepsis3.sql
+++ b/mimic-iv/concepts/postgres/sepsis/sepsis3.sql
@@ -18,7 +18,7 @@ WITH sofa AS
     , cns_24hours as cns
     , renal_24hours as renal
     , sofa_24hours as sofa_score
-  FROM mimic_derived.sofa
+  FROM mimiciv_derived.sofa
   WHERE sofa_24hours >= 2
 )
 , s1 as
@@ -51,7 +51,7 @@ WITH sofa AS
         PARTITION BY soi.stay_id
         ORDER BY suspected_infection_time, antibiotic_time, culture_time, endtime
     ) AS rn_sus
-  FROM mimic_derived.suspicion_of_infection as soi
+  FROM mimiciv_derived.suspicion_of_infection as soi
   INNER JOIN sofa
     ON soi.stay_id = sofa.stay_id
     AND sofa.endtime >= DATETIME_SUB(soi.suspected_infection_time, INTERVAL '48' HOUR)

--- a/mimic-iv/concepts/postgres/sepsis/suspicion_of_infection.sql
+++ b/mimic-iv/concepts/postgres/sepsis/suspicion_of_infection.sql
@@ -17,7 +17,7 @@ WITH ab_tbl AS
       PARTITION BY subject_id
       ORDER BY starttime, stoptime, antibiotic
     ) AS ab_id
-  from mimic_derived.antibiotic abx
+  from mimiciv_derived.antibiotic abx
 )
 , me as
 (
@@ -30,7 +30,7 @@ WITH ab_tbl AS
     , MAX(charttime) AS charttime
     , MAX(spec_type_desc) AS spec_type_desc
     , max(case when org_name is not null and org_name != '' then 1 else 0 end) as PositiveCulture
-  from mimic_hosp.microbiologyevents
+  from mimiciv_hosp.microbiologyevents
   group by micro_specimen_id
 )
 -- culture followed by an antibiotic

--- a/mimic-iv/concepts/postgres/treatment/crrt.sql
+++ b/mimic-iv/concepts/postgres/treatment/crrt.sql
@@ -51,7 +51,7 @@ with crrt_settings as
         AND ce.value IN ('Clotted')
             THEN 1
     ELSE NULL END as clotted
-  from mimic_icu.chartevents ce
+  from mimiciv_icu.chartevents ce
   where ce.itemid in
   (
     -- MetaVision ITEMIDs

--- a/mimic-iv/concepts/postgres/treatment/invasive_line.sql
+++ b/mimic-iv/concepts/postgres/treatment/invasive_line.sql
@@ -11,8 +11,8 @@ WITH mv AS
         , di.label AS line_type
         , mv.location AS line_site
         , starttime, endtime
-    FROM mimic_icu.procedureevents mv
-    INNER JOIN mimic_icu.d_items di
+    FROM mimiciv_icu.procedureevents mv
+    INNER JOIN mimiciv_icu.d_items di
       ON mv.itemid = di.itemid
     WHERE mv.itemid IN
     (

--- a/mimic-iv/concepts/postgres/treatment/rrt.sql
+++ b/mimic-iv/concepts/postgres/treatment/rrt.sql
@@ -135,7 +135,7 @@ with ce as
         WHEN ce.itemid = 226499
           THEN 'IHD'
       ELSE NULL END as dialysis_type
-  from mimic_icu.chartevents ce
+  from mimiciv_icu.chartevents ce
   WHERE ce.itemid in
   (
     -- === MetaVision itemids === --
@@ -206,7 +206,7 @@ with ce as
     , 1 AS dialysis_present
     , 0 AS dialysis_active
     , NULL AS dialysis_type
- from mimic_icu.outputevents
+ from mimiciv_icu.outputevents
  where itemid in
  (
        40386 -- hemodialysis
@@ -220,7 +220,7 @@ with ce as
     , 1 AS dialysis_present
     , 1 AS dialysis_active
     , 'CRRT' as dialysis_type
-  from mimic_icu.inputevents
+  from mimiciv_icu.inputevents
   where itemid in
   (
       227536 --	KCl (CRRT)	Medications	inputevents_mv	Solution
@@ -240,7 +240,7 @@ with ce as
         WHEN itemid = 225809 THEN 'CVVHDF' -- CVVHDF (Continuous venovenous hemodiafiltration)
         WHEN itemid = 225955 THEN 'SCUF' -- SCUF (Slow continuous ultra filtration)
       ELSE NULL END as dialysis_type
-  from mimic_icu.procedureevents
+  from mimiciv_icu.procedureevents
   where itemid in
   (
       225441 -- | Hemodialysis          | 4-Procedures              | procedureevents_mv | Process

--- a/mimic-iv/concepts/postgres/treatment/ventilation.sql
+++ b/mimic-iv/concepts/postgres/treatment/ventilation.sql
@@ -24,10 +24,10 @@ DROP TABLE IF EXISTS ventilation; CREATE TABLE ventilation AS
 WITH tm AS
 (
   SELECT stay_id, charttime
-  FROM mimic_derived.ventilator_setting
+  FROM mimiciv_derived.ventilator_setting
   UNION DISTINCT
   SELECT stay_id, charttime
-  FROM mimic_derived.oxygen_delivery
+  FROM mimiciv_derived.oxygen_delivery
 )
 , vs AS
 (
@@ -147,10 +147,10 @@ WITH tm AS
     -- not categorized: other
     ELSE NULL END AS ventilation_status
   FROM tm
-  LEFT JOIN mimic_derived.ventilator_setting vs
+  LEFT JOIN mimiciv_derived.ventilator_setting vs
       ON tm.stay_id = vs.stay_id
       AND tm.charttime = vs.charttime
-  LEFT JOIN mimic_derived.oxygen_delivery od
+  LEFT JOIN mimiciv_derived.oxygen_delivery od
       ON tm.stay_id = od.stay_id
       AND tm.charttime = od.charttime
 )
@@ -186,14 +186,14 @@ WITH tm AS
         -- , vent_mode
 
         -- calculate the time since the last event
-        , DATETIME_DIFF(charttime,charttime_lag,'MINUTE')/60 as ventduration
+        , DATETIME_DIFF(charttime, charttime_lag, 'MINUTE')/60 as ventduration
 
         -- now we determine if the current ventilation status is "new", or continuing the previous
         , CASE
             -- if lag is null, this is the first event for the patient
             WHEN ventilation_status_lag IS NULL THEN 1
             -- a 14 hour gap always initiates a new event
-            WHEN DATETIME_DIFF(charttime,charttime_lag,'HOUR') >= 14 THEN 1
+            WHEN DATETIME_DIFF(charttime, charttime_lag, 'HOUR') >= 14 THEN 1
             -- not a new event if identical to the last row
             WHEN ventilation_status_lag != ventilation_status THEN 1
           ELSE 0
@@ -224,7 +224,7 @@ SELECT stay_id
   , MAX(
         CASE
             WHEN charttime_lead IS NULL
-            OR DATETIME_DIFF(charttime_lead,charttime,'HOUR') >= 14
+            OR DATETIME_DIFF(charttime_lead, charttime, 'HOUR') >= 14
                 THEN charttime
         ELSE charttime_lead
         END

--- a/mimic-iv/concepts/score/apsiii.sql
+++ b/mimic-iv/concepts/score/apsiii.sql
@@ -260,9 +260,9 @@ select ie.subject_id, ie.hadm_id, ie.stay_id
       , arf.arf as arf
 
 FROM `physionet-data.mimic_icu.icustays` ie
-inner join `physionet-data.mimic_core.admissions` adm
+inner join `physionet-data.mimic_hosp.admissions` adm
   on ie.hadm_id = adm.hadm_id
-inner join `physionet-data.mimic_core.patients` pat
+inner join `physionet-data.mimic_hosp.patients` pat
   on ie.subject_id = pat.subject_id
 
 -- join to above views - the row number filters to 1 row per stay_id

--- a/mimic-iv/concepts/score/apsiii.sql
+++ b/mimic-iv/concepts/score/apsiii.sql
@@ -37,11 +37,11 @@ with pa as
   select ie.stay_id, bg.charttime
   , po2 as PaO2
   , ROW_NUMBER() over (partition by ie.stay_id ORDER BY bg.po2 DESC) as rn
-  from `physionet-data.mimic_derived.bg` bg
-  INNER JOIN `physionet-data.mimic_icu.icustays` ie
+  from `physionet-data.mimiciv_derived.bg` bg
+  INNER JOIN `physionet-data.mimiciv_icu.icustays` ie
     ON bg.hadm_id = ie.hadm_id
     AND bg.charttime >= ie.intime AND bg.charttime < ie.outtime
-  left join `physionet-data.mimic_derived.ventilation` vd
+  left join `physionet-data.mimiciv_derived.ventilation` vd
     on ie.stay_id = vd.stay_id
     and bg.charttime >= vd.starttime
     and bg.charttime <= vd.endtime
@@ -60,11 +60,11 @@ with pa as
   , bg.aado2
   , ROW_NUMBER() over (partition by ie.stay_id ORDER BY bg.aado2 DESC) as rn
   -- row number indicating the highest AaDO2
-  from `physionet-data.mimic_derived.bg` bg
-  INNER JOIN `physionet-data.mimic_icu.icustays` ie
+  from `physionet-data.mimiciv_derived.bg` bg
+  INNER JOIN `physionet-data.mimiciv_icu.icustays` ie
     ON bg.hadm_id = ie.hadm_id
     AND bg.charttime >= ie.intime AND bg.charttime < ie.outtime
-  INNER JOIN `physionet-data.mimic_derived.ventilation` vd
+  INNER JOIN `physionet-data.mimiciv_derived.ventilation` vd
     on ie.stay_id = vd.stay_id
     and bg.charttime >= vd.starttime
     and bg.charttime <= vd.endtime
@@ -125,8 +125,8 @@ with pa as
           else 12
         end
     end as acidbase_score
-  from `physionet-data.mimic_derived.bg` bg
-  INNER JOIN `physionet-data.mimic_icu.icustays` ie
+  from `physionet-data.mimiciv_derived.bg` bg
+  INNER JOIN `physionet-data.mimiciv_icu.icustays` ie
     ON bg.hadm_id = ie.hadm_id
     AND bg.charttime >= ie.intime AND bg.charttime < ie.outtime
   where ph is not null and pco2 is not null
@@ -154,10 +154,10 @@ with pa as
         and  icd.ckd = 0
           then 1
       else 0 end as arf
-  FROM `physionet-data.mimic_icu.icustays` ie
-  left join `physionet-data.mimic_derived.first_day_urine_output` uo
+  FROM `physionet-data.mimiciv_icu.icustays` ie
+  left join `physionet-data.mimiciv_derived.first_day_urine_output` uo
     on ie.stay_id = uo.stay_id
-  left join `physionet-data.mimic_derived.first_day_lab` labs
+  left join `physionet-data.mimiciv_derived.first_day_lab` labs
     on ie.stay_id = labs.stay_id
   left join
   (
@@ -169,7 +169,7 @@ with pa as
           -- we do not include 5859 as that is sometimes coded for acute-on-chronic ARF
         else 0 end)
       as ckd
-    from `physionet-data.mimic_hosp.diagnoses_icd`
+    from `physionet-data.mimiciv_hosp.diagnoses_icd`
     group by hadm_id
   ) icd
     on ie.hadm_id = icd.hadm_id
@@ -181,8 +181,8 @@ with pa as
     , MAX(
         CASE WHEN v.stay_id IS NOT NULL THEN 1 ELSE 0 END
     ) AS vent
-    FROM `physionet-data.mimic_icu.icustays` ie
-    LEFT JOIN `physionet-data.mimic_derived.ventilation` v
+    FROM `physionet-data.mimiciv_icu.icustays` ie
+    LEFT JOIN `physionet-data.mimiciv_derived.ventilation` v
         ON ie.stay_id = v.stay_id
         AND (
             v.starttime BETWEEN ie.intime AND DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
@@ -259,10 +259,10 @@ select ie.subject_id, ie.hadm_id, ie.stay_id
       -- acute renal failure
       , arf.arf as arf
 
-FROM `physionet-data.mimic_icu.icustays` ie
-inner join `physionet-data.mimic_hosp.admissions` adm
+FROM `physionet-data.mimiciv_icu.icustays` ie
+inner join `physionet-data.mimiciv_hosp.admissions` adm
   on ie.hadm_id = adm.hadm_id
-inner join `physionet-data.mimic_hosp.patients` pat
+inner join `physionet-data.mimiciv_hosp.patients` pat
   on ie.subject_id = pat.subject_id
 
 -- join to above views - the row number filters to 1 row per stay_id
@@ -281,13 +281,13 @@ left join arf
 -- join to custom tables to get more data....
 left join vent
   on ie.stay_id = vent.stay_id
-left join `physionet-data.mimic_derived.first_day_gcs` gcs
+left join `physionet-data.mimiciv_derived.first_day_gcs` gcs
   on ie.stay_id = gcs.stay_id
-left join `physionet-data.mimic_derived.first_day_vitalsign` vital
+left join `physionet-data.mimiciv_derived.first_day_vitalsign` vital
   on ie.stay_id = vital.stay_id
-left join `physionet-data.mimic_derived.first_day_urine_output` uo
+left join `physionet-data.mimiciv_derived.first_day_urine_output` uo
   on ie.stay_id = uo.stay_id
-left join `physionet-data.mimic_derived.first_day_lab` labs
+left join `physionet-data.mimiciv_derived.first_day_lab` labs
   on ie.stay_id = labs.stay_id
 )
 -- First, we calculate the score for the minimum values
@@ -854,7 +854,7 @@ select ie.subject_id, ie.hadm_id, ie.stay_id
 , glucose_score
 , acidbase_score
 , gcs_score
-FROM `physionet-data.mimic_icu.icustays` ie
+FROM `physionet-data.mimiciv_icu.icustays` ie
 left join score s
   on ie.stay_id = s.stay_id
 ;

--- a/mimic-iv/concepts/score/lods.sql
+++ b/mimic-iv/concepts/score/lods.sql
@@ -32,8 +32,8 @@ with cpap as
           WHEN lower(ce.value) LIKE '%cpap%' THEN 1
           WHEN lower(ce.value) LIKE '%bipap mask%' THEN 1
         else 0 end) as cpap
-  FROM `physionet-data.mimic_icu.icustays` ie
-  inner join `physionet-data.mimic_icu.chartevents` ce
+  FROM `physionet-data.mimiciv_icu.icustays` ie
+  inner join `physionet-data.mimiciv_icu.chartevents` ce
     on ie.stay_id = ce.stay_id
     and ce.charttime between ie.intime and DATETIME_ADD(ie.intime, INTERVAL '1' DAY)
   where itemid = 226732
@@ -48,11 +48,11 @@ with cpap as
   , pao2fio2ratio
   , case when vd.stay_id is not null then 1 else 0 end as vent
   , case when cp.stay_id is not null then 1 else 0 end as cpap
-  from `physionet-data.mimic_derived.bg` bg
-  INNER JOIN `physionet-data.mimic_icu.icustays` ie
+  from `physionet-data.mimiciv_derived.bg` bg
+  INNER JOIN `physionet-data.mimiciv_icu.icustays` ie
     ON bg.hadm_id = ie.hadm_id
     AND bg.charttime >= ie.intime AND bg.charttime < ie.outtime
-  left join `physionet-data.mimic_derived.ventilation` vd
+  left join `physionet-data.mimiciv_derived.ventilation` vd
     on ie.stay_id = vd.stay_id
     and bg.charttime >= vd.starttime
     and bg.charttime <= vd.endtime
@@ -100,10 +100,10 @@ select  ie.subject_id
 
       , uo.urineoutput
 
-FROM `physionet-data.mimic_icu.icustays` ie
-inner join `physionet-data.mimic_hosp.admissions` adm
+FROM `physionet-data.mimiciv_icu.icustays` ie
+inner join `physionet-data.mimiciv_hosp.admissions` adm
   on ie.hadm_id = adm.hadm_id
-inner join `physionet-data.mimic_hosp.patients` pat
+inner join `physionet-data.mimiciv_hosp.patients` pat
   on ie.subject_id = pat.subject_id
 
 -- join to above view to get pao2/fio2 ratio
@@ -111,13 +111,13 @@ left join pafi2 pf
   on ie.stay_id = pf.stay_id
 
 -- join to custom tables to get more data....
-left join `physionet-data.mimic_derived.first_day_gcs` gcs
+left join `physionet-data.mimiciv_derived.first_day_gcs` gcs
   on ie.stay_id = gcs.stay_id
-left join `physionet-data.mimic_derived.first_day_vitalsign` vital
+left join `physionet-data.mimiciv_derived.first_day_vitalsign` vital
   on ie.stay_id = vital.stay_id
-left join `physionet-data.mimic_derived.first_day_urine_output` uo
+left join `physionet-data.mimiciv_derived.first_day_urine_output` uo
   on ie.stay_id = uo.stay_id
-left join `physionet-data.mimic_derived.first_day_lab` labs
+left join `physionet-data.mimiciv_derived.first_day_lab` labs
   on ie.stay_id = labs.stay_id
 )
 , scorecomp as
@@ -218,7 +218,7 @@ select ie.subject_id, ie.hadm_id, ie.stay_id
 , pulmonary
 , hematologic
 , hepatic
-FROM `physionet-data.mimic_icu.icustays` ie
+FROM `physionet-data.mimiciv_icu.icustays` ie
 left join scorecomp s
   on ie.stay_id = s.stay_id
 ;

--- a/mimic-iv/concepts/score/lods.sql
+++ b/mimic-iv/concepts/score/lods.sql
@@ -101,9 +101,9 @@ select  ie.subject_id
       , uo.urineoutput
 
 FROM `physionet-data.mimic_icu.icustays` ie
-inner join `physionet-data.mimic_core.admissions` adm
+inner join `physionet-data.mimic_hosp.admissions` adm
   on ie.hadm_id = adm.hadm_id
-inner join `physionet-data.mimic_core.patients` pat
+inner join `physionet-data.mimic_hosp.patients` pat
   on ie.subject_id = pat.subject_id
 
 -- join to above view to get pao2/fio2 ratio

--- a/mimic-iv/concepts/score/oasis.sql
+++ b/mimic-iv/concepts/score/oasis.sql
@@ -13,9 +13,9 @@
 -- Variables used in OASIS:
 --  Heart rate, GCS, MAP, Temperature, Respiratory rate, Ventilation status (sourced FROM `physionet-data.mimic_icu.chartevents`)
 --  Urine output (sourced from OUTPUTEVENTS)
---  Elective surgery (sourced FROM `physionet-data.mimic_core.admissions` and SERVICES)
---  Pre-ICU in-hospital length of stay (sourced FROM `physionet-data.mimic_core.admissions` and ICUSTAYS)
---  Age (sourced FROM `physionet-data.mimic_core.patients`)
+--  Elective surgery (sourced FROM `physionet-data.mimic_hosp.admissions` and SERVICES)
+--  Pre-ICU in-hospital length of stay (sourced FROM `physionet-data.mimic_hosp.admissions` and ICUSTAYS)
+--  Age (sourced FROM `physionet-data.mimic_hosp.patients`)
 
 -- Regarding missing values:
 --  The ventilation flag is always 0/1. It cannot be missing, since VENT=0 if no data is found for vent settings.
@@ -96,9 +96,9 @@ select ie.subject_id, ie.hadm_id, ie.stay_id
         as icustay_expire_flag
       , adm.hospital_expire_flag
 FROM `physionet-data.mimic_icu.icustays` ie
-inner join `physionet-data.mimic_core.admissions` adm
+inner join `physionet-data.mimic_hosp.admissions` adm
   on ie.hadm_id = adm.hadm_id
-inner join `physionet-data.mimic_core.patients` pat
+inner join `physionet-data.mimic_hosp.patients` pat
   on ie.subject_id = pat.subject_id
 LEFT JOIN `physionet-data.mimic_derived.age` ag
   ON ie.hadm_id = ag.hadm_id

--- a/mimic-iv/concepts/score/sapsii.sql
+++ b/mimic-iv/concepts/score/sapsii.sql
@@ -24,7 +24,7 @@ with co as
         , stay_id
         , intime AS starttime
         , DATETIME_ADD(intime, INTERVAL '24' HOUR) AS endtime
-    from `physionet-data.mimic_icu.icustays` ie
+    from `physionet-data.mimiciv_icu.icustays` ie
 )
 , cpap as
 (
@@ -35,7 +35,7 @@ with co as
     , LEAST(max(DATETIME_ADD(charttime, INTERVAL '4' HOUR)), co.endtime) as endtime
     , max(case when REGEXP_CONTAINS(lower(ce.value), '(cpap mask|bipap)') then 1 else 0 end) as cpap
   from co
-  inner join `physionet-data.mimic_icu.chartevents` ce
+  inner join `physionet-data.mimiciv_icu.chartevents` ce
     on co.stay_id = ce.stay_id
     and ce.charttime > co.starttime
     and ce.charttime <= co.endtime
@@ -55,8 +55,8 @@ with co as
       PARTITION BY adm.HADM_ID
       ORDER BY TRANSFERTIME
     ) as serviceOrder
-  from `physionet-data.mimic_hosp.admissions` adm
-  left join `physionet-data.mimic_hosp.services` se
+  from `physionet-data.mimiciv_hosp.admissions` adm
+  left join `physionet-data.mimiciv_hosp.services` se
     on adm.hadm_id = se.hadm_id
 )
 -- icd-9 diagnostic codes are our best source for comorbidity information
@@ -98,7 +98,7 @@ select hadm_id
     WHEN icd_version = 10 AND SUBSTR(icd_code, 1, 3) BETWEEN 'C77' AND 'C79' THEN 1
     WHEN icd_version = 10 AND SUBSTR(icd_code, 1, 4) = 'C800' THEN 1
     ELSE 0 END) as mets      /* Metastatic cancer */
-    from `physionet-data.mimic_hosp.diagnoses_icd`
+    from `physionet-data.mimiciv_hosp.diagnoses_icd`
   group by hadm_id
 )
 
@@ -113,12 +113,12 @@ select hadm_id
   , case when vd.stay_id is not null then 1 else 0 end as vent
   , case when cp.subject_id is not null then 1 else 0 end as cpap
   from co
-  LEFT JOIN `physionet-data.mimic_derived.bg` bg
+  LEFT JOIN `physionet-data.mimiciv_derived.bg` bg
     ON co.subject_id = bg.subject_id
     AND bg.specimen = 'ART.'
     AND bg.charttime > co.starttime
     AND bg.charttime <= co.endtime
-  left join `physionet-data.mimic_derived.ventilation` vd
+  left join `physionet-data.mimiciv_derived.ventilation` vd
     on co.stay_id = vd.stay_id
     and bg.charttime > vd.starttime
     and bg.charttime <= vd.endtime
@@ -143,7 +143,7 @@ select hadm_id
     select co.stay_id
     , MIN(gcs.gcs) AS mingcs
     FROM co
-    left join `physionet-data.mimic_derived.gcs` gcs
+    left join `physionet-data.mimiciv_derived.gcs` gcs
     ON co.stay_id = gcs.stay_id
     AND co.starttime < gcs.charttime
     AND gcs.charttime <= co.endtime
@@ -161,7 +161,7 @@ select hadm_id
       , MIN(vital.temperature) AS tempc_min
       , MAX(vital.temperature) AS tempc_max
     FROM co
-    left join `physionet-data.mimic_derived.vitalsign` vital
+    left join `physionet-data.mimiciv_derived.vitalsign` vital
       on co.subject_id = vital.subject_id
       AND co.starttime < vital.charttime
       AND co.endtime >= vital.charttime
@@ -173,7 +173,7 @@ select hadm_id
         co.stay_id
       , SUM(uo.urineoutput) as urineoutput
     FROM co
-    left join `physionet-data.mimic_derived.urine_output` uo
+    left join `physionet-data.mimiciv_derived.urine_output` uo
       on co.stay_id = uo.stay_id
       AND co.starttime < uo.charttime
       AND co.endtime >= uo.charttime
@@ -192,7 +192,7 @@ select hadm_id
       , MIN(labs.bicarbonate) AS bicarbonate_min
       , MAX(labs.bicarbonate) AS bicarbonate_max               
     FROM co
-    left join `physionet-data.mimic_derived.chemistry` labs
+    left join `physionet-data.mimiciv_derived.chemistry` labs
       on co.subject_id = labs.subject_id
       AND co.starttime < labs.charttime
       AND co.endtime >= labs.charttime
@@ -205,7 +205,7 @@ select hadm_id
       , MIN(cbc.wbc) AS wbc_min
       , MAX(cbc.wbc) AS wbc_max  
     FROM co
-    LEFT JOIN `physionet-data.mimic_derived.complete_blood_count` cbc
+    LEFT JOIN `physionet-data.mimiciv_derived.complete_blood_count` cbc
       ON co.subject_id = cbc.subject_id
       AND co.starttime < cbc.charttime
       AND co.endtime >= cbc.charttime
@@ -218,7 +218,7 @@ select hadm_id
       , MIN(enz.bilirubin_total) AS bilirubin_min
       , MAX(enz.bilirubin_total) AS bilirubin_max  
     FROM co
-    LEFT JOIN `physionet-data.mimic_derived.enzyme` enz
+    LEFT JOIN `physionet-data.mimiciv_derived.enzyme` enz
       ON co.subject_id = enz.subject_id
       AND co.starttime < enz.charttime
       AND co.endtime >= enz.charttime
@@ -276,10 +276,10 @@ select
         end as AdmissionType
 
 
-from `physionet-data.mimic_icu.icustays` ie
-inner join `physionet-data.mimic_hosp.admissions` adm
+from `physionet-data.mimiciv_icu.icustays` ie
+inner join `physionet-data.mimiciv_hosp.admissions` adm
   on ie.hadm_id = adm.hadm_id
-LEFT JOIN `physionet-data.mimic_derived.age` va
+LEFT JOIN `physionet-data.mimiciv_derived.age` va
   on ie.hadm_id = va.hadm_id
 inner join co
   on ie.stay_id = co.stay_id

--- a/mimic-iv/concepts/score/sapsii.sql
+++ b/mimic-iv/concepts/score/sapsii.sql
@@ -55,7 +55,7 @@ with co as
       PARTITION BY adm.HADM_ID
       ORDER BY TRANSFERTIME
     ) as serviceOrder
-  from `physionet-data.mimic_core.admissions` adm
+  from `physionet-data.mimic_hosp.admissions` adm
   left join `physionet-data.mimic_hosp.services` se
     on adm.hadm_id = se.hadm_id
 )
@@ -277,7 +277,7 @@ select
 
 
 from `physionet-data.mimic_icu.icustays` ie
-inner join `physionet-data.mimic_core.admissions` adm
+inner join `physionet-data.mimic_hosp.admissions` adm
   on ie.hadm_id = adm.hadm_id
 LEFT JOIN `physionet-data.mimic_derived.age` va
   on ie.hadm_id = va.hadm_id

--- a/mimic-iv/concepts/score/sirs.sql
+++ b/mimic-iv/concepts/score/sirs.sql
@@ -35,12 +35,12 @@ select ie.stay_id
   , l.wbc_min
   , l.wbc_max
   , l.bands_max
-FROM `physionet-data.mimic_icu.icustays` ie
-left join `physionet-data.mimic_derived.first_day_bg_art` bg
+FROM `physionet-data.mimiciv_icu.icustays` ie
+left join `physionet-data.mimiciv_derived.first_day_bg_art` bg
  on ie.stay_id = bg.stay_id
-left join `physionet-data.mimic_derived.first_day_vitalsign` v
+left join `physionet-data.mimiciv_derived.first_day_vitalsign` v
   on ie.stay_id = v.stay_id
-left join `physionet-data.mimic_derived.first_day_lab` l
+left join `physionet-data.mimiciv_derived.first_day_lab` l
   on ie.stay_id = l.stay_id
 )
 , scorecalc as
@@ -91,7 +91,7 @@ select
   + coalesce(wbc_score,0)
     as sirs
   , temp_score, heart_rate_score, resp_score, wbc_score
-FROM `physionet-data.mimic_icu.icustays` ie
+FROM `physionet-data.mimiciv_icu.icustays` ie
 left join scorecalc s
   on ie.stay_id = s.stay_id
 ;

--- a/mimic-iv/concepts/sepsis/sepsis3.sql
+++ b/mimic-iv/concepts/sepsis/sepsis3.sql
@@ -16,7 +16,7 @@ WITH sofa AS
     , cns_24hours as cns
     , renal_24hours as renal
     , sofa_24hours as sofa_score
-  FROM `physionet-data.mimic_derived.sofa`
+  FROM `physionet-data.mimiciv_derived.sofa`
   WHERE sofa_24hours >= 2
 )
 , s1 as
@@ -49,7 +49,7 @@ WITH sofa AS
         PARTITION BY soi.stay_id
         ORDER BY suspected_infection_time, antibiotic_time, culture_time, endtime
     ) AS rn_sus
-  FROM `physionet-data.mimic_derived.suspicion_of_infection` as soi
+  FROM `physionet-data.mimiciv_derived.suspicion_of_infection` as soi
   INNER JOIN sofa
     ON soi.stay_id = sofa.stay_id
     AND sofa.endtime >= DATETIME_SUB(soi.suspected_infection_time, INTERVAL '48' HOUR)

--- a/mimic-iv/concepts/sepsis/suspicion_of_infection.sql
+++ b/mimic-iv/concepts/sepsis/suspicion_of_infection.sql
@@ -15,7 +15,7 @@ WITH ab_tbl AS
       PARTITION BY subject_id
       ORDER BY starttime, stoptime, antibiotic
     ) AS ab_id
-  from `physionet-data.mimic_derived.antibiotic` abx
+  from `physionet-data.mimiciv_derived.antibiotic` abx
 )
 , me as
 (
@@ -28,7 +28,7 @@ WITH ab_tbl AS
     , MAX(charttime) AS charttime
     , MAX(spec_type_desc) AS spec_type_desc
     , max(case when org_name is not null and org_name != '' then 1 else 0 end) as PositiveCulture
-  from `physionet-data.mimic_hosp.microbiologyevents`
+  from `physionet-data.mimiciv_hosp.microbiologyevents`
   group by micro_specimen_id
 )
 -- culture followed by an antibiotic

--- a/mimic-iv/concepts/treatment/crrt.sql
+++ b/mimic-iv/concepts/treatment/crrt.sql
@@ -49,7 +49,7 @@ with crrt_settings as
         AND ce.value IN ('Clotted')
             THEN 1
     ELSE NULL END as clotted
-  from `physionet-data.mimic_icu.chartevents` ce
+  from `physionet-data.mimiciv_icu.chartevents` ce
   where ce.itemid in
   (
     -- MetaVision ITEMIDs

--- a/mimic-iv/concepts/treatment/invasive_line.sql
+++ b/mimic-iv/concepts/treatment/invasive_line.sql
@@ -9,8 +9,8 @@ WITH mv AS
         , di.label AS line_type
         , mv.location AS line_site
         , starttime, endtime
-    FROM `physionet-data.mimic_icu.procedureevents` mv
-    INNER JOIN `physionet-data.mimic_icu.d_items` di
+    FROM `physionet-data.mimiciv_icu.procedureevents` mv
+    INNER JOIN `physionet-data.mimiciv_icu.d_items` di
       ON mv.itemid = di.itemid
     WHERE mv.itemid IN
     (

--- a/mimic-iv/concepts/treatment/rrt.sql
+++ b/mimic-iv/concepts/treatment/rrt.sql
@@ -133,7 +133,7 @@ with ce as
         WHEN ce.itemid = 226499
           THEN 'IHD'
       ELSE NULL END as dialysis_type
-  from `physionet-data.mimic_icu.chartevents` ce
+  from `physionet-data.mimiciv_icu.chartevents` ce
   WHERE ce.itemid in
   (
     -- === MetaVision itemids === --
@@ -204,7 +204,7 @@ with ce as
     , 1 AS dialysis_present
     , 0 AS dialysis_active
     , NULL AS dialysis_type
- from `physionet-data.mimic_icu.outputevents`
+ from `physionet-data.mimiciv_icu.outputevents`
  where itemid in
  (
        40386 -- hemodialysis
@@ -218,7 +218,7 @@ with ce as
     , 1 AS dialysis_present
     , 1 AS dialysis_active
     , 'CRRT' as dialysis_type
-  from `physionet-data.mimic_icu.inputevents`
+  from `physionet-data.mimiciv_icu.inputevents`
   where itemid in
   (
       227536 --	KCl (CRRT)	Medications	inputevents_mv	Solution
@@ -238,7 +238,7 @@ with ce as
         WHEN itemid = 225809 THEN 'CVVHDF' -- CVVHDF (Continuous venovenous hemodiafiltration)
         WHEN itemid = 225955 THEN 'SCUF' -- SCUF (Slow continuous ultra filtration)
       ELSE NULL END as dialysis_type
-  from `physionet-data.mimic_icu.procedureevents`
+  from `physionet-data.mimiciv_icu.procedureevents`
   where itemid in
   (
       225441 -- | Hemodialysis          | 4-Procedures              | procedureevents_mv | Process

--- a/mimic-iv/concepts/treatment/ventilation.sql
+++ b/mimic-iv/concepts/treatment/ventilation.sql
@@ -22,10 +22,10 @@
 WITH tm AS
 (
   SELECT stay_id, charttime
-  FROM `physionet-data.mimic_derived.ventilator_setting`
+  FROM `physionet-data.mimiciv_derived.ventilator_setting`
   UNION DISTINCT
   SELECT stay_id, charttime
-  FROM `physionet-data.mimic_derived.oxygen_delivery`
+  FROM `physionet-data.mimiciv_derived.oxygen_delivery`
 )
 , vs AS
 (
@@ -145,10 +145,10 @@ WITH tm AS
     -- not categorized: other
     ELSE NULL END AS ventilation_status
   FROM tm
-  LEFT JOIN `physionet-data.mimic_derived.ventilator_setting` vs
+  LEFT JOIN `physionet-data.mimiciv_derived.ventilator_setting` vs
       ON tm.stay_id = vs.stay_id
       AND tm.charttime = vs.charttime
-  LEFT JOIN `physionet-data.mimic_derived.oxygen_delivery` od
+  LEFT JOIN `physionet-data.mimiciv_derived.oxygen_delivery` od
       ON tm.stay_id = od.stay_id
       AND tm.charttime = od.charttime
 )


### PR DESCRIPTION
This PR updates the derived concepts to work for MIMIC-IV v2.0. It also fixes some incompatibilities in trying to run the `convert_bigquery_to_postgres.sh` script on Mac OS X as it has BSD sed and bash 3.x by default (as opposed to GNU sed and bash 4.x+ on Ubuntu).

Almost all concepts are materially unchanged, but file changes exist, as the schema prefix has been changed from `mimic_` to `mimiciv_`. The only real change is from `ethnicity` to `race` in the icustay_detail table.