### PR TITLE
mimic-iv/buildmimic/sqlite/README: mention sqlalchemy requirement

### DIFF
--- a/mimic-iv/buildmimic/sqlite/README.md
+++ b/mimic-iv/buildmimic/sqlite/README.md
@@ -17,6 +17,7 @@ into memory. It only needs three things to run:
 1. Python 3 installed
 2. SQLite
 3. [pandas](https://pandas.pydata.org/)
+4. [sqlalchemy](https://www.sqlalchemy.org/)
 
 ## Step 1: Download the CSV or CSV.GZ files.
 


### PR DESCRIPTION
Without sqlalchemy installed, pandas throws the following error:

```
[...]
  File "/.../import.py", line 23, in <module>
    df.to_sql(tablename, CONNECTION_STRING)
[...]
  File "/.../python3.10/site-packages/pandas/io/sql.py", line 754, in pandasSQL_builder
    raise ImportError("Using URI string without sqlalchemy installed.")
ImportError: Using URI string without sqlalchemy installed.
```