### PR TITLE
Add correct indices for mimic-iv-ed postgres

### DIFF
--- a/mimic-iv-ed/buildmimic/postgres/create.sql
+++ b/mimic-iv-ed/buildmimic/postgres/create.sql
@@ -8,8 +8,8 @@
 --  File created - Wed 13 Jul 2022
 --------------------------------------------------------
 
-DROP SCHEMA IF EXISTS mimic_ed CASCADE;
-CREATE SCHEMA mimic_ed;
+DROP SCHEMA IF EXISTS mimiciv_ed CASCADE;
+CREATE SCHEMA mimiciv_ed;
 
 /* Set the mimic_data_dir variable to point to directory containing
    all .csv files. If using Docker, this should not be changed here.
@@ -23,8 +23,8 @@ CREATE SCHEMA mimic_ed;
 --  DDL for Table diagnosis
 --------------------------------------------------------
 
-DROP TABLE IF EXISTS mimic_ed.diagnosis CASCADE;
-CREATE TABLE mimic_ed.diagnosis
+DROP TABLE IF EXISTS mimiciv_ed.diagnosis CASCADE;
+CREATE TABLE mimiciv_ed.diagnosis
 (
   subject_id INTEGER NOT NULL,
   stay_id INTEGER NOT NULL,
@@ -38,8 +38,8 @@ CREATE TABLE mimic_ed.diagnosis
 --  DDL for Table edstays
 --------------------------------------------------------
 
-DROP TABLE IF EXISTS mimic_ed.edstays CASCADE;
-CREATE TABLE mimic_ed.edstays
+DROP TABLE IF EXISTS mimiciv_ed.edstays CASCADE;
+CREATE TABLE mimiciv_ed.edstays
 (
   subject_id INTEGER NOT NULL,
   hadm_id INTEGER,
@@ -56,8 +56,8 @@ CREATE TABLE mimic_ed.edstays
 --  DDL for Table medrecon
 --------------------------------------------------------
 
-DROP TABLE IF EXISTS mimic_ed.medrecon CASCADE;
-CREATE TABLE mimic_ed.medrecon
+DROP TABLE IF EXISTS mimiciv_ed.medrecon CASCADE;
+CREATE TABLE mimiciv_ed.medrecon
 (
   subject_id INTEGER NOT NULL,
   stay_id INTEGER NOT NULL,
@@ -74,8 +74,8 @@ CREATE TABLE mimic_ed.medrecon
 --  DDL for Table pyxis
 --------------------------------------------------------
 
-DROP TABLE IF EXISTS mimic_ed.pyxis CASCADE;
-CREATE TABLE mimic_ed.pyxis
+DROP TABLE IF EXISTS mimiciv_ed.pyxis CASCADE;
+CREATE TABLE mimiciv_ed.pyxis
 (
   subject_id INTEGER NOT NULL,
   stay_id INTEGER NOT NULL,
@@ -90,8 +90,8 @@ CREATE TABLE mimic_ed.pyxis
 --  PARTITION for Table triage
 --------------------------------------------------------
 
-DROP TABLE IF EXISTS mimic_ed.triage CASCADE;
-CREATE TABLE mimic_ed.triage
+DROP TABLE IF EXISTS mimiciv_ed.triage CASCADE;
+CREATE TABLE mimiciv_ed.triage
 (
   subject_id INTEGER NOT NULL,
   stay_id INTEGER NOT NULL,
@@ -110,8 +110,8 @@ CREATE TABLE mimic_ed.triage
 --  DDL for Table vitalsign
 --------------------------------------------------------
 
-DROP TABLE IF EXISTS mimic_ed.vitalsign CASCADE;
-CREATE TABLE mimic_ed.vitalsign
+DROP TABLE IF EXISTS mimiciv_ed.vitalsign CASCADE;
+CREATE TABLE mimiciv_ed.vitalsign
 (
   subject_id INTEGER NOT NULL,
   stay_id INTEGER NOT NULL,

--- a/mimic-iv-ed/buildmimic/postgres/index.sql
+++ b/mimic-iv-ed/buildmimic/postgres/index.sql
@@ -4,31 +4,52 @@
 ----------------------------------------
 ----------------------------------------
 
--- patients
-DROP INDEX IF EXISTS patients_idx01;
-CREATE INDEX patients_idx01
-  ON patients (anchor_age);
+SET search_path TO mimiciv_ed;
 
-DROP INDEX IF EXISTS patients_idx02;
-CREATE INDEX patients_idx02
-  ON patients (anchor_year);
+-- diagnosis
 
--- admissions
- 
-DROP INDEX IF EXISTS admissions_idx01;
-CREATE INDEX admissions_idx01
-  ON admissions (admittime, dischtime, deathtime);
+DROP INDEX IF EXISTS diagnosis_idx01;
+CREATE INDEX diagnosis_idx01
+  ON diagnosis (subject_id, stay_id);
 
--- transfers
+DROP INDEX IF EXISTS diagnosis_idx02;
+CREATE INDEX diagnosis_idx02
+  ON diagnosis (icd_code, icd_version);
 
-DROP INDEX IF EXISTS transfers_idx01;
-CREATE INDEX transfers_idx01
-  ON transfers (hadm_id);
+-- edstays
 
-DROP INDEX IF EXISTS transfers_idx02;
-CREATE INDEX transfers_idx02
-  ON transfers (intime);
+DROP INDEX IF EXISTS edstays_idx01;
+CREATE INDEX edstays_idx01
+  ON edstays (subject_id, hadm_id, stay_id);
 
-DROP INDEX IF EXISTS transfers_idx03;
-CREATE INDEX transfers_idx03
-  ON transfers (careunit);
+DROP INDEX IF EXISTS edstays_idx02;
+CREATE INDEX edstays_idx02
+  ON edstays (intime, outtime);
+
+-- medrecon
+
+DROP INDEX IF EXISTS medrecon_idx01;
+CREATE INDEX medrecon_idx01
+  ON medrecon (subject_id, stay_id, charttime);
+
+-- pyxis
+
+DROP INDEX IF EXISTS pyxis_idx01;
+CREATE INDEX pyxis_idx01
+  ON pyxis (subject_id, stay_id, charttime);
+
+DROP INDEX IF EXISTS pyxis_idx02;
+CREATE INDEX pyxis_idx02
+  ON pyxis (gsn);
+
+-- triage
+
+DROP INDEX IF EXISTS triage_idx01;
+CREATE INDEX triage_idx01
+  ON triage (subject_id, stay_id);
+
+-- vitalsign
+
+DROP INDEX IF EXISTS vitalsign_idx01;
+CREATE INDEX vitalsign_idx01
+  ON vitalsign (subject_id, stay_id, charttime);

--- a/mimic-iv-ed/buildmimic/postgres/load.sql
+++ b/mimic-iv-ed/buildmimic/postgres/load.sql
@@ -15,7 +15,7 @@
 \cd :mimic_data_dir
 
 -- If running scripts individually, you can set the schema where all tables are created as follows:
-SET search_path TO mimic_ed;
+SET search_path TO mimiciv_ed;
 -- Restoring the search path to its default value can be accomplished as follows:
 -- SET search_path TO "$user",public;
 

--- a/mimic-iv-ed/buildmimic/postgres/load_gz.sql
+++ b/mimic-iv-ed/buildmimic/postgres/load_gz.sql
@@ -15,7 +15,7 @@
 \cd :mimic_data_dir
 
 -- If running scripts individually, you can set the schema where all tables are created as follows:
-SET search_path TO mimic_ed;
+SET search_path TO mimiciv_ed;
 -- Restoring the search path to its default value can be accomplished as follows:
 -- SET search_path TO "$user",public;
 


### PR DESCRIPTION
This PR adds actual indices for mimic-iv-ed postgres (Fix #1162) based on the mysql mimic-iv-ed `index.sql`.
Also fixed schema `mimic_ed` -> `mimiciv_ed` to be consistent with `validate.sql`/`validate_demo.sql` and `mimiciv_hosp`, `mimiciv_icu`.