### PR TITLE
mimic-iv/buildmimic/sqlite/import.py: replace `strip()`

### DIFF
--- a/mimic-iv/buildmimic/sqlite/import.py
+++ b/mimic-iv/buildmimic/sqlite/import.py
@@ -17,7 +17,11 @@ if os.path.exists(DATABASE_NAME):
 for f in glob("**/*.csv*", recursive=True):
     print("Starting processing {}".format(f))
     folder, filename = os.path.split(f)
-    tablename = filename.strip(".gz").strip(".csv").lower()
+    tablename = filename.lower()
+    if tablename.endswith('.gz'):
+        tablename = tablename[:-3]
+    if tablename.endswith('.csv'):
+        tablename = tablename[:-4]
     if os.path.getsize(f) < THRESHOLD_SIZE:
         df = pd.read_csv(f)
         df.to_sql(tablename, CONNECTION_STRING)


### PR DESCRIPTION
`strip()` removes any of the given characters from both the start and
end of a string: https://docs.python.org/3/library/stdtypes.html#str.strip
For a filename "chartevents.csv.gz" the resulting tablename currently is
"hartevent" where it should be "chartevents".

    'chartevents'.strip('.gz').strip('.csv').lower()

Instead, strip the suffixes manually to derive the tablename from the
filename.

Later, we could use `removesuffix()`, which is available from Python 3.9
onwards: https://docs.python.org/3/library/stdtypes.html#str.removesuffix