### PR TITLE
mimic-iv/buildmimic/sqlite/README: remove "edit step"

### DIFF
--- a/mimic-iv/buildmimic/sqlite/README.md
+++ b/mimic-iv/buildmimic/sqlite/README.md
@@ -39,17 +39,7 @@ path/to/mimic-iv/
     └── procedureevents.csv.gz
 ```
 
-## Step 2: Edit the script if needed.
-
-`import.sh` does **not** need edits to work with either the demo or full dataset.
-Please continue to Step 3.
-
-If you are using the `import.py` script,
-it may be necessary to make minor edits to the `import.py` script. For example:
-
-- If your files are `.csv` rather than `csv.gz`, you will need to change `csv.gz` to `csv`.
-
-## Step 3: Generate the SQLite file
+## Step 2: Generate the SQLite file
 
 To generate the SQLite file:
 


### PR DESCRIPTION
Since 2e9e0bd8aa0bf0129cc8c88c2fcb7ba859b50755 the `import.py` script
can handle both `.csv` and `.csv.gz` files. As far as I can tell, edits
shouldn't be necessary for the script to work.