### PR TITLE
Add lab results mappings for MIMIC-IV v2.0 - SSSOM format

### DIFF
--- a/mimic-iv/concepts/concept_map/d_labitems_to_loinc.csv
+++ b/mimic-iv/concepts/concept_map/d_labitems_to_loinc.csv
@@ -1,1631 +1,1624 @@
-itemid (omop_source_code),label,fluid,category,valueuom,omop_concept_id,omop_concept_name,omop_domain_id,omop_vocabulary_id,omop_concept_class_id,omop_standard_concept,omop_concept_code,sssom_author_id,sssom_reviewer_id,sssom_subject_source_version,common_vocabulary_version,sssom_mapping_tool,sssom_mapping_tool_version,sssom_mapping_date,sssom_confidence,sssom_comment,labevents_row_count
-50801,Alveolar-arterial Gradient,Blood,Blood Gas,mm Hg,3007913,Alveolar-arterial oxygen Partial pressure difference,Measurement,LOINC,Lab Test,S,19991-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,14503
-50802,Base Excess,Blood,Blood Gas,mEq/L,3012501,Base excess in Blood by calculation,Measurement,LOINC,Lab Test,S,11555-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,569287
-50803,"Calculated Bicarbonate, Whole Blood",Blood,Blood Gas,mEq/L,3006576,Bicarbonate [Moles/volume] in Blood,Measurement,LOINC,Lab Test,S,1959-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,24309
-50804,Calculated Total CO2,Blood,Blood Gas,mEq/L,3031147,"Carbon dioxide, total [Moles/volume] in Blood by calculation",Measurement,LOINC,Lab Test,S,34728-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,569282
-50805,Carboxyhemoglobin,Blood,Blood Gas,%,3023081,Carboxyhemoglobin/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,20563-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,5982
-50806,"Chloride, Whole Blood",Blood,Blood Gas,mEq/L,3018572,Chloride [Moles/volume] in Blood,Measurement,LOINC,Lab Test,S,2069-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,88911
-50807,Comments,Blood,Blood Gas,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-50808,Free Calcium,Blood,Blood Gas,mmol/L,3021119,Calcium.ionized [Moles/volume] in Blood,Measurement,LOINC,Lab Test,S,1994-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,298634
-50809,Glucose,Blood,Blood Gas,mg/dL,3000483,Glucose [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,2339-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,222718
-50810,"Hematocrit, Calculated",Blood,Blood Gas,%,3050746,Hematocrit [Volume Fraction] of Blood by Estimated,Measurement,LOINC,Lab Test,S,48703-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,117423
-50811,Hemoglobin,Blood,Blood Gas,g/dL,3000963,Hemoglobin [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,718-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,117417
-50812,Intubated,Blood,Blood Gas,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,164341
-50813,Lactate,Blood,Blood Gas,mmol/L,3047181,Lactate [Moles/volume] in Blood,Measurement,LOINC,Lab Test,S,32693-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,532387
-50814,Methemoglobin,Blood,Blood Gas,%,3007930,Methemoglobin/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,2614-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5276
-50815,O2 Flow,Blood,Blood Gas,L/min,3005629,Inhaled oxygen flow rate,Measurement,LOINC,Lab Test,S,3151-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,9986
-50816,Oxygen,Blood,Blood Gas,%,3020716,Inhaled oxygen concentration,Measurement,LOINC,Lab Test,S,3150-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,92346
-50817,Oxygen Saturation,Blood,Blood Gas,%,3013502,Oxygen saturation in Blood,Measurement,LOINC,Lab Test,S,20564-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,185563
-50818,pCO2,Blood,Blood Gas,mm Hg,3013290,Carbon dioxide [Partial pressure] in Blood,Measurement,LOINC,Lab Test,S,11557-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,569088
-50819,PEEP,Blood,Blood Gas,,3022875,Positive end expiratory pressure setting Ventilator,Measurement,LOINC,Lab Test,S,20077-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,60312
-50820,pH,Blood,Blood Gas,units,3010421,pH of Blood,Measurement,LOINC,Lab Test,S,11558-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,624942
-50821,pO2,Blood,Blood Gas,mm Hg,3027315,Oxygen [Partial pressure] in Blood,Measurement,LOINC,Lab Test,S,11556-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,569281
-50822,"Potassium, Whole Blood",Blood,Blood Gas,mEq/L,3005456,Potassium [Moles/volume] in Blood,Measurement,LOINC,Lab Test,S,6298-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,259088
-50823,Required O2,Blood,Blood Gas,,3020716,Inhaled oxygen concentration,Measurement,LOINC,Lab Test,S,3150-0,0000-0002-9348-9284,0000-0001-8822-1884,MIMIC-IV v2.0,,,,,,,14522
-50824,"Sodium, Whole Blood",Blood,Blood Gas,mEq/L,3000285,Sodium [Moles/volume] in Blood,Measurement,LOINC,Lab Test,S,2947-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,117619
-50825,Temperature,Blood,Blood Gas,,3020891,Body temperature,Measurement,LOINC,Lab Test,S,8310-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,108727
-50826,Tidal Volume,Blood,Blood Gas,,3012410,Tidal volume setting Ventilator,Measurement,LOINC,Lab Test,S,20112-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,51315
-50827,Ventilation Rate,Blood,Blood Gas,,21492234,Ventilation rate by Carbon dioxide measurement,Measurement,LOINC,Lab Test,S,76526-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/2/2022,0.1,,57051
-50828,Ventilator,Blood,Blood Gas,,3004921,Ventilation mode Ventilator,Measurement,LOINC,Lab Test,S,20124-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,59919
-50829,Fluid Type,Other Body Fluid,Blood Gas,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-50830,"pCO2, Body Fluid",Other Body Fluid,Blood Gas,mm Hg,3027480,Carbon dioxide [Partial pressure] in Body fluid,Measurement,LOINC,Lab Test,S,2023-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas""",3
-50831,pH,Other Body Fluid,Blood Gas,units,3018672,pH of Body fluid,Measurement,LOINC,Lab Test,S,2748-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas""",5527
-50832,"pO2, Body Fluid",Other Body Fluid,Blood Gas,mm Hg,3010251,Oxygen [Partial pressure] in Body fluid,Measurement,LOINC,Lab Test,S,2706-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas""",3
-50833,Potassium,Other Body Fluid,Blood Gas,,3036243,Potassium [Moles/volume] in Body fluid,Measurement,LOINC,Lab Test,S,2821-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas""",0
-50834,"Sodium, Body Fluid",Other Body Fluid,Blood Gas,,3022810,Sodium [Moles/volume] in Body fluid,Measurement,LOINC,Lab Test,S,2950-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas""",0
-50835,"Albumin, Ascites",Ascites,Chemistry,g/dL,3026692,Albumin [Mass/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,1749-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6315
-50836,"Amylase, Ascites",Ascites,Chemistry,IU/L,3008691,Amylase [Enzymatic activity/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,1797-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3396
-50837,"Bicarbonate, Ascites",Ascites,Chemistry,mEq/L,40757491,Bicarbonate [Moles/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,54360-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,37
-50838,"Bilirubin, Total, Ascites",Ascites,Chemistry,mg/dL,3011004,Bilirubin.total [Mass/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,14422-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2141
-50839,"Chloride, Ascites",Ascites,Chemistry,mEq/L,3043156,Chloride [Moles/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,33366-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,39
-50840,"Cholesterol, Ascites",Ascites,Chemistry,mg/dL,3002651,Cholesterol [Mass/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,14441-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,51
-50841,"Creatinine, Ascites",Ascites,Chemistry,mg/dL,3016647,Creatinine [Mass/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,12191-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2048
-50842,"Glucose, Ascites",Ascites,Chemistry,mg/dL,3002240,Glucose [Mass/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,2347-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5006
-50843,"Lactate Dehydrogenase, Ascites",Ascites,Chemistry,IU/L,3008581,Lactate dehydrogenase [Enzymatic activity/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,2531-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Discouraged LOINC code,3717
-50844,"Lipase, Ascites",Ascites,Chemistry,U/L,3045996,Lipase [Enzymatic activity/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,32722-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,97
-50845,"Miscellaneous, Ascites",Ascites,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,36
-50846,"Osmolality, Ascites",Ascites,Chemistry,mOsm/kg,3016937,Osmolality of Peritoneal fluid,Measurement,LOINC,Lab Test,S,2691-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7
-50847,"Potassium, Ascites",Ascites,Chemistry,mEq/L,3029821,Potassium [Moles/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,49789-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,42
-50848,"Sodium, Ascites",Ascites,Chemistry,mEq/L,3033042,Sodium [Moles/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,49790-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,55
-50849,"Total Protein, Ascites",Ascites,Chemistry,g/dL,3002331,Protein [Mass/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,2883-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7595
-50850,"Triglycerides, Ascites",Ascites,Chemistry,mg/dL,3023386,Triglyceride [Mass/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,14447-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,446
-50851,"Urea Nitrogen, Ascites",Ascites,Chemistry,mg/dL,3006866,Urea nitrogen [Mass/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,12265-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,24
-50852,% Hemoglobin A1c,Blood,Chemistry,%,3004410,Hemoglobin A1c/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4548-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,232948
-50853,25-OH Vitamin D,Blood,Chemistry,ng/mL,3020149,25-hydroxyvitamin D3 [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1989-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,81118
-50854,Absolute A1c,Blood,Chemistry,,3034639,Hemoglobin A1c [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,41995-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,539
-50855,Absolute Hemoglobin,Blood,Chemistry,,3000963,Hemoglobin [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,718-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,539
-50856,Acetaminophen,Blood,Chemistry,ug/mL,3002617,Acetaminophen [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3298-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,90547
-50857,Acetone,Blood,Chemistry,N/A,3022859,Acetone [Presence] in Serum or Plasma,Measurement,LOINC,Lab Test,S,5567-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1656
-50858,Acid Phosphatase,Blood,Chemistry,,3020233,Acid phosphatase [Enzymatic activity/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1715-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-50859,"Acid Phosphatase, Non-Prostatic",Blood,Chemistry,,3009383,Non prostatic acid phosphatase [Enzymatic activity/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,12173-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-50860,"AFP, Maternal Screen",Blood,Chemistry,,3009306,Alpha-1-Fetoprotein [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1834-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-50861,Alanine Aminotransferase (ALT),Blood,Chemistry,IU/L,3006923,Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1742-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1397464
-50862,Albumin,Blood,Chemistry,g/dL,3024561,Albumin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1751-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,775422
-50863,Alkaline Phosphatase,Blood,Chemistry,IU/L,3035995,Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,6768-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1214617
-50864,Alpha-Fetoprotein,Blood,Chemistry,ng/mL,3009306,Alpha-1-Fetoprotein [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1834-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,31268
-50865,Amikacin,Blood,Chemistry,ug/mL,3036152,Amikacin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,35669-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,578
-50866,Ammonia,Blood,Chemistry,umol/L,3011958,Ammonia [Moles/volume] in Plasma,Measurement,LOINC,Lab Test,S,16362-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7385
-50867,Amylase,Blood,Chemistry,IU/L,3016771,Amylase [Enzymatic activity/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1798-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,86340
-50868,Anion Gap,Blood,Chemistry,mEq/L,3037278,Anion gap 4 in Serum or Plasma,Measurement,LOINC,Lab Test,S,1863-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3114594
-50869,Anti-DGP (IgA/IgG),Blood,Chemistry,units,40766151,Gliadin peptide+tissue transglutaminase IgA+IgG Ab [Presence] in Serum by Immunoassay,Measurement,LOINC,Lab Test,S,63420-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1423
-50870,"Anti-Gliadin Antibody, IgA",Blood,Chemistry,units,40761803,Gliadin peptide IgA Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,58709-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,123
-50871,Anti-Mitochondrial Antibody,Blood,Chemistry,N/A,3005277,Mitochondria Ab [Presence] in Serum by Immunofluorescence,Measurement,LOINC,Lab Test,S,17284-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6163
-50872,Anti-Neutrophil Cytoplasmic Antibody,Blood,Chemistry,N/A,3009628,Neutrophil cytoplasmic Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,17351-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6854
-50873,Anti-Nuclear Antibody,Blood,Chemistry,N/A,3004616,Nuclear Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,8061-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,27565
-50874,"Anti-Nuclear Antibody, Titer",Blood,Chemistry,N/A,3002971,Nuclear Ab [Titer] in Serum by Immunofluorescence,Measurement,LOINC,Lab Test,S,5048-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7897
-50875,Anti-Parietal Cell Antibody,Blood,Chemistry,N/A,3018885,Parietal cell Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,14241-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,151
-50876,Anti-Smooth Muscle Antibody,Blood,Chemistry,N/A,3005932,Smooth muscle Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,14252-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6728
-50877,Anti-Thyroglobulin Antibodies,Blood,Chemistry,IU/mL,3025547,Thyroglobulin Ab [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,8098-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7097
-50878,Asparate Aminotransferase (AST),Blood,Chemistry,IU/L,3013721,Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1920-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1368625
-50879,Barbiturate Screen,Blood,Chemistry,N/A,3003132,"Barbiturates [Presence] in Serum, Plasma or Blood",Measurement,LOINC,Lab Test,S,3376-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,73560
-50880,Benzodiazepine Screen,Blood,Chemistry,N/A,3031951,Benzodiazepines [Presence] in Blood,Measurement,LOINC,Lab Test,S,42662-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,73663
-50881,Beta-2 Microglobulin,Blood,Chemistry,mg/L,3013201,Beta-2-Microglobulin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1952-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,8383
-50882,Bicarbonate,Blood,Chemistry,mEq/L,3016293,Bicarbonate [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1963-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3122445
-50883,"Bilirubin, Direct",Blood,Chemistry,mg/dL,3027597,Bilirubin.direct [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1968-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,199410
-50884,"Bilirubin, Indirect",Blood,Chemistry,mg/dL,3007359,Bilirubin.indirect [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1971-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,194542
-50885,"Bilirubin, Total",Blood,Chemistry,mg/dL,3024128,Bilirubin.total [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1975-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1320111
-50886,Blood Culture Hold,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-50887,Blue Top Hold,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,287173
-50888,Blue Top Hold Frozen,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,323
-50889,C-Reactive Protein,Blood,Chemistry,mg/L,3020460,C reactive protein [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1988-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,121922
-50890,C3,Blood,Chemistry,mg/dL,3000620,Complement C3 [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,4485-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,11778
-50891,C4,Blood,Chemistry,mg/dL,3017766,Complement C4 [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,4498-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,12358
-50892,CA-125,Blood,Chemistry,U/mL,3037551,Cancer Ag 125 [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,10334-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,13849
-50893,"Calcium, Total",Blood,Chemistry,mg/dL,3006906,Calcium [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,17861-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2278300
-50894,Calculated Free Testosterone,Blood,Chemistry,pg/mL,36032269,Testosterone Free [Moles/volume] in Serum or Plasma by calculation,Measurement,LOINC,Lab Test,S,96559-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6969
-50895,Calculated TBG,Blood,Chemistry,Ratio,3017523,Thyroxine (T4)/Thyroxine binding globulin [Mass Ratio] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3027-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,8302
-50896,Calculated Thyroxine (T4) Index,Blood,Chemistry,ug/dL,3000551,Thyroxine (T4) free index in Serum or Plasma by calculation,Measurement,LOINC,Lab Test,S,32215-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,8225
-50897,Call,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,57
-50898,Cancer Antigen 27.29,Blood,Chemistry,U/mL,3013520,Cancer Ag 27-29 [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,17842-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,10407
-50899,Carbamazepine,Blood,Chemistry,ug/mL,3028639,carBAMazepine [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3432-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3279
-50900,Carcinoembyronic Antigen (CEA),Blood,Chemistry,ng/mL,3003785,Carcinoembryonic Ag [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2039-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,41018
-50901,Centromere,Blood,Chemistry,N/A,3014825,Centromere Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,16137-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,540
-50902,Chloride,Blood,Chemistry,mEq/L,3014576,Chloride [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2075-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3239881
-50903,Cholesterol Ratio (Total/HDL),Blood,Chemistry,Ratio,3011163,Cholesterol.total/Cholesterol in HDL [Mass Ratio] in Serum or Plasma,Measurement,LOINC,Lab Test,S,9830-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,255002
-50904,"Cholesterol, HDL",Blood,Chemistry,mg/dL,3007070,Cholesterol in HDL [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2085-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,255936
-50905,"Cholesterol, LDL, Calculated",Blood,Chemistry,mg/dL,3028288,Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation,Measurement,LOINC,Lab Test,S,13457-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,232922
-50906,"Cholesterol, LDL, Measured",Blood,Chemistry,mg/dL,3009966,Cholesterol in LDL [Mass/volume] in Serum or Plasma by Direct assay,Measurement,LOINC,Lab Test,S,18262-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,41249
-50907,"Cholesterol, Total",Blood,Chemistry,mg/dL,3027114,Cholesterol [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2093-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,262156
-50908,CK-MB Index,Blood,Chemistry,%,3048863,Creatine kinase.MB/Creatine kinase.total [Ratio] in Serum or Plasma,Measurement,LOINC,Lab Test,S,49136-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,26426
-50909,Cortisol,Blood,Chemistry,ug/dL,3009682,Cortisol [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2143-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,26662
-50910,Creatine Kinase (CK),Blood,Chemistry,IU/L,3007220,Creatine kinase [Enzymatic activity/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2157-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,294189
-50911,"Creatine Kinase, MB Isoenzyme",Blood,Chemistry,ng/mL,3005785,Creatine kinase.MB [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,13969-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,237236
-50912,Creatinine,Blood,Chemistry,mg/dL,3016723,Creatinine [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2160-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3418103
-50913,Cryoglobulin,Blood,Chemistry,N/A,3021322,Cryoglobulin [Presence] in Serum,Measurement,LOINC,Lab Test,S,5117-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2313
-50914,Cyclosporin,Blood,Chemistry,ng/mL,3010375,cycloSPORINE [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,3520-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,20430
-50915,D-Dimer,Blood,Chemistry,ng/mL|ng/mL FEU,3051714,Fibrin D-dimer FEU [Mass/volume] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,48065-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,23669
-50916,DHEA-Sulfate,Blood,Chemistry,ug/dL,3015884,Dehydroepiandrosterone sulfate (DHEA-S) [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2191-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1967
-50917,Digoxin,Blood,Chemistry,ng/mL,3011335,Digoxin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,10535-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,12374
-50918,Double Stranded DNA,Blood,Chemistry,U/mL|N/A,3012718,DNA double strand Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,31348-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7607
-50919,EDTA Hold,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,85142
-50920,Estimated GFR (MDRD equation),Blood,Chemistry,,46236952,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",Measurement,LOINC,Lab Test,S,77147-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1431036
-50921,Estradiol,Blood,Chemistry,pg/mL,3025285,Estradiol (E2) [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2243-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3332
-50922,Ethanol,Blood,Chemistry,mg/dL,3025643,Ethanol [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,5640-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,93095
-50923,Fax,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,46
-50924,Ferritin,Blood,Chemistry,ng/mL,3001122,Ferritin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2276-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,142277
-50925,Folate,Blood,Chemistry,ng/mL,3036987,Folate [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2284-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,55389
-50926,Follicle Stimulating Hormone,Blood,Chemistry,mIU/mL,3023323,Follitropin [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,15067-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,9169
-50927,Gamma Glutamyltransferase,Blood,Chemistry,IU/L,3026910,Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2324-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,16460
-50928,Gastrin,Blood,Chemistry,,3009927,Gastrin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2333-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-50929,Gentamicin,Blood,Chemistry,ug/mL,3035510,Gentamicin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,35668-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4706
-50930,Globulin,Blood,Chemistry,g/dL,3021886,Globulin [Mass/volume] in Serum,Measurement,LOINC,Lab Test,S,2336-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,130399
-50931,Glucose,Blood,Chemistry,mg/dL,3004501,Glucose [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2345-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2862126
-50932,Gray Top Hold (plasma),Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,7487
-50933,Green Top Hold (plasma),Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,316911
-50934,H,Blood,Chemistry,U,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,1506736
-50935,Haptoglobin,Blood,Chemistry,mg/dL,3012336,Haptoglobin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,4542-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,44963
-50936,"HCG, Maternal Screen",Blood,Chemistry,,3018171,Choriogonadotropin [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,19080-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-50937,Hepatitis A Virus Antibody,Blood,Chemistry,N/A|Pos/Neg,3035456,Hepatitis A virus Ab [Presence] in Serum by Immunoassay,Measurement,LOINC,Lab Test,S,13951-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,18359
-50938,Hepatitis A Virus IgM Antibody,Blood,Chemistry,N/A,3013327,Hepatitis A virus IgM Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,22314-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5318
-50939,"Hepatitis B Core Antibody, IgM",Blood,Chemistry,N/A,3013527,Hepatitis B virus core IgM Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,31204-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3802
-50940,Hepatitis B Surface Antibody,Blood,Chemistry,N/A,3017797,Hepatitis B virus surface Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,22322-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,55637
-50941,Hepatitis B Surface Antigen,Blood,Chemistry,N/A,3019510,Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,5196-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,64899
-50942,Hepatitis B Virus Core Antibody,Blood,Chemistry,N/A,3036282,Hepatitis B virus core Ab [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,13952-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,40297
-50943,Hepatitis C Virus Antibody,Blood,Chemistry,N/A,3013801,Hepatitis C virus Ab [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,13955-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,63937
-50944,HIV Antibody,Blood,Chemistry,N/A,3037274,HIV 1 Ab [Units/volume] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,5220-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,61174
-50945,Homocysteine,Blood,Chemistry,umol/L,3016724,Homocysteine [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,13965-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2426
-50946,Human Chorionic Gonadotropin,Blood,Chemistry,mIU/mL,3018171,Choriogonadotropin [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,19080-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,36852
-50947,I,Blood,Chemistry,U,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,1506714
-50948,Immunofixation,Blood,Chemistry,,3037756,Immunofixation for Serum or Plasma,Measurement,LOINC,Lab Test,S,25700-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,9681
-50949,Immunoglobulin A,Blood,Chemistry,mg/dL,3007164,IgA [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2458-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,44134
-50950,Immunoglobulin G,Blood,Chemistry,mg/dL,3005719,IgG [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2465-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,47618
-50951,Immunoglobulin M,Blood,Chemistry,mg/dL,3028026,IgM [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2472-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,37981
-50952,Iron,Blood,Chemistry,ug/dL,3002400,Iron [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2498-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,121905
-50953,"Iron Binding Capacity, Total",Blood,Chemistry,ug/dL,3021044,Iron binding capacity [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2500-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,109164
-50954,Lactate Dehydrogenase (LD),Blood,Chemistry,IU/L,3016436,Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2532-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Discouraged LOINC code,487758
-50955,Light Green Top Hold,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,237914
-50956,Lipase,Blood,Chemistry,IU/L,3004905,Lipase [Enzymatic activity/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3040-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,238985
-50957,Lithium,Blood,Chemistry,mmol/L,3024666,Lithium [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,14334-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7700
-50958,Luteinizing Hormone,Blood,Chemistry,mIU/mL,3009214,Lutropin [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,10501-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5883
-50959,Macro Prolactin,Blood,Chemistry,,43055514,Macroprolactin [Presence] in Serum or Plasma,Measurement,LOINC,Lab Test,S,72680-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,31
-50960,Magnesium,Blood,Chemistry,mg/dL,3001420,Magnesium [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,19123-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2236791
-50961,Methotrexate,Blood,Chemistry,umol/L,3017115,Methotrexate [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,14836-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5923
-50962,N-Acetylprocainamide (NAPA),Blood,Chemistry,ug/mL,3001706,N-acetylprocainamide [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3834-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,24
-50963,NTproBNP,Blood,Chemistry,pg/mL,3029187,Natriuretic peptide.B prohormone N-Terminal [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,33762-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,68645
-50964,"Osmolality, Measured",Blood,Chemistry,mOsm/kg,3008295,Osmolality of Serum or Plasma,Measurement,LOINC,Lab Test,S,2692-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,42320
-50965,Parathyroid Hormone,Blood,Chemistry,pg/mL,3000067,Parathyrin.intact [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2731-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,51492
-50966,Phenobarbital,Blood,Chemistry,ug/mL,3025411,PHENobarbital [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3948-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4081
-50967,Phenytoin,Blood,Chemistry,ug/mL,3022616,Phenytoin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3968-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,23728
-50968,"Phenytoin, Free",Blood,Chemistry,ug/mL,3005893,Phenytoin Free [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3969-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,778
-50969,"Phenytoin, Percent Free",Blood,Chemistry,%,3002551,Phenytoin Free/Phenytoin.total in Serum or Plasma,Measurement,LOINC,Lab Test,S,10548-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,744
-50970,Phosphate,Blood,Chemistry,mg/dL,3011904,Phosphate [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2777-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2146872
-50971,Potassium,Blood,Chemistry,mEq/L,3023103,Potassium [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2823-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3308845
-50972,Procainamide,Blood,Chemistry,ug/mL,3004653,Procainamide [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3982-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,24
-50973,Prolactin,Blood,Chemistry,ng/mL,3004722,Prolactin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2842-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,10114
-50974,Prostate Specific Antigen,Blood,Chemistry,ng/mL,3013603,Prostate specific Ag [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2857-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,60947
-50975,Protein Electrophoresis,Blood,Chemistry,,3035956,Protein Fractions [Interpretation] in Serum or Plasma by Electrophoresis,Measurement,LOINC,Lab Test,S,12851-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,44297
-50976,"Protein, Total",Blood,Chemistry,g/dL,3020630,Protein [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2885-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,164786
-50977,Quinidine,Blood,Chemistry,,3019736,quiNIDine [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,6694-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-50978,Rapamycin,Blood,Chemistry,ng/mL,3021374,Sirolimus [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,29247-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,11557
-50979,Red Top Hold,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,180716
-50980,Rheumatoid Factor,Blood,Chemistry,IU/mL,3021614,Rheumatoid factor [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,11572-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,11013
-50981,Salicylate,Blood,Chemistry,mg/dL,3000787,Salicylates [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,4024-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,88888
-50982,Sex Hormone Binding Globulin,Blood,Chemistry,nmol/L,3004248,Sex hormone binding globulin [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,13967-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7355
-50983,Sodium,Blood,Chemistry,mEq/L,3019550,Sodium [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2951-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3277103
-50984,Stat,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,7
-50985,Study Tubes,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,1242
-50986,tacroFK,Blood,Chemistry,ng/mL,3026250,Tacrolimus [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,11253-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,99797
-50988,Testosterone,Blood,Chemistry,ng/dL,3008893,Testosterone [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2986-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,18040
-50989,"Testosterone, Free",Blood,Chemistry,pg/mL,3016049,Testosterone Free [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2991-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2247
-50990,Theophylline,Blood,Chemistry,ug/mL,3016072,Theophylline [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,4049-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,112
-50991,Thyroglobulin,Blood,Chemistry,ng/mL,3036535,Thyroglobulin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3013-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5058
-50992,Thyroid Peroxidase Antibodies,Blood,Chemistry,IU/mL,3027238,Thyroperoxidase Ab [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,8099-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5231
-50993,Thyroid Stimulating Hormone,Blood,Chemistry,uIU/mL|uU/ML,3009201,Thyrotropin [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3016-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,331444
-50994,Thyroxine (T4),Blood,Chemistry,ug/dL,3016991,Thyroxine (T4) [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3026-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,22620
-50995,"Thyroxine (T4), Free",Blood,Chemistry,ng/dL,3008598,Thyroxine (T4) free [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3024-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,106782
-50996,"Tissue Transglutaminase Ab, IgA",Blood,Chemistry,units,3019050,Tissue transglutaminase IgA Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,31017-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,16143
-50997,Tobramycin,Blood,Chemistry,ug/mL,3035509,Tobramycin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,35670-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1990
-50998,Transferrin,Blood,Chemistry,mg/dL,3004789,Transferrin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3034-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,109185
-50999,Tricyclic Antidepressant Screen,Blood,Chemistry,N/A,21494637,Tricyclic antidepressants [Presence] in Blood by Screen method,Measurement,LOINC,Lab Test,S,80146-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,87795
-51000,Triglycerides,Blood,Chemistry,mg/dL,3022192,Triglyceride [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2571-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,265822
-51001,Triiodothyronine (T3),Blood,Chemistry,ng/dL,3010340,Triiodothyronine (T3) [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3053-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,20080
-51002,Troponin I,Blood,Chemistry,,3021337,Troponin I.cardiac [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,10839-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51003,Troponin T,Blood,Chemistry,ng/mL,3019800,Troponin T.cardiac [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,6598-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,374094
-51004,"UE3, Maternal Screen",Blood,Chemistry,,3025455,Estriol (E3).unconjugated [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2250-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51005,Uptake Ratio,Blood,Chemistry,Ratio,3021717,Triiodothyronine resin uptake (T3RU) in Serum or Plasma,Measurement,LOINC,Lab Test,S,3050-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,8277
-51006,Urea Nitrogen,Blood,Chemistry,mg/dL,3013682,Urea nitrogen [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3094-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3321619
-51007,Uric Acid,Blood,Chemistry,mg/dL,3037556,Urate [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3084-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,137597
-51008,Valproic Acid,Blood,Chemistry,ug/mL,3016201,Valproate [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,4086-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,12305
-51009,Vancomycin,Blood,Chemistry,ug/mL,3005715,Vancomycin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,20578-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,104400
-51010,Vitamin B12,Blood,Chemistry,pg/mL,3000593,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2132-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,107552
-51019,"Albumin, Joint Fluid",Joint Fluid,Chemistry,g/dL,3025380,Albumin [Mass/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,1752-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,9
-51020,"Amylase, Joint Fluid",Joint Fluid,Chemistry,IU/L,3004142,Amylase [Enzymatic activity/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,14388-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6
-51021,"Creatinine, Joint Fluid",Joint Fluid,Chemistry,mg/dL,3007367,Creatinine [Mass/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,14401-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2
-51022,"Glucose, Joint Fluid",Joint Fluid,Chemistry,mg/dL,3001978,Glucose [Mass/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,2348-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,171
-51023,"LD, Joint Fluid",Joint Fluid,Chemistry,IU/L,3016675,Lactate dehydrogenase [Enzymatic activity/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Discouraged LOINC code,41
-51024,"Total Protein, Joint Fluid",Joint Fluid,Chemistry,g/dL,3036670,Protein [Mass/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,2886-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,132
-51025,"Albumin, Body Fluid",Other Body Fluid,Chemistry,g/dL,3025313,Albumin [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,1747-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,640
-51026,"Amylase, Body Fluid",Other Body Fluid,Chemistry,IU/L,3012133,Amylase [Enzymatic activity/volume] in Body fluid,Measurement,LOINC,Lab Test,S,1795-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1355
-51027,"Bicarbonate, Other Fluid",Other Body Fluid,Chemistry,mEq/L,3024655,Bicarbonate [Moles/volume] in Body fluid,Measurement,LOINC,Lab Test,S,16459-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,197
-51028,"Bilirubin, Total, Body Fluid",Other Body Fluid,Chemistry,mg/dL,3028193,Bilirubin.total [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,1974-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,409
-51029,"Calcium, Body Fluid",Other Body Fluid,Chemistry,mg/dL,3000822,Calcium [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,15155-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,11
-51030,"Chloride, Body Fluid",Other Body Fluid,Chemistry,mEq/L,3013194,Chloride [Moles/volume] in Body fluid,Measurement,LOINC,Lab Test,S,2072-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,34
-51031,"Cholesterol, Body Fluid",Other Body Fluid,Chemistry,mg/dL,3015232,Cholesterol [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,12183-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,15
-51032,"Creatinine, Body Fluid",Other Body Fluid,Chemistry,mg/dL,3016662,Creatinine [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,12190-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,429
-51033,FetalFN,Other Body Fluid,Chemistry,,3036848,Fibronectin.fetal [Presence] in Vaginal fluid,Measurement,LOINC,Lab Test,S,20404-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1308
-51034,"Glucose, Body Fluid",Other Body Fluid,Chemistry,mg/dL,3019210,Glucose [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,2344-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,738
-51035,"LD, Body Fluid",Other Body Fluid,Chemistry,IU/L,3008338,Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid,Measurement,LOINC,Lab Test,S,2529-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Discouraged LOINC code,643
-51036,"Lipase, Body Fluid",Other Body Fluid,Chemistry,U/L,3026286,Lipase [Enzymatic activity/volume] in Body fluid,Measurement,LOINC,Lab Test,S,15212-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,54
-51037,"Magnesium, Body Fluid",Other Body Fluid,Chemistry,mg/dL,3014175,Magnesium [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,29365-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,9
-51038,"Miscellaneous, Body Fluid",Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,748
-51039,"Osmolality, Body Fluid",Other Body Fluid,Chemistry,mOsm/kg,3004663,Osmolality of Body fluid,Measurement,LOINC,Lab Test,S,15200-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,10
-51040,"Phosphate, Body Fluid",Other Body Fluid,Chemistry,mg/dL,3034814,Phosphate [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,12242-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,11
-51041,"Potassium, Body Fluid",Other Body Fluid,Chemistry,mEq/L,3036243,Potassium [Moles/volume] in Body fluid,Measurement,LOINC,Lab Test,S,2821-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,40
-51042,"Sodium, Body Fluid",Other Body Fluid,Chemistry,mEq/L,3022810,Sodium [Moles/volume] in Body fluid,Measurement,LOINC,Lab Test,S,2950-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,43
-51043,"Total Protein, Body Fluid",Other Body Fluid,Chemistry,g/dL,3005029,Protein [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,2881-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,724
-51044,Triglycer,Other Body Fluid,Chemistry,mg/dL,3000637,Triglyceride [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,12228-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,143
-51045,"Urea Nitrogen, Body Fluid",Other Body Fluid,Chemistry,mg/dL,3019930,Urea nitrogen [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,3093-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,55
-51046,"Albumin, Pleural",Pleural,Chemistry,g/dL,3011544,Albumin [Mass/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,1748-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4780
-51047,"Amylase, Pleural",Pleural,Chemistry,IU/L,3015401,Amylase [Enzymatic activity/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,1796-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1927
-51048,"Bicarbonate, Pleural",Pleural,Chemistry,mEq/L,40757492,Bicarbonate [Moles/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,54361-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6
-51049,"Bilirubin, Total, Pleural",Pleural,Chemistry,mg/dL,3013272,Bilirubin.total [Mass/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,14421-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,171
-51050,"Chloride, Pleural",Pleural,Chemistry,mEq/L,3038308,Chloride [Moles/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,53627-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6
-51051,"Cholesterol, Pleural",Pleural,Chemistry,mg/dL,3033364,Cholesterol [Mass/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,9618-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4598
-51052,"Creatinine, Pleural",Pleural,Chemistry,mg/dL,3025065,Creatinine [Mass/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,14399-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1322
-51053,"Glucose, Pleural",Pleural,Chemistry,mg/dL,3003403,Glucose [Mass/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,2346-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7120
-51054,"Lactate Dehydrogenase, Pleural",Pleural,Chemistry,IU/L,3015054,Lactate dehydrogenase [Enzymatic activity/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,2530-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Discouraged LOINC code,7691
-51055,"Lipase, Pleural",Pleural,Chemistry,U/L,3048752,Lipase [Enzymatic activity/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,47418-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,9
-51056,"Miscellaneous, Pleural",Pleural,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,1611
-51057,"Potassium, Pleural",Pleural,Chemistry,mEq/L,3013098,Potassium [Moles/volume] in Specimen,Measurement,LOINC,Lab Test,S,32336-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,9
-51058,"Sodium, Pleural",Pleural,Chemistry,mEq/L,3026681,Sodium [Moles/volume] in Specimen,Measurement,LOINC,Lab Test,S,32340-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,11
-51059,"Total Protein, Pleural",Pleural,Chemistry,g/dL,3003434,Protein [Mass/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,2882-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7689
-51060,"Triglycerides, Pleural",Pleural,Chemistry,mg/dL,3034207,Triglyceride [Mass/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,9619-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1669
-51061,"Bicarbonate, Stool",Stool,Chemistry,mEq/L,3014637,Bicarbonate [Moles/volume] in Specimen,Measurement,LOINC,Lab Test,S,22735-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,49
-51062,"Chloride, Stool",Stool,Chemistry,mEq/L,3001260,Chloride [Moles/volume] in Stool,Measurement,LOINC,Lab Test,S,15158-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,94
-51063,"Osmolality, Stool",Stool,Chemistry,mOsm/kg,3007256,Osmolality of Stool,Measurement,LOINC,Lab Test,S,2693-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,236
-51064,"Potassium, Stool",Stool,Chemistry,mEq/L,3005819,Potassium [Moles/volume] in Stool,Measurement,LOINC,Lab Test,S,15202-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,243
-51065,"Sodium, Stool",Stool,Chemistry,mEq/L,3011846,Sodium [Moles/volume] in Stool,Measurement,LOINC,Lab Test,S,15207-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,245
-51066,24 hr Calcium,Urine,Chemistry,mg/24hr,3007687,Calcium [Mass/time] in 24 hour Urine,Measurement,LOINC,Lab Test,S,6874-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2128
-51067,24 hr Creatinine,Urine,Chemistry,mg/24hr,3004239,Creatinine [Mass/time] in 24 hour Urine,Measurement,LOINC,Lab Test,S,2162-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,8992
-51068,24 hr Protein,Urine,Chemistry,mg/24hr,3020876,Protein [Mass/time] in 24 hour Urine,Measurement,LOINC,Lab Test,S,2889-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3946
-51069,"Albumin, Urine",Urine,Chemistry,mg/dL,3000034,Microalbumin [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,14957-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,59424
-51070,"Albumin/Creatinine, Urine",Urine,Chemistry,mg/g,3002827,Microalbumin/Creatinine [Mass Ratio] in 24 hour Urine,Measurement,LOINC,Lab Test,S,14958-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,57281
-51071,"Amphetamine Screen, Urine",Urine,Chemistry,N/A,3000144,Amphetamine [Presence] in Urine by Screen method,Measurement,LOINC,Lab Test,S,19343-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,83308
-51072,"Amylase, Urine",Urine,Chemistry,U/L,3017315,Amylase [Enzymatic activity/volume] in Urine,Measurement,LOINC,Lab Test,S,1799-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,128
-51073,"Amylase/Creatinine Ratio, Urine",Urine,Chemistry,Ratio,3044902,Amylase/Creatinine [Ratio] in Urine,Measurement,LOINC,Lab Test,S,,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,125
-51074,"Barbiturate Screen, Urine",Urine,Chemistry,N/A,3005058,Barbiturates [Presence] in Urine by Screen method,Measurement,LOINC,Lab Test,S,19270-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,82624
-51075,"Benzodiazepine Screen, Urine",Urine,Chemistry,N/A,3007682,Benzodiazepines [Presence] in Urine by Screen method,Measurement,LOINC,Lab Test,S,14316-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,83459
-51076,"Bicarbonate, Urine",Urine,Chemistry,mEq/L,3008251,Bicarbonate [Moles/volume] in Urine,Measurement,LOINC,Lab Test,S,1964-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2643
-51077,"Calcium, Urine",Urine,Chemistry,mg/dL,3006661,Calcium [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,17862-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4758
-51078,"Chloride, Urine",Urine,Chemistry,mEq/L,3007733,Chloride [Moles/volume] in Urine,Measurement,LOINC,Lab Test,S,2078-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,40812
-51079,"Cocaine, Urine",Urine,Chemistry,N/A,3016879,Cocaine [Presence] in Urine,Measurement,LOINC,Lab Test,S,3397-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,84074
-51080,Creatinine Clearance,Urine,Chemistry,mL/min,3005770,Creatinine renal clearance in 24 hour Urine and Serum or Plasma,Measurement,LOINC,Lab Test,S,2164-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,656
-51081,"Creatinine, Serum",Urine,Chemistry,mg/dL,3016723,Creatinine [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2160-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,"Conflict. Label is ""Creatinine, Serum"", fluid is ""Urine""",656
-51082,"Creatinine, Urine",Urine,Chemistry,mg/dL,3017250,Creatinine [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,2161-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,193779
-51083,"Ethanol, Urine",Urine,Chemistry,N/A,3010109,Ethanol [Presence] in Urine,Measurement,LOINC,Lab Test,S,5644-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,107
-51084,"Glucose, Urine",Urine,Chemistry,mg/dL,3020399,Glucose [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,2350-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,137
-51085,"HCG, Urine, Qualitative",Urine,Chemistry,#ERROR!,3018954,Choriogonadotropin (pregnancy test) [Presence] in Urine,Measurement,LOINC,Lab Test,S,2106-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,85264
-51086,"Immunofixation, Urine",Urine,Chemistry,,3017704,Immunofixation for Urine,Measurement,LOINC,Lab Test,S,13440-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6474
-51087,Length of Urine Collection,Urine,Chemistry,,3016750,Collection duration of Urine,Measurement,LOINC,Lab Test,S,13362-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,667727
-51088,"Magnesium, Urine",Urine,Chemistry,mg/dL,3019738,Magnesium [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,19124-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1524
-51089,Marijuana,Urine,Chemistry,N/A,3028064,Tetrahydrocannabinol [Presence] in Urine,Measurement,LOINC,Lab Test,S,3426-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,11479
-51090,"Methadone, Urine",Urine,Chemistry,N/A,3036180,Methadone [Presence] in Urine,Measurement,LOINC,Lab Test,S,3773-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,83121
-51091,"Myoglobin, Urine",Urine,Chemistry,,3011470,Myoglobin [Presence] in Urine,Measurement,LOINC,Lab Test,S,2640-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,441
-51092,"Opiate Screen, Urine",Urine,Chemistry,N/A,3015208,Opiates [Presence] in Urine by Screen method,Measurement,LOINC,Lab Test,S,19295-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,84217
-51093,"Osmolality, Urine",Urine,Chemistry,mOsm/kg,3026782,Osmolality of Urine,Measurement,LOINC,Lab Test,S,2695-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,52053
-51094,pH,Urine,Chemistry,,3015736,pH of Urine,Measurement,LOINC,Lab Test,S,2756-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,10793
-51095,"Phosphate, Urine",Urine,Chemistry,mg/dL,3026729,Phosphate [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,2778-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3175
-51096,Porphobilinogen Screen,Urine,Chemistry,#ERROR!,3034719,Porphobilinogen [Presence] in Urine,Measurement,LOINC,Lab Test,S,2809-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,500
-51097,"Potassium, Urine",Urine,Chemistry,mEq/L,3016038,Potassium [Moles/volume] in Urine,Measurement,LOINC,Lab Test,S,2828-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,42324
-51098,"Prot. Electrophoresis, Urine",Urine,Chemistry,#ERROR!,3007822,Protein Fractions [Interpretation] in Urine by Electrophoresis,Measurement,LOINC,Lab Test,S,13438-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,20100
-51099,Protein/Creatinine Ratio,Urine,Chemistry,Ratio|mg/mg,3001582,Protein/Creatinine [Mass Ratio] in Urine,Measurement,LOINC,Lab Test,S,2890-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,80119
-51100,"Sodium, Urine",Urine,Chemistry,mEq/L,3003181,Sodium [Moles/volume] in Urine,Measurement,LOINC,Lab Test,S,2955-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,69549
-51101,Total Collection Time,Urine,Chemistry,hrs,3016750,Collection duration of Urine,Measurement,LOINC,Lab Test,S,13362-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,656
-51102,"Total Protein, Urine",Urine,Chemistry,mg/dL,3037121,Protein [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,2888-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,93047
-51103,Uhold,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,159132
-51104,"Urea Nitrogen, Urine",Urine,Chemistry,mg/dL,3011965,Urea nitrogen [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,3095-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,35385
-51105,"Uric Acid, Urine",Urine,Chemistry,mg/dL,3033526,Urate [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,3086-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1653
-51106,Urine Creatinine,Urine,Chemistry,mg/dL,3017250,Creatinine [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,2161-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate ot itemid 51082,656
-51107,"Urine tube, held",Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,135262
-51108,Urine Volume,Urine,Chemistry,mL,3036603,Volume of Urine,Measurement,LOINC,Lab Test,S,28009-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,10933
-51109,"Urine Volume, Total",Urine,Chemistry,mL,3036603,Volume of Urine,Measurement,LOINC,Lab Test,S,28009-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,656
-51110,Atypical Lymphocytes,Ascites,Hematology,%,3043989,Variant lymphocytes/100 leukocytes in Peritoneal fluid,Measurement,LOINC,Lab Test,S,33369-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,452
-51111,Bands,Ascites,Hematology,%,1988747,Band form neutrophils/100 leukocytes in Peritoneal fluid by Manual count,Measurement,LOINC,Lab Test,S,99603-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.72,https://loinc.org/search/,,3/31/2022,,Only manual count is available,281
-51112,Basophils,Ascites,Hematology,%,3032363,Basophils/100 leukocytes in Peritoneal fluid,Measurement,LOINC,Lab Test,S,35069-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,344
-51113,Blasts,Ascites,Hematology,%,3046003,Blasts/100 leukocytes in Peritoneal fluid,Measurement,LOINC,Lab Test,S,33372-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3
-51114,Eosinophils,Ascites,Hematology,%,3019298,Eosinophils/100 leukocytes in Peritoneal fluid,Measurement,LOINC,Lab Test,S,30380-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1805
-51115,"Hematocrit, Ascites",Ascites,Hematology,%,3008108,Hematocrit [Volume Fraction] of Body fluid,Measurement,LOINC,Lab Test,S,11153-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,351
-51116,Lymphocytes,Ascites,Hematology,%,3004437,Lymphocytes/100 leukocytes in Peritoneal fluid,Measurement,LOINC,Lab Test,S,26482-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,12103
-51117,Macrophage,Ascites,Hematology,%,3041635,Macrophages/100 leukocytes in Peritoneal fluid by Manual count,Measurement,LOINC,Lab Test,S,40517-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Only manual count is available,10091
-51118,Mesothelial Cell,Ascites,Hematology,%,3024271,Mesothelial cells/100 leukocytes in Peritoneal fluid,Measurement,LOINC,Lab Test,S,30432-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,8253
-51119,Metamyelocytes,Ascites,Hematology,%,3024936,Metamyelocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17801-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,19
-51120,Monocytes,Ascites,Hematology,%,3033483,Monocytes/100 leukocytes in Peritoneal fluid,Measurement,LOINC,Lab Test,S,26488-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,12103
-51121,Myelocytes,Ascites,Hematology,%,3024394,Myelocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17800-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,14
-51122,Nucleated RBC,Ascites,Hematology,%,42868645,Nucleated erythrocytes/100 cells in Peritoneal fluid,Measurement,LOINC,Lab Test,S,70171-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,164
-51123,Other,Ascites,Hematology,%,3008855,Leukocytes other/100 leukocytes in Peritoneal fluid,Measurement,LOINC,Lab Test,S,30409-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2743
-51124,Plasma,Ascites,Hematology,%,3041137,Plasma cells/100 leukocytes in Peritoneal fluid by Manual count,Measurement,LOINC,Lab Test,S,40518-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,657
-51125,Polys,Ascites,Hematology,%,3008838,Polymorphonuclear cells/100 leukocytes in Peritoneal fluid,Measurement,LOINC,Lab Test,S,26520-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,12103
-51126,Promyelocytes,Ascites,Hematology,%,3023316,Promyelocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17799-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,17
-51127,"RBC, Ascites",Ascites,Hematology,#/uL,3009613,Erythrocytes [#/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,26457-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,11866
-51129,Young,Ascites,Hematology,%,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,3
-51130,Absolute CD3 Count,Blood,Hematology,#/uL,3011412,CD3 cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,8122-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,27336
-51131,Absolute CD4 Count,Blood,Hematology,#/uL,3028167,CD3+CD4+ (T4 helper) cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,24467-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,27337
-51132,Absolute CD8 Count,Blood,Hematology,#/uL,3001405,CD3+CD8+ (T8 suppressor cells) cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,14135-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,27336
-51133,Absolute Lymphocyte Count,Blood,Hematology,K/uL,3004327,Lymphocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,731-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,531922
-51134,Acanthocytes,Blood,Hematology,N/A,3019416,Acanthocytes [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,7789-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,15155
-51135,ADP,Blood,Hematology,,3018442,Adenosine diphosphate [Mass/volume] in Serum,Measurement,LOINC,Lab Test,S,1724-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,325
-51136,Alpha Antiplasmin,Blood,Hematology,,3023479,Plasmin inhibitor actual/normal in Platelet poor plasma by Chromogenic method,Measurement,LOINC,Lab Test,S,27810-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,0
-51137,Anisocytosis,Blood,Hematology,N/A,3038691,Anisocytosis [Presence] in Blood,Measurement,LOINC,Lab Test,S,38892-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,262134
-51138,Anticardiolipin Antibody IgG,Blood,Hematology,GPL,3009041,Cardiolipin IgG Ab [Units/volume] in Serum by Immunoassay,Measurement,LOINC,Lab Test,S,3181-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2638
-51139,Anticardiolipin Antibody IgM,Blood,Hematology,MPL,3015813,Cardiolipin IgM Ab [Units/volume] in Serum by Immunoassay,Measurement,LOINC,Lab Test,S,3182-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2638
-51140,Antithrombin,Blood,Hematology,%,3000515,Antithrombin actual/normal in Platelet poor plasma by Chromogenic method,Measurement,LOINC,Lab Test,S,27811-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2210
-51141,APT Test,Blood,Hematology,,3000873,Hemoglobin F [Presence] in Blood by Alkali denaturation,Measurement,LOINC,Lab Test,S,4632-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,4
-51142,Arachadonic Acid,Blood,Hematology,,3031450,Arachidonate (C20:4w6) [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,35168-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,335
-51143,Atypical Lymphocytes,Blood,Hematology,%,3013498,Variant lymphocytes/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,13046-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,223882
-51144,Bands,Blood,Hematology,%,3004809,Band form neutrophils/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,26508-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,243606
-51145,Basophilic Stippling,Blood,Hematology,N/A,3026904,Basophilic stippling [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,703-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,14568
-51146,Basophils,Blood,Hematology,%,3013869,Basophils/100 leukocytes in Blood by Automated count,Measurement,LOINC,Lab Test,S,706-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,1308846
-51147,Bite Cells,Blood,Hematology,N/A,3005686,Bite cells [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,10371-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7903
-51148,Blasts,Blood,Hematology,%,3025159,Blasts/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,26446-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,25126
-51149,Bleeding Time,Blood,Hematology,min,3011625,Bleeding time,Measurement,LOINC,Lab Test,S,11067-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,70
-51150,Blood Parasite Smear,Blood,Hematology,N/A,37019529,Parasite [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,91900-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4578
-51152,CD10,Blood,Hematology,,3010287,CD10 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8107-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,1322
-51153,CD103,Blood,Hematology,,3018791,CD103 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,17100-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,64
-51154,CD117,Blood,Hematology,,3026595,CD117 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,17107-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,239
-51155,CD11c,Blood,Hematology,,3009295,CD11c cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8109-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,262
-51156,CD13,Blood,Hematology,,3025842,CD13 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8110-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,276
-51157,CD138,Blood,Hematology,,3031831,CD138 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,42869-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,12
-51158,CD14,Blood,Hematology,,3026992,CD14 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8111-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,228
-51159,CD15,Blood,Hematology,,3010143,CD15 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,17117-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,235
-51161,CD16,Blood,Hematology,,3010201,CD16 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8115-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,107
-51162,CD16/56 Absolute Count,Blood,Hematology,#/uL,3020358,CD16+CD56+ cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,20402-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1104
-51163,CD16/56%,Blood,Hematology,%,3015455,CD16+CD56+ cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,18267-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1104
-51164,CD19,Blood,Hematology,,3016228,CD19 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8117-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,Duplicate of itemid 51165,1382
-51165,CD19 %,Blood,Hematology,%,3016228,CD19 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8117-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1134
-51166,CD19 Absolute Count,Blood,Hematology,#/uL,3010503,CD19 cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,8116-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1134
-51167,CD2,Blood,Hematology,,3021562,CD2 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8118-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,961
-51168,CD20,Blood,Hematology,,3022878,CD20 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8119-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,Duplicate of itemid 51169,1325
-51169,CD20 %,Blood,Hematology,%,3022878,CD20 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8119-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1134
-51170,CD20 Absolute Count,Blood,Hematology,#/uL,3018071,CD20 cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,9558-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1134
-51171,CD22,Blood,Hematology,,3022703,CD22 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,14017-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,70
-51172,CD23,Blood,Hematology,,3025559,CD23 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,14018-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,1073
-51173,CD25,Blood,Hematology,,3011497,CD25 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8121-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,82
-51174,CD3 %,Blood,Hematology,%,3022533,CD3 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8124-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1281
-51175,CD3 Absolute Count,Blood,Hematology,#/uL,3011412,CD3 cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,8122-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1281
-51176,"CD3 Cells, Percent",Blood,Hematology,%,3022533,CD3 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8124-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51174,28634
-51177,CD33,Blood,Hematology,,3006501,CD33 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8102-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,228
-51178,CD34,Blood,Hematology,%,3023256,CD34 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8125-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,300
-51179,CD38,Blood,Hematology,,3019183,CD38 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8126-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,92
-51180,"CD4 Cells, Percent",Blood,Hematology,%,3014037,CD3+CD4+ (T4 helper) cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8123-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,28092
-51181,CD4/CD8 Ratio,Blood,Hematology,Ratio,40757349,CD3+CD4+ (T4 helper) cells/CD3+CD8+ (T8 suppressor cells) cells [# Ratio] in Blood,Measurement,LOINC,Lab Test,S,54218-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,27336
-51182,CD41,Blood,Hematology,,3021854,CD41 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,17148-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,190
-51183,CD45,Blood,Hematology,,3023116,CD45 (Lymphs) cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8130-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,1430
-51184,CD5,Blood,Hematology,,3020383,CD5 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8132-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,Duplicate of itemid 51185,1314
-51185,CD5 %,Blood,Hematology,%,3020383,CD5 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8132-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,204
-51186,CD5 Absolute Count,Blood,Hematology,#/uL,3018627,CD5 cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,9559-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,204
-51187,CD55,Blood,Hematology,,3007166,CD55 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,17175-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,211
-51188,CD56,Blood,Hematology,,3005460,CD56 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8133-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,351
-51189,CD57,Blood,Hematology,,3004291,CD57 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8134-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,159
-51190,CD59,Blood,Hematology,,3026461,CD59 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,17177-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,211
-51191,CD64,Blood,Hematology,,3027120,CD64 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,17183-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,206
-51192,CD7,Blood,Hematology,,3003255,CD7 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8135-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,970
-51193,CD71,Blood,Hematology,,3002153,CD71 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8136-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,195
-51194,"CD8 Cells, Percent",Blood,Hematology,%,3007449,CD3+CD8+ (T8 suppressor cells) cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8101-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,28082
-51195,Collagen,Blood,Hematology,,21491241,Platelet aggregation collagen induced [Units/volume] in Blood,Measurement,LOINC,Lab Test,S,78685-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,318
-51196,D-Dimer,Blood,Hematology,ng/mL|ng/mL FEU,3051714,Fibrin D-dimer FEU [Mass/volume] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,48065-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,8317
-51197,Elliptocytes,Blood,Hematology,N/A,3000493,Elliptocytes [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,11274-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,14491
-51198,Envelope Cells,Blood,Hematology,N/A,3017196,Microscopic observation [Identifier] in Specimen by Wright stain,Measurement,LOINC,Lab Test,S,681-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2336
-51199,Eosinophil Count,Blood,Hematology,#/uL,3028615,Eosinophils [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,711-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,531
-51200,Eosinophils,Blood,Hematology,%,3010457,Eosinophils/100 leukocytes in Blood by Automated count,Measurement,LOINC,Lab Test,S,713-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,1308846
-51201,Epinepherine,Blood,Hematology,,3008625,EPINEPHrine [Mass/volume] in Plasma,Measurement,LOINC,Lab Test,S,2230-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,157
-51202,Factor II,Blood,Hematology,%,3005353,Prothrombin activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3289-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,246
-51203,Factor IX,Blood,Hematology,%,3006109,Coagulation factor IX activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3187-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,320
-51204,Factor V,Blood,Hematology,%,3005757,Coagulation factor V activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3193-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,284
-51205,Factor VII,Blood,Hematology,%,3011547,Coagulation factor VII activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3198-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,465
-51206,Factor VIII,Blood,Hematology,%,3019250,Coagulation factor VIII activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3209-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2464
-51207,Factor VIII Inhibitor,Blood,Hematology,N/A,3024942,Coagulation factor VIII inhibitor [Units/volume] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3204-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,192
-51208,Factor X,Blood,Hematology,%,3004409,Coagulation factor X activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3218-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,234
-51209,Factor XI,Blood,Hematology,%,3001850,Coagulation factor XI activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3226-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,306
-51210,Factor XII,Blood,Hematology,%,3002348,Coagulation factor XII activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3232-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,67
-51211,Factor XIII,Blood,Hematology,%,3020066,Coagulation factor XIII activity actual/normal in Platelet poor plasma by Chromogenic method,Measurement,LOINC,Lab Test,S,27815-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,92
-51212,Fetal Hemoglobin,Blood,Hematology,%,3018738,Hemoglobin F/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4576-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,391
-51213,Fibrin Degradation Products,Blood,Hematology,ug/mL,3000401,Fibrin+Fibrinogen fragments [Mass/volume] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,30226-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4526
-51214,"Fibrinogen, Functional",Blood,Hematology,mg/dL,3016407,Fibrinogen [Mass/volume] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3255-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,117171
-51215,FMC-7,Blood,Hematology,,3003047,FMC7 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,17220-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1088
-51216,Fragmented Cells,Blood,Hematology,N/A,3028468,Fragments [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,10373-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6776
-51217,Glyco A,Blood,Hematology,,3037918,Glycolate [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,42502-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,191
-51218,Granulocyte Count,Blood,Hematology,#/uL,3035715,Granulocytes [#/volume] in Blood,Measurement,LOINC,Lab Test,S,30394-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,99523
-51219,H/O Smear,Blood,Hematology,,3018760,Blood smear finding [Identifier] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,5909-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,14459
-51220,Heinz Body Prep,Blood,Hematology,N/A,3022613,Heinz bodies [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,716-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,223
-51221,Hematocrit,Blood,Hematology,%,3023314,Hematocrit [Volume Fraction] of Blood by Automated count,Measurement,LOINC,Lab Test,S,4544-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,3491637
-51222,Hemoglobin,Blood,Hematology,g/dL,3000963,Hemoglobin [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,718-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,3338828
-51223,Hemoglobin A2,Blood,Hematology,%,3020784,Hemoglobin A2/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4551-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3266
-51224,Hemoglobin C,Blood,Hematology,%,3001258,Hemoglobin C/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4563-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5476
-51225,Hemoglobin F,Blood,Hematology,%,3018738,Hemoglobin F/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4576-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51212,3431
-51226,Hemogloblin A,Blood,Hematology,%,3020428,Hemoglobin A/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4546-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5476
-51227,Hemogloblin S,Blood,Hematology,%,3005081,Hemoglobin S/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4625-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5476
-51228,Heparin,Blood,Hematology,U/mL|IU/mL,40769146,Heparin unfractionated [Units/volume] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,66483-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3754
-51229,"Heparin, LMW",Blood,Hematology,U/mL|IU/mL,3045452,LMW Heparin [Units/volume] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,32684-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2608
-51230,HLA-DR,Blood,Hematology,,3047187,HLA-DR [Presence],Measurement,LOINC,Lab Test,S,32621-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,1293
-51231,Howell-Jolly Bodies,Blood,Hematology,N/A,3002620,Howell-Jolly bodies [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,7793-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4895
-51232,Hypersegmented Neutrophils,Blood,Hematology,%,3009864,Neutrophils.hypersegmented/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,30450-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,639
-51233,Hypochromia,Blood,Hematology,N/A,3021303,Hypochromia [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,728-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,254096
-51234,Immunophenotyping,Blood,Hematology,,40758359,Immunophenotyping study,Measurement,LOINC,Lab Test,S,55230-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,2810
-51235,Inhibitor Screen,Blood,Hematology,,3041789,Factor inhibitor XXX [Presence] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,40744-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,935
-51236,Inpatient Hematology/Oncology Smear,Blood,Hematology,,3018760,Blood smear finding [Identifier] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,5909-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,4746
-51237,INR(PT),Blood,Hematology,,3022217,INR in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,6301-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1463103
-51238,Kappa,Blood,Hematology,,3007672,Kappa lymphocytes/100 lymphocytes in Blood,Measurement,LOINC,Lab Test,S,17096-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,1313
-51239,Lambda,Blood,Hematology,,3034226,Lambda lymphocytes/100 lymphocytes in Blood,Measurement,LOINC,Lab Test,S,17224-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,1313
-51240,Large Platelets,Blood,Hematology,,3034118,Platelets Large [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,32146-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6256
-51241,Leukocyte Alkaline Phosphatase,Blood,Hematology,Score,3004218,Leukocyte phosphatase [Enzymatic activity/volume] in Leukocytes,Measurement,LOINC,Lab Test,S,4659-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,51
-51242,LUC,Blood,Hematology,%,3010224,Large unstained cells/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,26463-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,452
-51243,Lupus Anticoagulant,Blood,Hematology,N/A,3027184,Lupus anticoagulant [Interpretation] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,3281-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,4671
-51244,Lymphocytes,Blood,Hematology,%,3037511,Lymphocytes/100 leukocytes in Blood by Automated count,Measurement,LOINC,Lab Test,S,736-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,1308851
-51245,"Lymphocytes, Percent",Blood,Hematology,%,3037511,Lymphocytes/100 leukocytes in Blood by Automated count,Measurement,LOINC,Lab Test,S,736-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51244,27336
-51246,Macrocytes,Blood,Hematology,N/A,3005707,Macrocytes [Presence] in Blood,Measurement,LOINC,Lab Test,S,30424-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,258210
-51247,MacroOvalocytes,Blood,Hematology,N/A,3010950,Oval macrocytes [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,10376-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,904
-51248,MCH,Blood,Hematology,pg,3012030,MCH [Entitic mass] by Automated count,Measurement,LOINC,Lab Test,S,785-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,3315892
-51249,MCHC,Blood,Hematology,%|g/dL,3009744,MCHC [Mass/volume] by Automated count,Measurement,LOINC,Lab Test,S,786-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,3316019
-51250,MCV,Blood,Hematology,fL,3023599,MCV [Entitic volume] by Automated count,Measurement,LOINC,Lab Test,S,787-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,3315893
-51251,Metamyelocytes,Blood,Hematology,%,3002179,Metamyelocytes/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,28541-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,226555
-51252,Microcytes,Blood,Hematology,N/A,3025639,Microcytes [Presence] in Blood,Measurement,LOINC,Lab Test,S,30434-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,254973
-51253,Monocyte Count,Blood,Hematology,#/uL,3033575,Monocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,742-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,36
-51254,Monocytes,Blood,Hematology,%,3011948,Monocytes/100 leukocytes in Blood by Automated count,Measurement,LOINC,Lab Test,S,5905-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,1308850
-51255,Myelocytes,Blood,Hematology,%,3017181,Myelocytes/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,26498-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,224984
-51256,Neutrophils,Blood,Hematology,%,3008342,Neutrophils/100 leukocytes in Blood by Automated count,Measurement,LOINC,Lab Test,S,770-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,1308851
-51257,Nucleated Red Cells,Blood,Hematology,%,40761514,Nucleated erythrocytes/100 leukocytes [Ratio] in Blood by Automated count,Measurement,LOINC,Lab Test,S,58413-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,85227
-51258,Osmotic Fragility,Blood,Hematology,,3032605,Osmotic fragility [Interpretation] of Red Blood Cells,Measurement,LOINC,Lab Test,S,34964-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,7
-51259,Other Cells,Blood,Hematology,%,3013727,Leukocytes other/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,26471-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,10427
-51260,Ovalocytes,Blood,Hematology,N/A,3027920,Ovalocytes [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,774-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,127093
-51261,Pappenheimer Bodies,Blood,Hematology,N/A,3019761,Pappenheimer bodies [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,7795-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4907
-51262,Pencil Cells,Blood,Hematology,N/A,3011151,Pencil cells [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,10377-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2461
-51263,Plasma Cells,Blood,Hematology,%,3018718,Plasma cells/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,13047-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1865
-51264,Platelet Clumps,Blood,Hematology,,3035460,Platelet clump [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,7796-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,369
-51265,Platelet Count,Blood,Hematology,K/uL,3024929,Platelets [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,777-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,3371171
-51266,Platelet Smear,Blood,Hematology,N/A,3033641,Platelet adequacy [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,9317-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,279543
-51267,Poikilocytosis,Blood,Hematology,N/A,3011368,Poikilocytosis [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,779-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,261799
-51268,Polychromasia,Blood,Hematology,N/A,3011987,Polychromasia [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,10378-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,256943
-51269,Promyelocytes,Blood,Hematology,%,3011587,Promyelocytes/100 leukocytes in Blood by Manual count,Measurement,LOINC,Lab Test,S,783-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,10340
-51270,"Protein C, Antigen",Blood,Hematology,%,3002022,Protein C Ag actual/normal in Platelet poor plasma by Immunoassay,Measurement,LOINC,Lab Test,S,27820-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,137
-51271,"Protein C, Functional",Blood,Hematology,%,3020287,Protein C actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,27819-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1665
-51272,"Protein S, Antigen",Blood,Hematology,%,3037201,Protein S Ag actual/normal in Platelet poor plasma by Immunoassay,Measurement,LOINC,Lab Test,S,27823-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,177
-51273,"Protein S, Functional",Blood,Hematology,%,3036669,Protein S actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,27822-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1543
-51274,PT,Blood,Hematology,sec,3034426,Prothrombin time (PT),Measurement,LOINC,Lab Test,S,5902-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1462413
-51275,PTT,Blood,Hematology,sec,3018677,aPTT in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,14979-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1319083
-51276,Quantitative G6PD,Blood,Hematology,U/g/Hb,3003994,Glucose-6-Phosphate dehydrogenase [Enzymatic activity/mass] in Red Blood Cells,Measurement,LOINC,Lab Test,S,32546-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3272
-51277,RDW,Blood,Hematology,%,3019897,Erythrocyte distribution width [Ratio] by Automated count,Measurement,LOINC,Lab Test,S,788-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,3315670
-51278,Red Blood Cell Fragments,Blood,Hematology,,3019880,Schistocytes [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,800-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51287,5
-51279,Red Blood Cells,Blood,Hematology,m/uL,3020416,Erythrocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,789-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,3315894
-51280,Reptilase Time,Blood,Hematology,sec,3005308,Reptilase time,Measurement,LOINC,Lab Test,S,6683-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6
-51281,Reptilase Time Control,Blood,Hematology,sec,3011893,Reptilase time in Control Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,5942-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5
-51282,"Reticulocyte Count, Absolute",Blood,Hematology,m/uL|/mm3,3023520,Reticulocytes [#/volume] in Blood,Measurement,LOINC,Lab Test,S,14196-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,26855
-51283,"Reticulocyte Count, Automated",Blood,Hematology,%,40763528,Reticulocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,60474-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,"Conflict. Label is ""Count"", Unit is ""%""",54614
-51284,"Reticulocyte Count, Manual",Blood,Hematology,%,3041154,Reticulocytes [#/volume] in Blood by Manual count,Measurement,LOINC,Lab Test,S,40665-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,"Conflict. Label is ""Count"", Unit is ""%""",4597
-51285,"Reticulocyte, Cellular Hemoglobin",Blood,Hematology,,46234968,Reticulocyte cellular hemoglobin distribution width [Entitic mass] in Blood by calculation,Measurement,LOINC,Lab Test,S,76686-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51286,Ristocetin,Blood,Hematology,,3027990,Ristocetin [Susceptibility],Measurement,LOINC,Lab Test,S,18975-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,135
-51287,Schistocytes,Blood,Hematology,N/A,3019880,Schistocytes [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,800-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,68264
-51288,Sedimentation Rate,Blood,Hematology,mm/hr,3013707,Erythrocyte sedimentation rate by Westergren method,Measurement,LOINC,Lab Test,S,4537-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,63710
-51289,Serum Viscosity,Blood,Hematology,,3010493,Viscosity of Serum,Measurement,LOINC,Lab Test,S,3128-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1481
-51290,Sickle Cell Preparation,Blood,Hematology,N/A,3020412,Sickle cells [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,801-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,758
-51291,Sickle Cells,Blood,Hematology,N/A,3020412,Sickle cells [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,801-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51290,798
-51292,Spherocytes,Blood,Hematology,N/A,3005481,Spherocytes [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,802-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,19777
-51293,Sugar Water Test,Blood,Hematology,,3028647,Sucrose hemolysis [Presence] of Blood,Measurement,LOINC,Lab Test,S,13534-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,0
-51294,Target Cells,Blood,Hematology,N/A,3025616,Target cells [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,10381-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,25129
-51295,TdT,Blood,Hematology,,3008488,Terminal deoxyribonucleotidyl transferase [Enzymatic activity/volume] in Plasma,Measurement,LOINC,Lab Test,S,2983-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,46
-51296,Teardrop Cells,Blood,Hematology,N/A,3000456,Dacrocytes [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,7791-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,79105
-51297,Thrombin,Blood,Hematology,sec,3036489,Thrombin time,Measurement,LOINC,Lab Test,S,3243-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2047
-51298,Von Willebrand Factor Activity,Blood,Hematology,%,3037533,von Willebrand factor (vWf) ristocetin cofactor actual/normal in Platelet poor plasma by Platelet aggregation,Measurement,LOINC,Lab Test,S,6014-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1127
-51299,Von Willebrand Factor Antigen,Blood,Hematology,%,3036035,von Willebrand factor (vWf) Ag actual/normal in Platelet poor plasma by Immunoassay,Measurement,LOINC,Lab Test,S,27816-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1151
-51300,WBC Count,Blood,Hematology,K/uL,3000905,Leukocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,6690-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,27336
-51301,White Blood Cells,Blood,Hematology,K/uL,3000905,Leukocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,6690-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51300,3321183
-51302,Young Cells,Blood,Hematology,%,40758562,Immature cells/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,55433-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,168
-51303,CD10,Bone Marrow,Hematology,,3030454,CD10 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51216-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51304,CD103,Bone Marrow,Hematology,,3029695,CD103 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51221-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,38
-51305,CD117,Bone Marrow,Hematology,,3037631,CD117 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,42866-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,747
-51306,CD11c,Bone Marrow,Hematology,,3046866,CD11c cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,33202-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,434
-51307,CD13,Bone Marrow,Hematology,,3029960,CD13 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51237-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,877
-51308,CD138,Bone Marrow,Hematology,,3031244,CD138 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,42870-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,16
-51309,CD14,Bone Marrow,Hematology,,3004400,CD14 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,32507-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,614
-51310,CD15,Bone Marrow,Hematology,,3029648,CD15 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51251-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,718
-51311,CD16,Bone Marrow,Hematology,,3029325,CD16 blasts/100 blasts in Bone marrow,Measurement,LOINC,Lab Test,S,51086-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,29
-51312,CD16/56,Bone Marrow,Hematology,,3029712,CD16+CD56+ cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51255-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,145
-51313,CD19,Bone Marrow,Hematology,,3035081,CD19 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,32525-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1657
-51314,CD2,Bone Marrow,Hematology,,3009357,CD2 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,32527-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,887
-51315,CD20,Bone Marrow,Hematology,,3029955,CD20 blasts/100 blasts in Bone marrow,Measurement,LOINC,Lab Test,S,51115-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,1502
-51316,CD22,Bone Marrow,Hematology,,3029412,CD22 blasts/100 blasts in Bone marrow,Measurement,LOINC,Lab Test,S,51124-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,45
-51317,CD23,Bone Marrow,Hematology,,3032694,CD23 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51268-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1113
-51318,CD25,Bone Marrow,Hematology,,3012205,CD25 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,32493-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,63
-51319,CD3,Bone Marrow,Hematology,,3018064,CD3 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,32529-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1583
-51320,CD33,Bone Marrow,Hematology,,3029723,CD33 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51293-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,668
-51321,CD34,Bone Marrow,Hematology,,40760512,CD34 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,57400-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,974
-51322,CD38,Bone Marrow,Hematology,,3030000,CD38 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51298-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,48
-51323,CD4,Bone Marrow,Hematology,,3023029,CD3+CD4+ (T4 helper) cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,32533-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,528
-51324,CD41,Bone Marrow,Hematology,,3029369,CD41 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51319-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,354
-51325,CD45,Bone Marrow,Hematology,,3029857,CD45 (Lymphs) cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51340-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2144
-51326,CD5,Bone Marrow,Hematology,,3035527,CD5 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,35640-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1472
-51327,CD55,Bone Marrow,Hematology,,3033246,CD55 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51344-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6
-51328,CD56,Bone Marrow,Hematology,,3030751,CD3+CD56+ cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51280-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,444
-51329,CD57,Bone Marrow,Hematology,,3014360,CD57 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,32497-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,37
-51330,CD59,Bone Marrow,Hematology,,3031007,CD59 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51358-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5
-51331,CD64,Bone Marrow,Hematology,,3030234,CD64 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51365-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,442
-51332,CD7,Bone Marrow,Hematology,,3035186,CD7 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,35641-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,915
-51333,CD71,Bone Marrow,Hematology,,3009872,CD71 cells/100 cells in Specimen,Measurement,LOINC,Lab Test,S,21169-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,332
-51334,CD8,Bone Marrow,Hematology,,3018724,CD3+CD8+ (T8 suppressor) cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,32535-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,485
-51335,FMC-7,Bone Marrow,Hematology,,3043498,CD20+FMC7+ cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,44061-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,1113
-51336,Glyco A,Bone Marrow,Hematology,,40758985,Glycolate [Moles/volume] in Body fluid,Measurement,LOINC,Lab Test,S,55864-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,319
-51337,HLA-DR,Bone Marrow,Hematology,,3029669,HLA-DR+ cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51380-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,1550
-51338,Immunophenotyping,Bone Marrow,Hematology,,40758359,Immunophenotyping study,Measurement,LOINC,Lab Test,S,55230-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,4851
-51339,Iron Stain,Bone Marrow,Hematology,,3018543,Iron.microscopic observation [Identifier] in Bone marrow by Potassium ferrocyanide stain,Measurement,LOINC,Lab Test,S,13513-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51340,Kappa,Bone Marrow,Hematology,,3051293,Kappa lymphocytes/100 lymphocytes in Bone marrow,Measurement,LOINC,Lab Test,S,46237-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,1475
-51341,Lambda,Bone Marrow,Hematology,,3000611,Lambda lymphocytes/100 lymphocytes in Specimen,Measurement,LOINC,Lab Test,S,20618-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,1475
-51342,Wright Giemsa,Bone Marrow,Hematology,,3014837,Microscopic observation [Identifier] in Bone marrow by Wright Giemsa stain,Measurement,LOINC,Lab Test,S,10355-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3151
-51365,Atypical Lymphocytes,Joint Fluid,Hematology,%,3046317,Variant lymphocytes/100 leukocytes in Synovial fluid,Measurement,LOINC,Lab Test,S,33371-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,142
-51366,Bands,Joint Fluid,Hematology,%,3042845,Band form neutrophils/100 leukocytes in Synovial fluid,Measurement,LOINC,Lab Test,S,33361-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,220
-51367,Basophils,Joint Fluid,Hematology,%,3035319,Basophils/100 leukocytes in Synovial fluid,Measurement,LOINC,Lab Test,S,17833-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,175
-51368,Eosinophils,Joint Fluid,Hematology,%,3035611,Eosinophils/100 leukocytes in Synovial fluid,Measurement,LOINC,Lab Test,S,17834-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1082
-51369,"Hematocrit, Joint Fluid",Joint Fluid,Hematology,%,42868642,Hematocrit [Volume Fraction] of Synovial fluid,Measurement,LOINC,Lab Test,S,70168-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,795
-51370,"Joint Crystals, Birefringence",Joint Fluid,Hematology,,3022683,Crystals [type] in Synovial fluid by Light microscopy,Measurement,LOINC,Lab Test,S,5781-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,1323
-51371,"Joint Crystals, Comment",Joint Fluid,Hematology,,3012027,Character of Synovial fluid,Measurement,LOINC,Lab Test,S,14271-1,0000-0002-9348-9284,0000-0001-8822-1884,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51372,"Joint Crystals, Location",Joint Fluid,Hematology,,3050238,Crystals [Presence] in Synovial fluid by Light microscopy,Measurement,LOINC,Lab Test,S,38458-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,1323
-51373,"Joint Crystals, Number",Joint Fluid,Hematology,,3050238,Crystals [Presence] in Synovial fluid by Light microscopy,Measurement,LOINC,Lab Test,S,38458-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,5645
-51374,"Joint Crystals, Shape",Joint Fluid,Hematology,,3022683,Crystals [type] in Synovial fluid by Light microscopy,Measurement,LOINC,Lab Test,S,5781-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,1323
-51375,Lymphocytes,Joint Fluid,Hematology,%,3003329,Lymphocytes/100 leukocytes in Synovial fluid,Measurement,LOINC,Lab Test,S,26483-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6392
-51376,Macrophage,Joint Fluid,Hematology,%,3029170,Macrophages/100 leukocytes in Synovial fluid,Measurement,LOINC,Lab Test,S,33376-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3052
-51377,Mesothelial Cells,Joint Fluid,Hematology,%,3043694,Mesothelial cells/100 leukocytes in Synovial fluid,Measurement,LOINC,Lab Test,S,33365-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,332
-51378,Metamyelocytes,Joint Fluid,Hematology,%,3024936,Metamyelocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17801-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,15
-51379,Monocytes,Joint Fluid,Hematology,%,3009361,Monocytes/100 leukocytes in Synovial fluid,Measurement,LOINC,Lab Test,S,17835-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6392
-51380,NRBC,Joint Fluid,Hematology,%,40771130,Nucleated erythrocytes/100 leukocytes [Ratio] in Synovial fluid,Measurement,LOINC,Lab Test,S,68545-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,70
-51381,Other,Joint Fluid,Hematology,%,3013794,Leukocytes other/100 leukocytes in Synovial fluid,Measurement,LOINC,Lab Test,S,30410-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,920
-51382,Polys,Joint Fluid,Hematology,%,3006571,Polymorphonuclear cells/100 leukocytes in Synovial fluid,Measurement,LOINC,Lab Test,S,26522-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6392
-51383,"RBC, Joint Fluid",Joint Fluid,Hematology,#/uL,3010144,Erythrocytes [#/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,26458-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5619
-51385,Atypical Lymphocytes,Other Body Fluid,Hematology,%,3007169,Variant lymphocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,30417-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,145
-51386,Bands,Other Body Fluid,Hematology,%,3017161,Band form neutrophils/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,26510-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,192
-51387,Basophils,Other Body Fluid,Hematology,%,3021302,Basophils/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,28543-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,196
-51388,CD10,Other Body Fluid,Hematology,,3030724,CD10 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51217-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1929
-51389,CD103,Other Body Fluid,Hematology,,3034064,CD103 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,42864-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,11
-51390,CD117,Other Body Fluid,Hematology,,3031818,CD117 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,42867-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,63
-51391,CD11c,Other Body Fluid,Hematology,,3030790,CD11c cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51232-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,30
-51392,CD13,Other Body Fluid,Hematology,,3030772,CD13 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51238-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,104
-51393,CD138,Other Body Fluid,Hematology,,3033713,CD138 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,42871-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,44
-51394,CD14,Other Body Fluid,Hematology,,3029714,CD14 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51248-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,41
-51395,CD15,Other Body Fluid,Hematology,,3029717,CD15 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51252-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,58
-51396,CD16,Other Body Fluid,Hematology,,3022430,CD16 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,17828-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,15
-51397,CD16/56,Other Body Fluid,Hematology,,3008741,CD16+CD56+ cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,18268-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,87
-51398,CD19,Other Body Fluid,Hematology,,3013368,CD19 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,17829-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3130
-51399,CD2,Other Body Fluid,Hematology,,3034427,CD2 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,17827-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1081
-51400,CD20,Other Body Fluid,Hematology,,40760530,CD20 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,57418-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1925
-51401,CD22,Other Body Fluid,Hematology,,3031560,CD22 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,42875-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,17
-51402,CD23,Other Body Fluid,Hematology,,3033041,CD23 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51269-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1482
-51403,CD25,Other Body Fluid,Hematology,,3031912,CD25 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51271-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,23
-51404,CD3,Other Body Fluid,Hematology,,3033894,CD3 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,17826-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1945
-51405,CD33,Other Body Fluid,Hematology,,3029576,CD33 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51294-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,50
-51406,CD34,Other Body Fluid,Hematology,#/uL,40762032,CD34 cells [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,58939-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1045
-51407,CD38,Other Body Fluid,Hematology,,3030804,CD38 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51299-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,50
-51408,CD4,Other Body Fluid,Hematology,,3002870,CD3+CD4+ (T4 helper) cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,17822-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,234
-51409,CD4/CD8 Ratio,Other Body Fluid,Hematology,,3014859,CD3+CD4+ (T4 helper) cells/CD3+CD8+ (T8 suppressor cells) cells [# Ratio] in Body fluid,Measurement,LOINC,Lab Test,S,18266-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,50
-51410,CD41,Other Body Fluid,Hematology,,3030262,CD41 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51320-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,15
-51411,CD45,Other Body Fluid,Hematology,,3001845,CD45 (Lymphs) cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,17823-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3234
-51412,CD5,Other Body Fluid,Hematology,,40760535,CD5 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,57423-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1980
-51413,CD56,Other Body Fluid,Hematology,,40760536,CD56 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,57424-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,68
-51414,CD57,Other Body Fluid,Hematology,,3029617,CD57 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51351-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,16
-51415,CD64,Other Body Fluid,Hematology,,3029062,CD64 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51366-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,33
-51416,CD7,Other Body Fluid,Hematology,,40760537,CD7 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,57425-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1087
-51417,CD71,Other Body Fluid,Hematology,,40760538,CD71 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,57426-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,15
-51418,CD8,Other Body Fluid,Hematology,,3000683,CD3+CD8+ (T8 suppressor) cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,17824-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,228
-51419,Eosinophils,Other Body Fluid,Hematology,%,3021453,Eosinophils/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,26452-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1631
-51420,FMC-7,Other Body Fluid,Hematology,,40760540,FMC7 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,57428-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1488
-51421,Glyco A,Other Body Fluid,Hematology,,40758985,Glycolate [Moles/volume] in Body fluid,Measurement,LOINC,Lab Test,S,55864-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,14
-51422,"Hematocrit, Other Fluid",Other Body Fluid,Hematology,%,3008108,Hematocrit [Volume Fraction] of Body fluid,Measurement,LOINC,Lab Test,S,11153-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,466
-51423,HLA-DR,Other Body Fluid,Hematology,,3030297,HLA-DR+ cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51381-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1520
-51424,Immunophenotyping,Other Body Fluid,Hematology,,40758359,Immunophenotyping study,Measurement,LOINC,Lab Test,S,55230-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,5473
-51425,Kappa,Other Body Fluid,Hematology,,3051901,Kappa lymphocytes/100 lymphocytes in Body fluid,Measurement,LOINC,Lab Test,S,46238-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2733
-51426,Lambda,Other Body Fluid,Hematology,,3000611,Lambda lymphocytes/100 lymphocytes in Specimen,Measurement,LOINC,Lab Test,S,20618-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,2732
-51427,Lymphocytes,Other Body Fluid,Hematology,%,3028079,Lymphocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,11031-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4974
-51428,Macrophage,Other Body Fluid,Hematology,%,3024126,Macrophages/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,30427-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3421
-51429,Mesothelial cells,Other Body Fluid,Hematology,%,3036353,Mesothelial cells/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,28544-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1132
-51430,Metamyelocytes,Other Body Fluid,Hematology,%,3024936,Metamyelocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17801-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,22
-51431,Monos,Other Body Fluid,Hematology,%,3038104,Monocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,26487-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4974
-51432,Myelocytes,Other Body Fluid,Hematology,%,3024394,Myelocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17800-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,11
-51433,NRBC,Other Body Fluid,Hematology,%,3053291,Nucleated erythrocytes/100 leukocytes [Ratio] in Body fluid,Measurement,LOINC,Lab Test,S,49229-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,91
-51434,Other Cell,Other Body Fluid,Hematology,%,46235833,Other cells/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,76350-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1724
-51435,Plasma,Other Body Fluid,Hematology,%,3011681,Plasma cells/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17803-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,58
-51436,Polys,Other Body Fluid,Hematology,%,3025450,Polymorphonuclear cells/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,26518-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4974
-51437,Promyelocytes,Other Body Fluid,Hematology,%,3023316,Promyelocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17799-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,11
-51438,"RBC, Other Fluid",Other Body Fluid,Hematology,#/uL,3010910,Erythrocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,26455-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1934
-51440,Atypical Lymphocytes,Pleural,Hematology,%,3046289,Variant lymphocytes/100 leukocytes in Pleural fluid,Measurement,LOINC,Lab Test,S,33370-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,409
-51441,Bands,Pleural,Hematology,%,1988450,Band form neutrophils/100 leukocytes in Pleural fluid by Manual count,Measurement,LOINC,Lab Test,S,99604-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.72,https://loinc.org/search/,,3/1/2022,,Manual count only,185
-51442,Basophils,Pleural,Hematology,%,3030571,Basophils/100 leukocytes in Pleural fluid,Measurement,LOINC,Lab Test,S,35070-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,468
-51443,Blasts,Pleural,Hematology,%,3028880,Blasts/100 leukocytes in Pleural fluid,Measurement,LOINC,Lab Test,S,33373-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,11
-51444,Eosinophils,Pleural,Hematology,%,3001893,Eosinophils/100 leukocytes in Pleural fluid,Measurement,LOINC,Lab Test,S,30379-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2424
-51445,"Hematocrit, Pleural",Pleural,Hematology,%,42868643,Hematocrit [Volume Fraction] of Pleural fluid,Measurement,LOINC,Lab Test,S,70169-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,971
-51446,Lymphocytes,Pleural,Hematology,%,3005532,Lymphocytes/100 leukocytes in Pleural fluid,Measurement,LOINC,Lab Test,S,26481-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7930
-51447,Macrophages,Pleural,Hematology,%,3039528,Macrophages/100 leukocytes in Pleural fluid by Manual count,Measurement,LOINC,Lab Test,S,40520-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Manual count only,5755
-51448,Mesothelial Cells,Pleural,Hematology,%,3028029,Mesothelial cells/100 leukocytes in Pleural fluid,Measurement,LOINC,Lab Test,S,30431-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4430
-51449,Metamyelocytes,Pleural,Hematology,%,3024936,Metamyelocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17801-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,24
-51450,Monos,Pleural,Hematology,%,3043387,Monocytes/100 leukocytes in Pleural fluid,Measurement,LOINC,Lab Test,S,33362-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7930
-51451,Myelocytes,Pleural,Hematology,%,3024394,Myelocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17800-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,15
-51452,NRBC,Pleural,Hematology,%,42868644,Nucleated erythrocytes/100 cells in Pleural fluid,Measurement,LOINC,Lab Test,S,70170-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,141
-51453,Other,Pleural,Hematology,%,3015094,Leukocytes other/100 leukocytes in Pleural fluid,Measurement,LOINC,Lab Test,S,30408-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3149
-51454,Plasma Cells,Pleural,Hematology,%,3040900,Plasma cells/100 leukocytes in Pleural fluid by Manual count,Measurement,LOINC,Lab Test,S,40522-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Manual count only,524
-51455,Polys,Pleural,Hematology,%,3026051,Polymorphonuclear cells/100 leukocytes in Pleural fluid,Measurement,LOINC,Lab Test,S,26519-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7930
-51456,Promyelocytes,Pleural,Hematology,%,3023316,Promyelocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17799-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,31
-51457,"RBC, Pleural",Pleural,Hematology,#/uL,3028308,Erythrocytes [#/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,26456-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7341
-51459,Young Cells,Pleural,Hematology,%,40758562,Immature cells/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,55433-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,1
-51460,"Blood, Occult",Stool,Hematology,N/A,3016251,Hemoglobin.gastrointestinal [Presence] in Stool,Measurement,LOINC,Lab Test,S,2335-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,2995
-51461,Ammonium Biurate,Urine,Hematology,/hpf,3019200,Ammonium urate crystals [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,25144-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,25
-51462,Amorphous Crystals,Urine,Hematology,/hpf,40763395,Crystals.amorphous [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,60340-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,34733
-51463,Bacteria,Urine,Hematology,/hpf,3025255,Bacteria [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,5769-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,502195
-51464,Bilirubin,Urine,Hematology,mg/dL|N/A|EU/dL,3018834,Bilirubin.total [Presence] in Urine by Test strip,Measurement,LOINC,Lab Test,S,5770-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,713348
-51465,Bilirubin Crystals,Urine,Hematology,/hpf,3014537,Bilirubin crystals [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5771-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,88
-51466,Blood,Urine,Hematology,N/A,3051227,Blood [Presence] in Urine by Visual,Measurement,LOINC,Lab Test,S,53963-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,713350
-51467,Broad Casts,Urine,Hematology,#/lpf,3017179,Broad casts [#/area] in Urine sediment by Microscopy low power field,Measurement,LOINC,Lab Test,S,18487-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,103
-51468,Calcium Carbonate Crystals,Urine,Hematology,/hpf,3007501,Calcium carbonate crystals [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5773-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,15
-51469,Calcium Oxalate Crystals,Urine,Hematology,/hpf,3006490,Calcium oxalate crystals [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5774-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,15877
-51470,Calcium Phosphate Crystals,Urine,Hematology,/hpf,3022327,Calcium phosphate crystals [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5775-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,59
-51471,Cellular Cast,Urine,Hematology,#/lpf,3042588,Mixed cellular casts [#/area] in Urine sediment by Microscopy low power field,Measurement,LOINC,Lab Test,S,38995-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1002
-51472,Cholesterol Crystals,Urine,Hematology,/hpf,3026327,Cholesterol crystals [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5777-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,20
-51473,Cysteine Crystals,Urine,Hematology,/hpf,3027820,Cystine crystals [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5784-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,18
-51474,Eosinophils,Urine,Hematology,,3037579,Eosinophils [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,25156-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7109
-51475,Epithelial Casts,Urine,Hematology,#/lpf,3024290,Epithelial casts [#/area] in Urine sediment by Microscopy low power field,Measurement,LOINC,Lab Test,S,5786-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,34
-51476,Epithelial Cells,Urine,Hematology,#/hpf,3010189,Epithelial cells [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,5787-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,502193
-51477,Free Fat,Urine,Hematology,,3023744,Fat [Presence] in Urine,Measurement,LOINC,Lab Test,S,2272-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,12
-51478,Glucose,Urine,Hematology,mg/dL,3024629,Glucose [Mass/volume] in Urine by Test strip,Measurement,LOINC,Lab Test,S,5792-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,713349
-51479,Granular Casts,Urine,Hematology,#/lpf,3011483,Granular casts [#/area] in Urine sediment by Microscopy low power field,Measurement,LOINC,Lab Test,S,5793-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,15192
-51480,Hematocrit,Urine,Hematology,%,3003427,Hematocrit [Volume Fraction] of Urine,Measurement,LOINC,Lab Test,S,17809-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,15
-51481,Hemosiderin,Urine,Hematology,N/A,3036265,Hemosiderin [Presence] in Urine,Measurement,LOINC,Lab Test,S,4644-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,699
-51482,Hyaline Casts,Urine,Hematology,#/lpf,3022509,Hyaline casts [#/area] in Urine sediment by Microscopy low power field,Measurement,LOINC,Lab Test,S,5796-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,109894
-51483,Hyphenated Yeast,Urine,Hematology,,3033741,Yeast.hyphae [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,41865-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5
-51484,Ketone,Urine,Hematology,mg/dL,3023539,Ketones [Mass/volume] in Urine by Test strip,Measurement,LOINC,Lab Test,S,5797-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,713348
-51485,Leucine Crystals,Urine,Hematology,,3019169,Leucine crystals [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5798-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,9
-51486,Leukocytes,Urine,Hematology,N/A,3022547,Leukocytes [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,20455-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,713354
-51487,Nitrite,Urine,Hematology,N/A,3021601,Nitrite [Presence] in Urine by Test strip,Measurement,LOINC,Lab Test,S,5802-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,713347
-51488,Non-squamous Epithelial Cells,Urine,Hematology,#/hpf,3042062,Epithelial cells.non-squamous [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,41284-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,196
-51489,NonSquamous Epithelial Cell,Urine,Hematology,#/hpf,3042062,Epithelial cells.non-squamous [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,41284-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51488,749
-51490,Oval Fat Body,Urine,Hematology,/hpf,3010491,Oval fat bodies (globules) [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,5788-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,33
-51491,pH,Urine,Hematology,units,3022621,pH of Urine by Test strip,Measurement,LOINC,Lab Test,S,5803-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51094,713354
-51492,Protein,Urine,Hematology,mg/dL,3005897,Protein [Mass/volume] in Urine by Test strip,Measurement,LOINC,Lab Test,S,5804-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,713349
-51493,RBC,Urine,Hematology,#/hpf,3035124,Erythrocytes [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,13945-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,502196
-51494,RBC Casts,Urine,Hematology,#/lpf,3002587,RBC casts [#/area] in Urine sediment by Microscopy low power field,Measurement,LOINC,Lab Test,S,5807-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,96
-51495,RBC Clumps,Urine,Hematology,/hpf,40761550,Erythrocyte clumps [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,58449-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,38
-51496,"Reducing Substances, Urine",Urine,Hematology,%,3020029,Reducing substances [Presence] in Urine,Measurement,LOINC,Lab Test,S,5809-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,336
-51497,Renal Epithelial Cells,Urine,Hematology,#/hpf,3015023,Epithelial cells.renal [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,26052-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7350
-51498,Specific Gravity,Urine,Hematology,,3000330,Specific gravity of Urine by Test strip,Measurement,LOINC,Lab Test,S,5811-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,713354
-51499,Sperm,Urine,Hematology,,3026796,Spermatozoa [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,8248-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,824
-51500,Sulfonamides,Urine,Hematology,,3003356,Sulfonamide crystals [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5812-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,8
-51501,Transitional Epithelial Cells,Urine,Hematology,#/hpf,3035851,Transitional cells [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,30089-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,65928
-51502,Trichomonas,Urine,Hematology,/hpf,3029154,Trichomonas sp [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,33905-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,158
-51503,Triple Phosphate Crystals,Urine,Hematology,/hpf,3001137,Triple phosphate crystals [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5814-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1238
-51504,Tyrosine Crystals,Urine,Hematology,,3021314,Tyrosine crystals [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5815-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,11
-51505,Uric Acid Crystals,Urine,Hematology,/hpf,3036882,Urate crystals [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5817-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2446
-51506,Urine Appearance,Urine,Hematology,N/A,3007876,Appearance of Urine,Measurement,LOINC,Lab Test,S,5767-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,713354
-51507,"Urine Casts, Other",Urine,Hematology,#/lpf,3005658,Casts [#/area] in Urine sediment by Microscopy low power field,Measurement,LOINC,Lab Test,S,9842-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,414
-51508,Urine Color,Urine,Hematology,N/A,3027162,Color of Urine,Measurement,LOINC,Lab Test,S,5778-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,132570
-51509,Urine Comments,Urine,Hematology,,3036005,Urine sediment comments by Light microscopy Narrative,Measurement,LOINC,Lab Test,S,11279-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51510,"Urine Crystals, Other",Urine,Hematology,/hpf,3026978,Unidentified crystals [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5783-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,400
-51511,Urine Fat Bodies,Urine,Hematology,,3033486,Oval fat bodies (globules) [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,25158-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,77
-51512,Urine Mucous,Urine,Hematology,/hpf,3006175,Mucus [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,8247-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,331200
-51513,Urine Specimen Type,Urine,Hematology,,3025954,Urinalysis specimen collection method,Measurement,LOINC,Lab Test,S,19159-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4873
-51514,Urobilinogen,Urine,Hematology,mg/dL,3037072,Urobilinogen [Mass/volume] in Urine by Test strip,Measurement,LOINC,Lab Test,S,20405-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,713347
-51515,Waxy Casts,Urine,Hematology,#/lpf,3020851,Waxy casts [#/area] in Urine sediment by Microscopy low power field,Measurement,LOINC,Lab Test,S,5819-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,291
-51516,WBC,Urine,Hematology,#/hpf,3035583,Leukocytes [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,5821-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,502196
-51517,WBC Casts,Urine,Hematology,#/lpf,3002052,WBC casts [#/area] in Urine sediment by Microscopy low power field,Measurement,LOINC,Lab Test,S,5820-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,633
-51518,WBC Clumps,Urine,Hematology,/hpf,40770446,Leukocyte clumps [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,67848-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,18856
-51519,Yeast,Urine,Hematology,/hpf,3037244,Yeast [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,5822-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,502193
-51556,Anti-Microsomal Antibodies,Blood,Chemistry,,3015352,Thyroperoxidase Ab [Units/volume] in Serum or Plasma by Radioimmunoassay (RIA),Measurement,LOINC,Lab Test,S,5382-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51557,Anti-Microsomal Antibody,Blood,Chemistry,,3011617,Mitochondria Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,8077-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51558,Antirnp,Blood,Chemistry,,3008025,Ribonucleoprotein extractable nuclear Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,8091-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51559,Anti-ro,Blood,Chemistry,,3015154,Sjogrens syndrome-A extractable nuclear Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,8093-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51560,Anti-SARS-CoV-2 IgA,Blood,Chemistry,,723473,SARS-CoV-2 (COVID-19) IgA Ab [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,94562-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51561,Anti-SARS-CoV-2 IgG,Blood,Chemistry,,723474,SARS-CoV-2 (COVID-19) IgG Ab [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,94563-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51562,Anti-Skin Antibody,Blood,Chemistry,,40769532,Skin Ab [Titer] in Serum,Measurement,LOINC,Lab Test,S,66878-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51563,Anti-sm,Blood,Chemistry,,3005932,Smooth muscle Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,14252-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51564,ARCH-1,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,25853
-51565,Argon,Blood,Chemistry,,21490915,Argon [VFr/PPres] Gas delivery system,Measurement,LOINC,Lab Test,S,76127-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51566,Beta,Blood,Chemistry,,3016520,Beta globulin [Mass/volume] in Serum or Plasma by Electrophoresis,Measurement,LOINC,Lab Test,S,2871-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51567,Beta Hydroxybutyrate,Blood,Chemistry,mmol/L,3003985,Beta hydroxybutyrate [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,6873-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,395
-51568,"Bilirubin, Neonatal",Blood,Chemistry,,3043744,Bilirubin.conjugated+indirect [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,33898-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51569,"Bilirubin, Neonatal, Direct",Blood,Chemistry,,3019676,Bilirubin.conjugated [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,15152-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51570,"Bilirubin, Neonatal, Indirect",Blood,Chemistry,,3007359,Bilirubin.indirect [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1971-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51571,Billed,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,2
-51572,Bioavailable Testosterone,Blood,Chemistry,,3023837,Testosterone.free+weakly bound/Testosterone.total in Serum or Plasma,Measurement,LOINC,Lab Test,S,6891-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51573,Bromide,Blood,Chemistry,,3026383,Bromide [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1984-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51574,C1 Inhibitor,Blood,Chemistry,,3003245,Complement C1 esterase inhibitor [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,4477-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51575,C1q,Blood,Chemistry,,3002140,Complement C1q [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,4478-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51576,C2,Blood,Chemistry,,3001793,Complement C2 [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,4484-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51577,C5,Blood,Chemistry,,3017692,Complement C5 [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,4505-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51578,C6,Blood,Chemistry,,3018772,Complement C6 [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,4507-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51579,CA 19-9,Blood,Chemistry,U/mL,3022914,Cancer Ag 19-9 [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,24108-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,573
-51580,Calculated CK-MB,Blood,Chemistry,,3025909,Creatine kinase.MB/Creatine kinase.total in Serum or Plasma by calculation,Measurement,LOINC,Lab Test,S,12189-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51581,Carotene,Blood,Chemistry,,3001599,Carotene [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2053-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51582,CH50,Blood,Chemistry,,3028461,Complement total hemolytic CH50 [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,4532-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51583,Chol Estr,Blood,Chemistry,,3016297,Cholesterol esterase [Enzymatic activity/volume] in Serum,Measurement,LOINC,Lab Test,S,2083-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51584,Chylomicrons,Blood,Chemistry,,3020132,Chylomicrons [Presence] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2121-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51585,Clostrid,Blood,Chemistry,,3035407,Clostridium tetani toxoid Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,26643-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51586,CMV IgG Ab,Blood,Chemistry,,3016816,Cytomegalovirus IgG Ab [Presence] in Serum or Plasma,Measurement,LOINC,Lab Test,S,22244-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,824
-51587,CMV IgG Ab Value,Blood,Chemistry,,3005356,Cytomegalovirus IgG Ab [Units/volume] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,5124-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,823
-51588,CMV IgM Ab,Blood,Chemistry,,3013332,Cytomegalovirus IgM Ab [Presence] in Serum or Plasma,Measurement,LOINC,Lab Test,S,30325-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,697
-51589,CMV IgM Ab Value,Blood,Chemistry,,3003526,Cytomegalovirus IgM Ab [Units/volume] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,5126-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51590,CMV Interpretation,Blood,Chemistry,,3038184,Cytomegalovirus IgG Ab [Interpretation] in Serum or Plasma,Measurement,LOINC,Lab Test,S,20475-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,697
-51591,Confirmation,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51592,Conj Bili,Blood,Chemistry,,3027597,Bilirubin.direct [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1968-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51593,Copper,Blood,Chemistry,,3027126,Copper [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,5631-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51594,"Creatine Kinase, Isoenzyme BB",Blood,Chemistry,,3015040,Creatine kinase.BB/Creatine kinase.total in Serum or Plasma,Measurement,LOINC,Lab Test,S,9642-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51595,"Creatine Kinase, Isoenzyme MB",Blood,Chemistry,,3016311,Creatine kinase.MB/Creatine kinase.total in Serum or Plasma,Measurement,LOINC,Lab Test,S,20569-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51596,"Creatine Kinase, Isoenzyme MM",Blood,Chemistry,,3008558,Creatine kinase.MM/Creatine kinase.total in Serum or Plasma,Measurement,LOINC,Lab Test,S,9643-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51597,Cvhlc,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51598,Cytomegalovirus Viral Load,Blood,Chemistry,log10 IU/mL,40757337,Cytomegalovirus DNA [Log #/volume] (viral load) in Serum or Plasma by NAA with probe detection,Measurement,LOINC,Lab Test,S,54206-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6906
-51599,D,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51600,Delete,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51601,Delete,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51602,Delete,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51603,Delete,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51604,Delete,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51605,Delta/Dlt,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51606,Digitoxin,Blood,Chemistry,,3007288,Digitoxin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3559-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51607,"Dimeric Inhibin A, Maternal Screen",Blood,Chemistry,,3018595,Inhibin A [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,23883-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51608,DirLst,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,2
-51609,Disopyramide,Blood,Chemistry,,3026235,Disopyramide [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3576-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51610,Dlta Bili,Blood,Chemistry,,3004173,Bilirubin.delta [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1970-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51611,Down Syndrome Risk,Blood,Chemistry,,3043238,Trisomy 21 risk [Likelihood] in Fetus,Measurement,LOINC,Lab Test,S,43995-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51612,Dr. X,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51613,eAG,Blood,Chemistry,mg/dL,3005131,Glucose mean value [Mass/volume] in Blood Estimated from glycated hemoglobin,Measurement,LOINC,Lab Test,S,27353-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,201396
-51614,Epstein-Barr Virus  EBNA IgG Ab,Blood,Chemistry,,3021849,Epstein Barr virus nuclear IgG Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,7883-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,636
-51615,Epstein-Barr Virus EBNA IgG Ab,Blood,Chemistry,,3021849,Epstein Barr virus nuclear IgG Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,7883-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51614,630
-51616,Epstein-Barr Virus IgG Ab Value,Blood,Chemistry,,3007080,Epstein Barr virus nuclear IgG Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,31374-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,629
-51617,Epstein-Barr Virus IgM Ab Value,Blood,Chemistry,,3006033,Epstein Barr virus nuclear IgM Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,31375-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,629
-51618,Epstein-Barr Virus Interpretation,Blood,Chemistry,,3031599,Epstein Barr virus band pattern [Interpretation] in Specimen by Immunoblot Narrative,Measurement,LOINC,Lab Test,S,49564-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,636
-51619,Epstein-Barr Virus VCA IgG Ab,Blood,Chemistry,,3015681,Epstein Barr virus capsid IgG Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,7885-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,636
-51620,Epstein-Barr Virus VCA IgM Ab,Blood,Chemistry,,3008360,Epstein Barr virus capsid IgM Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,7886-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,636
-51621,Ethylene Glycol,Blood,Chemistry,mg/dL,3020475,"Ethylene glycol [Mass/volume] in Serum, Plasma or Blood",Measurement,LOINC,Lab Test,S,5646-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,166
-51622,Factor B,Blood,Chemistry,,3002568,Complement factor B [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2269-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51623,Fibrinogen,Blood,Chemistry,,3016407,Fibrinogen [Mass/volume] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3255-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51624,Free Calcium,Blood,Chemistry,,3021119,Calcium.ionized [Moles/volume] in Blood,Measurement,LOINC,Lab Test,S,1994-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51625,Free Kappa,Blood,Chemistry,mg/L,3034860,Kappa light chains.free [Mass/volume] in Serum,Measurement,LOINC,Lab Test,S,36916-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,14253
-51626,Free Kappa/Free Lambda Ratio,Blood,Chemistry,,3053209,Kappa light chains.free/Lambda light chains.free [Mass Ratio] in Serum,Measurement,LOINC,Lab Test,S,48378-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,14164
-51627,Free Lambda,Blood,Chemistry,mg/L,3047169,Lambda light chains.free [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,33944-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,14239
-51628,Fructosamine,Blood,Chemistry,,3019839,Fructosamine [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,15069-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51629,Fructosamine Plus,Blood,Chemistry,,3019839,Fructosamine [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,15069-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51630,Gamma,Blood,Chemistry,,3023465,Gamma globulin [Mass/volume] in Serum or Plasma by Electrophoresis,Measurement,LOINC,Lab Test,S,2874-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51631,Glycated Hemoglobin,Blood,Chemistry,,3004410,Hemoglobin A1c/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4548-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51632,Growth Hormone,Blood,Chemistry,,3023709,Somatotropin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2963-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51633,Hbeag,Blood,Chemistry,,3023378,Hepatitis B virus e Ag [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,13954-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51634,Hbsag,Blood,Chemistry,,3019510,Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,5196-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51635,Hbsag,Blood,Chemistry,,3019510,Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,5196-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51634,0
-51636,"HCG, Multiples of Median",Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51637,"HCG, Qualitative",Blood,Chemistry,,3011149,Choriogonadotropin.beta subunit (pregnancy test) [Presence] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2110-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51638,Hematocrit,Blood,Chemistry,%,3023314,Hematocrit [Volume Fraction] of Blood by Automated count,Measurement,LOINC,Lab Test,S,4544-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51221,386
-51639,Hematocrit,Blood,Chemistry,,3023314,Hematocrit [Volume Fraction] of Blood by Automated count,Measurement,LOINC,Lab Test,S,4544-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51221,0
-51640,Hemoglobin,Blood,Chemistry,,3000963,Hemoglobin [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,718-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 50811,0
-51641,Hemoglobin  A,Blood,Chemistry,,3020428,Hemoglobin A/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4546-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51642,Hemoglobin  A1,Blood,Chemistry,,3005446,Hemoglobin A1/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4547-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51643,Hemoglobin  A2,Blood,Chemistry,,3020784,Hemoglobin A2/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,968472,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51223,0
-51644,Hemoglobin  C,Blood,Chemistry,,3001258,Hemoglobin C/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4563-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51645,"Hemoglobin, Calculated",Blood,Chemistry,g/dL,3027484,Hemoglobin [Mass/volume] in Blood by calculation,Measurement,LOINC,Lab Test,S,20509-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,386
-51646,Hemoglobin  F,Blood,Chemistry,,3018738,Hemoglobin F/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4576-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51212,0
-51647,Hemoglobin  S,Blood,Chemistry,,3005081,Hemoglobin S/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,4625-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51227,0
-51648,Hepatitis B Viral Load,Blood,Chemistry,log10 IU/mL,3048505,Hepatitis B virus DNA [log units/volume] (viral load) in Serum or Plasma by NAA with probe detection,Measurement,LOINC,Lab Test,S,48398-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3393
-51649,Hepatitis B Virus E Antibody,Blood,Chemistry,,3023202,Hepatitis B virus e Ab [Units/volume] in Serum by Immunoassay,Measurement,LOINC,Lab Test,S,5189-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51650,Hepatitis B Virus E Antigen,Blood,Chemistry,,3011516,Hepatitis B virus e Ag [Units/volume] in Serum by Immunoassay,Measurement,LOINC,Lab Test,S,5191-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51651,Hepatitis C Viral Load,Blood,Chemistry,log10 IU/mL,3034868,Hepatitis C virus RNA [log units/volume] (viral load) in Serum or Plasma by NAA with probe detection,Measurement,LOINC,Lab Test,S,38180-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4498
-51652,High-Sensitivity CRP,Blood,Chemistry,mg/L,3010156,C reactive protein [Mass/volume] in Serum or Plasma by High sensitivity method,Measurement,LOINC,Lab Test,S,30522-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,229
-51653,HIV 1 Ab Confirmation,Blood,Chemistry,N/A,3017675,HIV 1 Ab [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,29893-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,253
-51654,HIV 1 Viral Load,Blood,Chemistry,log10 copies/mL|log10 cop/mL,3026532,HIV 1 RNA [Log #/volume] (viral load) in Serum or Plasma by NAA with probe detection,Measurement,LOINC,Lab Test,S,29541-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3842
-51655,HIV 2 Ab Confirmation,Blood,Chemistry,N/A,3024449,HIV 2 Ab [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,30361-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,253
-51656,Hlap,Blood,Chemistry,,3011081,Alkaline phosphatase.heat labile [Enzymatic activity/volume] in Serum or Plasma by Heat stability,Measurement,LOINC,Lab Test,S,32351-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51657,HPE1,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,0,Unknown Abbreviation,22663
-51658,HPE2,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,0,Unknown Abbreviation,19165
-51659,HPE3,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,0,Unknown Abbreviation,15796
-51660,HPE4,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,0,Unknown Abbreviation,6315
-51661,HPE5,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,0,Unknown Abbreviation,917
-51662,HPE6,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,0,Unknown Abbreviation,2009
-51663,HPE7,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,0,Unknown Abbreviation,21887
-51664,HPE8,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,0,Unknown Abbreviation,1281
-51665,HPE9,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,0,Unknown Abbreviation,11
-51666,H. pylori IgG Ab,Blood,Chemistry,,3023871,Helicobacter pylori IgG Ab [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,17859-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,332
-51667,H. pylori IgG Ab Value,Blood,Chemistry,,3027491,Helicobacter pylori IgG Ab [Units/volume] in Serum by Immunoassay,Measurement,LOINC,Lab Test,S,5176-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,296
-51668,Hsap,Blood,Chemistry,,3016506,Alkaline phosphatase.heat stable [Enzymatic activity/volume] in Serum or Plasma by Heat stability,Measurement,LOINC,Lab Test,S,32352-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51669,Htlv Ab,Blood,Chemistry,,3014389,HTLV I+II Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,22362-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51670,Icd9,Blood,Chemistry,,3038810,"Diagnosis recommendations, ICD9-CM CPHS",Measurement,LOINC,Lab Test,S,39222-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51671,IFEgel,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51672,Immune Complexes,Blood,Chemistry,,3017905,Immune complex [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,5228-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51673,Immunoelectrophoresis,Blood,Chemistry,,3000265,Immunoelectrophoresis for Serum or Plasma,Measurement,LOINC,Lab Test,S,13169-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51674,Immunoglobulin E,Blood,Chemistry,,3016604,IgE [Mass/volume] in Serum,Measurement,LOINC,Lab Test,S,2462-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51675,INR(PT),Blood,Chemistry,,3022217,INR in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,6301-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,34
-51676,Insulin,Blood,Chemistry,,3016244,Insulin [Units/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,20448-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51677,K (GREEN),Blood,Chemistry,mEq/L,3023103,Potassium [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2823-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 50971,460
-51678,L,Blood,Chemistry,U,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,1506719
-51679,Lap,Blood,Chemistry,,3004218,Leukocyte phosphatase [Enzymatic activity/volume] in Leukocytes,Measurement,LOINC,Lab Test,S,4659-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51680,"LD, Isoenzyme 1",Blood,Chemistry,,3006898,Lactate dehydrogenase 1/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,Measurement,LOINC,Lab Test,S,2536-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51681,"LD, Isoenzyme 2",Blood,Chemistry,,3023919,Lactate dehydrogenase 2/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,Measurement,LOINC,Lab Test,S,2539-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51682,"LD, Isoenzyme 3",Blood,Chemistry,,3007858,Lactate dehydrogenase 3/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,Measurement,LOINC,Lab Test,S,2542-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51683,"LD, Isoenzyme 4",Blood,Chemistry,,3024830,Lactate dehydrogenase 4/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,Measurement,LOINC,Lab Test,S,2545-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51684,"LD, Isoenzyme 5",Blood,Chemistry,,3012481,Lactate dehydrogenase 5/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,Measurement,LOINC,Lab Test,S,2548-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51685,Lidocaine,Blood,Chemistry,,3004944,Lidocaine [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3714-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51686,Lip2,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51687,Lipo Electrophoresis,Blood,Chemistry,,3008183,Lipoprotein fractions [Interpretation] in Serum or Plasma by Electrophoresis,Measurement,LOINC,Lab Test,S,20510-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51688,Lyme C6 Ab,Blood,Chemistry,,3033987,Borrelia burgdorferi C6 Ab [Units/volume] in Serum by Immunoassay,Measurement,LOINC,Lab Test,S,38173-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1011
-51689,Lyme G and M Value,Blood,Chemistry,,3044883,Borrelia burgdorferi IgG+IgM Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,34148-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1003
-51690,Lymphocytes,Blood,Chemistry,,3037511,Lymphocytes/100 leukocytes in Blood by Automated count,Measurement,LOINC,Lab Test,S,736-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,Duplicate of itemid 51244,0
-51691,MCV,Blood,Chemistry,,3023599,MCV [Entitic volume] by Automated count,Measurement,LOINC,Lab Test,S,787-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of Itemid 51250,0
-51692,"Monospot, Rapid Antigen",Blood,Chemistry,,3033533,Heterophile Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,31418-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,55
-51693,Mumps IgG Ab,Blood,Chemistry,,3028498,Mumps virus IgG Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,22415-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,522
-51694,Mumps IgG Ab Value,Blood,Chemistry,,3018867,Mumps virus IgG Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,7966-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,523
-51695,Myoglobin,Blood,Chemistry,,3005895,Myoglobin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2639-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51696,Neural Tube Defect Risk,Blood,Chemistry,,3048541,Neural tube defect risk [Likelihood] in Fetus,Measurement,LOINC,Lab Test,S,48803-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51697,Neutrophils,Blood,Chemistry,mmol/L,3013650,Neutrophils [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,751-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Incorrect Unit (mmol/l),88
-51698,No MD,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51699,Not Done,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51700,Np-fx,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51701,"Osmolality, Calculated",Blood,Chemistry,,3034739,Osmolality of Serum or Plasma by calculation,Measurement,LOINC,Lab Test,S,18182-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51702,Park,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51703,PEPgel,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51704,Platelet Count,Blood,Chemistry,,3024929,Platelets [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,777-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51265,0
-51705,Primidone,Blood,Chemistry,,3002248,Primidone [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3978-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51706,Problem Specimen,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,25863
-51707,Progesterone,Blood,Chemistry,,3027144,Progesterone [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2839-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51708,Qnthbsab,Blood,Chemistry,,3023421,Hepatitis B virus surface Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,16935-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51709,Quantitative RPR Test,Blood,Chemistry,,3026501,Reagin Ab [Titer] in Serum by RPR,Measurement,LOINC,Lab Test,S,31147-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51710,Rapid Plasma Reagin Test,Blood,Chemistry,,3021461,Reagin Ab [Presence] in Serum by RPR,Measurement,LOINC,Lab Test,S,20507-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51711,Red Blood Cells,Blood,Chemistry,,3020416,Erythrocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,789-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51279,0
-51712,Referred,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51713,Reflex Confirmatory Hepatitis C Viral Load,Blood,Chemistry,,3018447,Hepatitis C virus RNA [Units/volume] (viral load) in Serum or Plasma by NAA with probe detection,Measurement,LOINC,Lab Test,S,11011-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51714,Reflex HIV Confirmation,Blood,Chemistry,,40760007,HIV 1+2 Ab+HIV1 p24 Ag [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,56888-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,Not enough info,27
-51715,Renin,Blood,Chemistry,,3007808,Renin [Enzymatic activity/volume] in Plasma,Measurement,LOINC,Lab Test,S,2915-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51716,Renin,Blood,Chemistry,,3007808,Renin [Enzymatic activity/volume] in Plasma,Measurement,LOINC,Lab Test,S,2915-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate ot itemid 51715,0
-51717,Reserved,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51718,Reserved1,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51719,Reserved3,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51720,Reserved4,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51721,Reverse T3,Blood,Chemistry,,3027514,Triiodothyronine (T3).reverse [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3052-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51722,RFXLDLM,Blood,Chemistry,,3028437,Cholesterol in LDL [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2089-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,1543
-51723,Rubella,Blood,Chemistry,,3010937,Rubella virus Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,22496-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51724,Rubella IgG Ab,Blood,Chemistry,,3013750,Rubella virus IgG Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,25514-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,908
-51725,Rubeola IgG Ab,Blood,Chemistry,,3013339,Measles virus IgG Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,20479-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,606
-51726,Rubeola IgG Ab Value,Blood,Chemistry,,3006573,Measles virus IgG Ab [Units/volume] in Serum by Immunoassay,Measurement,LOINC,Lab Test,S,5244-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,608
-51727,Send Out,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51728,Serum B12,Blood,Chemistry,,3000593,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2132-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51010,0
-51729,Serum B12,Blood,Chemistry,,3000593,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2132-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51010,0
-51730,Serum Folate,Blood,Chemistry,,3036987,Folate [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2284-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 50925,0
-51731,Single Stranded DNA,Blood,Chemistry,,3003717,DNA single strand Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,5132-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51732,STX1,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,27492
-51733,STX2,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,29198
-51734,STX3,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,28004
-51735,STX4,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,12811
-51736,STX5,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,12815
-51737,STX6,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,27265
-51738,Thyroid Binding Globulin,Blood,Chemistry,,3020924,Thyroxine binding globulin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3021-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51739,Total CO2,Blood,Chemistry,mEq/L,3015632,"Carbon dioxide, total [Moles/volume] in Serum or Plasma",Measurement,LOINC,Lab Test,S,2028-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,355
-51740,Toxic Screen,Blood,Chemistry,,3017324,Toxicology panel - Blood,Measurement,LOINC,Lab Test,S,29587-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51741,Toxoplasma IgG Ab,Blood,Chemistry,,3024995,Toxoplasma gondii IgG Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,22580-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,486
-51742,Toxoplasma IgG Ab Value,Blood,Chemistry,,3006957,Toxoplasma gondii IgG Ab [Units/volume] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,5388-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,474
-51743,Toxoplasma IgM Ab,Blood,Chemistry,,3038943,Toxoplasma gondii IgM Ab [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,40678-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,120
-51744,Toxoplasma IgM Ab Value,Blood,Chemistry,,3017382,Toxoplasma gondii IgM Ab [Units/volume] in Serum by Immunoassay,Measurement,LOINC,Lab Test,S,5390-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,111
-51745,Toxoplasma Interpretation,Blood,Chemistry,,3005475,Toxoplasma gondii Ab [Interpretation] in Serum,Measurement,LOINC,Lab Test,S,20464-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,486
-51746,Transferrin Saturation,Blood,Chemistry,,3000185,Iron saturation [Mass Fraction] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2502-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51747,Treponemal Antibody Test,Blood,Chemistry,,3019832,Treponema pallidum Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,22587-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51748,Treponema pallidum (Syphilis) Ab,Blood,Chemistry,,3019832,Treponema pallidum Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,22587-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3190
-51749,Treponema pallidum (syphilis) value,Blood,Chemistry,,3015378,Treponema pallidum Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,11597-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3165
-51750,"UE3, Multiples of Median",Blood,Chemistry,,3003262,Estriol (E3).unconjugated [Multiple of the median] in Serum or Plasma,Measurement,LOINC,Lab Test,S,20466-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51751,Uncon Bil,Blood,Chemistry,,3007359,Bilirubin.indirect [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1971-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 50885,0
-51752,Voided Specimen,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,16738
-51753,VZV IgG Ab,Blood,Chemistry,,3022386,Varicella zoster virus IgG Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,19162-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,918
-51754,VZV IgG Ab Value,Blood,Chemistry,,3022575,Varicella zoster virus IgG Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,8047-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,918
-51755,White Blood Cells,Blood,Chemistry,K/uL,3000905,Leukocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,6690-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51300,218
-51756,White Blood Cells,Blood,Chemistry,,3000905,Leukocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,6690-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51300,0
-51757,Xxx,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51758,Xylose,Blood,Chemistry,,3019048,Xylose [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,32347-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51759,Z,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51760,Z,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51761,Zinc,Blood,Chemistry,,3017394,Zinc [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,5763-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51762,EE1,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,852
-51763,EE2,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,749
-51764,EE7,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,564
-51765,EE3,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,238
-51766,EE4,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,67
-51767,EE5,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,99
-51768,EE6,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51769,RUBIgGV,Blood,Chemistry,,3011564,Rubella virus IgG Ab [Units/volume] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,5334-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,912
-51770,MDRDgfr,Blood,Chemistry,,46236952,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",Measurement,LOINC,Lab Test,S,77147-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51771,,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51772,PAN3,Blood,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,1192
-51773,RFXFRKL,Blood,Chemistry,,3035795,FMR1 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method,Measurement,LOINC,Lab Test,S,36913-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51774,RFXHCV,Blood,Chemistry,,3052023,Hepatitis C virus Ab Signal/Cutoff in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,48159-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51775,(Albumin),Cerebrospinal Fluid,Chemistry,,3024474,Albumin [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,1746-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51776,<Albumin>,Cerebrospinal Fluid,Chemistry,mg/dL,3024474,Albumin [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,1746-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51775,37
-51777,"Albumin, CSF",Cerebrospinal Fluid,Chemistry,,3024474,Albumin [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,-56064,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51775,0
-51778,Alpha-1,Cerebrospinal Fluid,Chemistry,,3018149,Alpha 1 globulin/Protein.total in Cerebral spinal fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,13972-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51779,Alpha-2,Cerebrospinal Fluid,Chemistry,,3006757,Alpha 2 globulin/Protein.total in Cerebral spinal fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,13975-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51780,"Amylase, CSF",Cerebrospinal Fluid,Chemistry,,3007327,Amylase [Enzymatic activity/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,14389-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51781,Beta,Cerebrospinal Fluid,Chemistry,,3025229,Beta globulin/Protein.total in Cerebral spinal fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,13976-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51782,"Bicarbonate, CSF",Cerebrospinal Fluid,Chemistry,,3005805,Bicarbonate [Moles/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,16460-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51783,"Bilirubin, Total, CSF",Cerebrospinal Fluid,Chemistry,mg/dL,3027110,Bilirubin.total [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,1973-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4
-51784,"Chloride, CSF",Cerebrospinal Fluid,Chemistry,mEq/L,3036172,Chloride [Moles/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,2070-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1
-51785,"Cholesterol, CSF",Cerebrospinal Fluid,Chemistry,,3035660,Cholesterol [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,14439-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51786,Clostrid,Cerebrospinal Fluid,Chemistry,,46236184,Clostridium perfringens [Presence] in Specimen by Organism specific culture,Measurement,LOINC,Lab Test,S,77496-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51787,"Creatinine, CSF",Cerebrospinal Fluid,Chemistry,,3024535,Creatinine [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,14398-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51788,Cryptococ,Cerebrospinal Fluid,Chemistry,,3001363,Cryptococcus sp Ag [Presence] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,31788-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51789,Fl Scan,Cerebrospinal Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51790,"Glucose, CSF",Cerebrospinal Fluid,Chemistry,mg/dL,3022548,Glucose [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,2342-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,13760
-51791,HIV 1 Viral Load,Cerebrospinal Fluid,Chemistry,log10 copies/mL,3026532,HIV 1 RNA [Log #/volume] (viral load) in Serum or Plasma by NAA with probe detection,Measurement,LOINC,Lab Test,S,29541-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,15
-51792,"Immunoelectrophoresis, CSF",Cerebrospinal Fluid,Chemistry,,3041917,Immunoelectrophoresis for Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,40685-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51793,"Immunoglobulin G, CSF",Cerebrospinal Fluid,Chemistry,,3007368,IgG [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,2464-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51794,"Immunoglobulin G, CSF",Cerebrospinal Fluid,Chemistry,,3007368,IgG [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,2464-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51793,0
-51795,"Lactate Dehydrogenase, CSF",Cerebrospinal Fluid,Chemistry,IU/L,3016920,Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,2528-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2306
-51796,"Miscellaneous, CSF",Cerebrospinal Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,513
-51797,"Osmolality, CSF",Cerebrospinal Fluid,Chemistry,,3028160,Osmolality of Specimen,Measurement,LOINC,Lab Test,S,2696-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51798,"PEP, CSF",Cerebrospinal Fluid,Chemistry,,3006670,Protein Fractions [Interpretation] in Cerebral spinal fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,13439-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,815
-51799,"PEP, CSF, Gamma Region",Cerebrospinal Fluid,Chemistry,,3022932,Gamma globulin [Mass/volume] in Cerebral spinal fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,2873-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51800,"Potassium, CSF",Cerebrospinal Fluid,Chemistry,,3018062,Potassium [Moles/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,2819-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51801,"Sodium, CSF",Cerebrospinal Fluid,Chemistry,,3003834,Sodium [Moles/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,2948-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51802,"Total Protein, CSF",Cerebrospinal Fluid,Chemistry,mg/dL,3019473,Protein [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,2880-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,14122
-51803,"Triglycerides, CSF",Cerebrospinal Fluid,Chemistry,,3036816,Triglyceride [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,14446-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51804,"Urea Nitrogen, CSF",Cerebrospinal Fluid,Chemistry,,3034450,Urea nitrogen [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,14000-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51805,"Uric Acid, CSF",Cerebrospinal Fluid,Chemistry,,3007151,Urate [Mass/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,13902-2,,,MIMIC-IV v2.0,,,,,,,0
-51806,Voided Specimen,Cerebrospinal Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,36
-51807,(Albumin),Joint Fluid,Chemistry,,3025380,Albumin [Mass/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,1752-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51808,Alpha-1,Joint Fluid,Chemistry,,3026790,Alpha 1 globulin/Protein.total in Synovial fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,15125-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51809,Alpha-2,Joint Fluid,Chemistry,,3028168,Alpha 2 globulin/Protein.total in Synovial fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,15126-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51810,Beta,Joint Fluid,Chemistry,,3028778,Beta globulin/Protein.total in Synovial fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,15127-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51811,"Bicarbonate,Joint Fluid",Joint Fluid,Chemistry,,3014637,Bicarbonate [Moles/volume] in Specimen,Measurement,LOINC,Lab Test,S,22735-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51812,"Bilirubin, Total, Joint Fluid",Joint Fluid,Chemistry,,3014687,Bilirubin.total [Mass/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,14423-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51813,"Chloride, Joint Fluid",Joint Fluid,Chemistry,,3009024,Chloride [Moles/volume] in Specimen,Measurement,LOINC,Lab Test,S,32307-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51814,"Cholesterol, Joint Fluid",Joint Fluid,Chemistry,,3020324,Cholesterol [Mass/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,14443-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51815,Clostrid,Joint Fluid,Chemistry,,1617096,Clostridium perfringens [Presence] in Synovial fluid by NAA with non-probe detection,Measurement,LOINC,Lab Test,S,97614-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51816,Cryptococ,Joint Fluid,Chemistry,,3024255,Cryptococcus sp Ag [Presence] in Specimen,Measurement,LOINC,Lab Test,S,29533-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51817,Fl Scan,Joint Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51818,"IgG, Joint Fluid",Joint Fluid,Chemistry,,3031064,Immune complex.IgG [Units/volume] in Synovial fluid by C1q binding assay,Measurement,LOINC,Lab Test,S,42601-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51819,"Immunoelectrophoresis, Joint Fluid",Joint Fluid,Chemistry,,3000265,Immunoelectrophoresis for Serum or Plasma,Measurement,LOINC,Lab Test,S,13169-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51820,"Osmolality, Joint Fluid",Joint Fluid,Chemistry,,3028160,Osmolality of Specimen,Measurement,LOINC,Lab Test,S,2696-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51821,"PEP, Joint Fluid, Gamma Region",Joint Fluid,Chemistry,,3000516,Gamma globulin [Mass/volume] in Synovial fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,2875-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51822,"Potassium, Joint Fluid",Joint Fluid,Chemistry,,3007485,Potassium [Moles/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,14172-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51823,"Sodium, Joint Fluid",Joint Fluid,Chemistry,,3026681,Sodium [Moles/volume] in Specimen,Measurement,LOINC,Lab Test,S,32340-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51824,"Triglycerides, Joint Fluid",Joint Fluid,Chemistry,,3014110,Triglyceride [Mass/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,14449-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51825,"Urea Nitrogen, Joint Fluid",Joint Fluid,Chemistry,,3006710,Urea nitrogen [Mass/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,14396-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51826,"Uric Acid, Joint Fluid",Joint Fluid,Chemistry,mg/dL,3038146,Urate [Mass/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,3085-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1
-51827,Voided Specimen,Joint Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,11
-51828,Voided Specimen,Bone Marrow,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51829,72 Hr Fat,Other Body Fluid,Chemistry,,3023505,Fat [Mass/time] in 72 hour Stool,Measurement,LOINC,Lab Test,S,2271-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51830,Acid BAO,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51831,Acid MAO,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51832,Adenovirus,Other Body Fluid,Chemistry,,3007270,Adenovirus Ab [Units/volume] in Body fluid,Measurement,LOINC,Lab Test,S,31217-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,35
-51833,"AFP, Amniotic Fluid",Other Body Fluid,Chemistry,,3010296,Alpha-1-Fetoprotein [Mass/volume] in Amniotic fluid,Measurement,LOINC,Lab Test,S,1832-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51834,"AFP, Body Fluid",Other Body Fluid,Chemistry,,3034165,Alpha-1-Fetoprotein [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,11207-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51835,(Albumi,Other Body Fluid,Chemistry,,3025313,Albumin [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,1747-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51836,<Albumin>,Other Body Fluid,Chemistry,,3025313,Albumin [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,1747-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51835,0
-51837,Alpha-1,Other Body Fluid,Chemistry,,3019891,Alpha 1 globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17812-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51838,Alpha-2,Other Body Fluid,Chemistry,,3005504,Alpha 2 globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17814-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51839,Anat Path Hold,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,2585
-51840,Beta,Other Body Fluid,Chemistry,,3003304,Beta globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17816-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51841,"Blood, Occult",Other Body Fluid,Chemistry,,3016251,Hemoglobin.gastrointestinal [Presence] in Stool,Measurement,LOINC,Lab Test,S,2335-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51842,Bun,Other Body Fluid,Chemistry,,3019930,Urea nitrogen [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,3093-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51843,C. diff PCR,Other Body Fluid,Chemistry,,40764128,Clostridioides difficile DNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,61367-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51844,C diff Toxin Antigen Assay,Other Body Fluid,Chemistry,,3026688,Clostridioides difficile toxin A+B [Units/volume] in Specimen by Immunoassay,Measurement,LOINC,Lab Test,S,6364-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51845,Chlamydia pneumoniae,Other Body Fluid,Chemistry,,3019540,Chlamydophila pneumoniae [Presence] in Specimen by Organism specific culture,Measurement,LOINC,Lab Test,S,21184-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,35
-51846,Chlamydia trachomatis,Other Body Fluid,Chemistry,N/A,3043310,Chlamydia trachomatis rRNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,43304-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,8787
-51847,Clostrid,Other Body Fluid,Chemistry,,3007592,Clostridium perfringens enterotoxin [Presence] in Body fluid,Measurement,LOINC,Lab Test,S,20799-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51848,"Coronavirus, NOT CoVID-19",Other Body Fluid,Chemistry,,3042596,Human coronavirus RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,41001-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51849,COV1,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51850,COV3,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51851,COV5,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,
-51852,COV6,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,
-51853,COVID-19,Other Body Fluid,Chemistry,,586516,SARS-CoV-2 (COVID-19) [Presence] in Specimen by Organism specific culture,Measurement,LOINC,Lab Test,S,94763-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51854,Cryptococ,Other Body Fluid,Chemistry,,3023879,Cryptococcus sp Ag [Presence] in Body fluid,Measurement,LOINC,Lab Test,S,16692-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51855,"DSPC, Amniotic Fluid",Other Body Fluid,Chemistry,,3036054,Phosphatidylcholine/Albumin [Mass Ratio] in Amniotic fluid,Measurement,LOINC,Lab Test,S,30165-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51856,Epr,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51857,Fl Scan,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,1
-51858,HIV 1 Viral Load,Other Body Fluid,Chemistry,,3038207,HIV 1 RNA [#/volume] (viral load) in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,25836-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51859,Human Metapneumovirus,Other Body Fluid,Chemistry,,3042194,Human metapneumovirus RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,38917-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,35
-51860,Human Rhinovirus/Enterovirus,Other Body Fluid,Chemistry,,3040684,Rhinovirus+Enterovirus RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,40991-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,35
-51861,"Immunoelectrophoresis, Fluid",Other Body Fluid,Chemistry,,3000265,Immunoelectrophoresis for Serum or Plasma,Measurement,LOINC,Lab Test,S,13169-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51862,"Immunoglobulin G, Body Fluid",Other Body Fluid,Chemistry,,3015390,IgG [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,15183-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51863,Influenza A,Other Body Fluid,Chemistry,,3028459,Influenza virus A Ag [Presence] in Specimen by Immunoassay,Measurement,LOINC,Lab Test,S,5862-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,35
-51864,Influenza A by PCR,Other Body Fluid,Chemistry,,3044938,Influenza virus A RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,34487-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,214
-51865,Influenza A by PCR,Other Body Fluid,Chemistry,,3044938,Influenza virus A RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,34487-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51864,19006
-51866,Influenza A H1,Other Body Fluid,Chemistry,,3030120,Influenza virus A H1 RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,49521-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,35
-51867,Influenza A H1-2009,Other Body Fluid,Chemistry,,40758594,Influenza virus A H1 2009 pandemic RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,55465-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,35
-51868,Influenza A H3,Other Body Fluid,Chemistry,,3032731,Influenza virus A H3 RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,49524-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,35
-51869,"Influenza A, Rapid Antigen",Other Body Fluid,Chemistry,,3002523,Influenza virus A Ag [Presence] in Specimen,Measurement,LOINC,Lab Test,S,31859-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,273
-51870,"Influenza A, Rapid Antigen",Other Body Fluid,Chemistry,,3002523,Influenza virus A Ag [Presence] in Specimen,Measurement,LOINC,Lab Test,S,31859-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51869,119
-51871,Influenza B,Other Body Fluid,Chemistry,,3011688,Influenza virus B Ag [Presence] in Specimen by Immunoassay,Measurement,LOINC,Lab Test,S,5866-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,35
-51872,Influenza B by PCR,Other Body Fluid,Chemistry,,3038288,Influenza virus B RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,40982-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,214
-51873,Influenza B by PCR,Other Body Fluid,Chemistry,,3038288,Influenza virus B RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,40982-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51872,19006
-51874,"Influenza B, Rapid Antigen",Other Body Fluid,Chemistry,,3003740,Influenza virus B Ag [Presence] in Specimen,Measurement,LOINC,Lab Test,S,31864-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,273
-51875,"Influenza B, Rapid Antigen",Other Body Fluid,Chemistry,,21492989,Influenza virus B Ag [Presence] in Upper respiratory specimen by Rapid immunoassay,Measurement,LOINC,Lab Test,S,80383-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,Duplicate of itemid 51874,119
-51876,"L/S Ratio, Amniotic Fluid",Other Body Fluid,Chemistry,,3035904,Lecithin/Sphingomyelin [Ratio] in Amniotic fluid,Measurement,LOINC,Lab Test,S,14976-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51877,MRSA PCR,Other Body Fluid,Chemistry,,3033966,Methicillin resistant Staphylococcus aureus (MRSA) DNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,35492-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,877
-51878,Mycoplasma pneumoniae,Other Body Fluid,Chemistry,,3035653,Mycoplasma pneumoniae [Presence] in Specimen by Organism specific culture,Measurement,LOINC,Lab Test,S,19054-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,35
-51879,Neisseria gonorrhoeae,Other Body Fluid,Chemistry,N/A,3045028,Neisseria gonorrhoeae rRNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,43305-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,8783
-51880,Norovirus Genogroup I,Other Body Fluid,Chemistry,,1616677,Norovirus genogroup I RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,97525-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51881,Norovirus Genogroup II,Other Body Fluid,Chemistry,,1616915,Norovirus genogroup II RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,97532-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51882,O & P,Other Body Fluid,Chemistry,,3012744,Ova and parasites identified in Specimen by Light microscopy,Measurement,LOINC,Lab Test,S,673-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51883,Parainfluenza 1,Other Body Fluid,Chemistry,,40758227,Parainfluenza virus 1 [Presence] in Specimen by Organism specific culture,Measurement,LOINC,Lab Test,S,55097-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,35
-51884,Parainfluenza 2,Other Body Fluid,Chemistry,,40758228,Parainfluenza virus 2 [Presence] in Specimen by Organism specific culture,Measurement,LOINC,Lab Test,S,55098-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,35
-51885,Parainfluenza 3,Other Body Fluid,Chemistry,,40758229,Parainfluenza virus 3 [Presence] in Specimen by Organism specific culture,Measurement,LOINC,Lab Test,S,55099-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,35
-51886,Parainfluenza 4,Other Body Fluid,Chemistry,,3038297,Parainfluenza virus 4 RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,41010-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,35
-51887,"PEP, Body Fluid",Other Body Fluid,Chemistry,,36305551,Protein electrophoresis panel - Body fluid,Measurement,LOINC,Lab Test,S,88698-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51888,"PEP, Body Fluid, Gamma Region",Other Body Fluid,Chemistry,,3023700,Gamma globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17818-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51889,Phosphatidylglycerol,Other Body Fluid,Chemistry,,3013297,Phosphatidylglycerol [Presence] in Amniotic fluid,Measurement,LOINC,Lab Test,S,2785-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-51890,Rapid COVID-19,Other Body Fluid,Chemistry,,723477,SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay,Measurement,LOINC,Lab Test,S,94558-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,
-51891,Respiratory Syncytial Virus A,Other Body Fluid,Chemistry,,3005156,Respiratory syncytial virus A RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,30075-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,35
-51892,Respiratory Syncytial Virus B,Other Body Fluid,Chemistry,,3000108,Respiratory syncytial virus B RNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,30076-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,35
-51893,Staph aureus PCR,Other Body Fluid,Chemistry,,40764165,Staphylococcus aureus DNA [Presence] in Specimen by NAA with probe detection,Measurement,LOINC,Lab Test,S,61404-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,877
-51894,"Strep A, Rapid Antigen",Other Body Fluid,Chemistry,,21491660,Streptococcus pyogenes Ag [Presence] in Throat by Rapid immunoassay,Measurement,LOINC,Lab Test,S,78012-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,1292
-51895,"Strep A, Rapid Antigen",Other Body Fluid,Chemistry,,21491660,Streptococcus pyogenes Ag [Presence] in Throat by Rapid immunoassay,Measurement,LOINC,Lab Test,S,78012-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,Duplicate of itemid 51894,255
-51896,Sudan Stain,Other Body Fluid,Chemistry,,3013569,Microscopic observation [Identifier] in Body fluid by Sudan black stain,Measurement,LOINC,Lab Test,S,10763-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51897,Surfactant/Albumin,Other Body Fluid,Chemistry,mg/g,3017439,Surfactant/Albumin [Mass Ratio] in Amniotic fluid,Measurement,LOINC,Lab Test,S,30562-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,36
-51898,Surf/Alb,Other Body Fluid,Chemistry,,3017439,Surfactant/Albumin [Mass Ratio] in Amniotic fluid,Measurement,LOINC,Lab Test,S,30562-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51897,0
-51899,Trichomonas vaginalis,Other Body Fluid,Chemistry,N/A,3047204,Trichomonas vaginalis [Presence] in Specimen by Wet preparation,Measurement,LOINC,Lab Test,S,32766-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2236
-51900,"Uric Acid, Body Fluid",Other Body Fluid,Chemistry,,3050920,Urate [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,53612-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51901,Voided Specimen,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,327
-51902,Vpf,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51903,PAN1,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,8780
-51904,PAN2,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,2230
-51905,,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51906,reuse,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51907,reuse1,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51908,COV2,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51909,COV4,Other Body Fluid,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51910,(Albumin),Pleural,Chemistry,,3011544,Albumin [Mass/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,1748-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51911,Alpha-1,Pleural,Chemistry,,3019891,Alpha 1 globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17812-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51912,Alpha-2,Pleural,Chemistry,,3005504,Alpha 2 globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17814-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51913,Beta,Pleural,Chemistry,,3003304,Beta globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17816-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51914,Clostrid,Pleural,Chemistry,,46236184,Clostridium perfringens [Presence] in Specimen by Organism specific culture,Measurement,LOINC,Lab Test,S,77496-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51915,Cryptococ,Pleural,Chemistry,,3024255,Cryptococcus sp Ag [Presence] in Specimen,Measurement,LOINC,Lab Test,S,29533-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51916,Fl Scan,Pleural,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51917,"Immunoelectrophoresis, Pleural",Pleural,Chemistry,,3000265,Immunoelectrophoresis for Serum or Plasma,Measurement,LOINC,Lab Test,S,13169-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51918,"Immunoglobulin G, Pleural",Pleural,Chemistry,,3015390,IgG [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,15183-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51919,"Osmolality, Pleural",Pleural,Chemistry,,3016098,Osmolality of Pleural fluid,Measurement,LOINC,Lab Test,S,2690-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51920,"PEP, Pleural, Gamma Region",Pleural,Chemistry,,3023700,Gamma globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17818-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51921,"proBNP, Pleural",Pleural,Chemistry,pg/mL,46236287,Natriuretic peptide.B prohormone N-Terminal [Mass/volume] in Pleural fluid by Immunoassay,Measurement,LOINC,Lab Test,S,77621-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1190
-51922,"Urea Nitrogen, Pleural",Pleural,Chemistry,mg/dL,3004717,Urea nitrogen [Mass/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,14394-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1
-51923,"Uric Acid, Pleural",Pleural,Chemistry,,40763523,Urate [Mass/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,60469-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51924,Voided Specimen,Pleural,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,16
-51925,72 Hr Fat,Stool,Chemistry,,3023505,Fat [Mass/time] in 72 hour Stool,Measurement,LOINC,Lab Test,S,2271-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51926,(Albumin),Stool,Chemistry,,40757477,Albumin [Mass/volume] in Stool,Measurement,LOINC,Lab Test,S,54346-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51927,0
-51927,"Albumin, Stool",Stool,Chemistry,g/dL,40757477,Albumin [Mass/volume] in Stool,Measurement,LOINC,Lab Test,S,54346-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1
-51928,Alpha-1,Stool,Chemistry,,3019891,Alpha 1 globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17812-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51929,Alpha-2,Stool,Chemistry,,3005504,Alpha 2 globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17814-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51930,"Amylase, Stool",Stool,Chemistry,,3021162,Amylase [Enzymatic activity/volume] in Specimen,Measurement,LOINC,Lab Test,S,32298-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51931,Beta,Stool,Chemistry,,3003304,Beta globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17816-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51932,"Bilirubin, Total, Stool",Stool,Chemistry,,3024733,Bilirubin.total [Presence] in Stool,Measurement,LOINC,Lab Test,S,1976-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51933,C. diff PCR,Stool,Chemistry,,3051552,Clostridioides difficile toxin genes [Presence] in Stool by NAA with probe detection,Measurement,LOINC,Lab Test,S,54067-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2540
-51934,C Diff Toxin Antigen Assay,Stool,Chemistry,,3032068,Clostridioides difficile toxin A+B [Presence] in Stool,Measurement,LOINC,Lab Test,S,34713-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,402
-51935,"Cholesterol, Stool",Stool,Chemistry,,3015548,Cholesterol [Moles/volume] in Specimen,Measurement,LOINC,Lab Test,S,32308-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51936,Clostrid,Stool,Chemistry,,3032057,Clostridioides difficile [Presence] in Stool,Measurement,LOINC,Lab Test,S,34712-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51937,"Creatinine, Stool",Stool,Chemistry,,3052695,Creatinine [Moles/volume] in Stool,Measurement,LOINC,Lab Test,S,47610-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51938,Cryptococ,Stool,Chemistry,,3024255,Cryptococcus sp Ag [Presence] in Specimen,Measurement,LOINC,Lab Test,S,29533-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51939,Fl Scan,Stool,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51940,Gamma,Stool,Chemistry,,3023700,Gamma globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17818-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51941,"Glucose, Stool",Stool,Chemistry,,3040980,Glucose [Presence] in Stool,Measurement,LOINC,Lab Test,S,51595-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51942,"IgG, Stool",Stool,Chemistry,,3015390,IgG [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,15183-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51943,"Immunoelectrophoresis, Stool",Stool,Chemistry,,3000265,Immunoelectrophoresis for Serum or Plasma,Measurement,LOINC,Lab Test,S,13169-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51944,"Lactate Dehydrogenase, Stool",Stool,Chemistry,,3007869,Lactate dehydrogenase [Enzymatic activity/volume] in Specimen,Measurement,LOINC,Lab Test,S,32324-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-51945,Norovirus Genogroup I,Stool,Chemistry,,40758035,Norovirus genogroup I RNA [Presence] in Stool by NAA with probe detection,Measurement,LOINC,Lab Test,S,54905-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1508
-51946,Norovirus Genogroup II,Stool,Chemistry,,40758036,Norovirus genogroup II RNA [Presence] in Stool by NAA with probe detection,Measurement,LOINC,Lab Test,S,54906-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1508
-51947,O & P,Stool,Chemistry,,3020389,Ova and parasites identified in Stool by Concentration,Measurement,LOINC,Lab Test,S,10701-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51948,Sudan Stain,Stool,Chemistry,,3024796,Fat.microscopic observation [Identifier] in Stool by Sudan IV stain,Measurement,LOINC,Lab Test,S,10753-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51949,"Total Protein, Stool",Stool,Chemistry,,3051707,Protein [Mass/volume] in Stool,Measurement,LOINC,Lab Test,S,47739-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51950,"Triglycerides, Stool",Stool,Chemistry,,46236065,Triglyceride [Mass/mass] in 24 hour Stool,Measurement,LOINC,Lab Test,S,77360-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51951,"Urea Nitrogen, Stool",Stool,Chemistry,,3019930,Urea nitrogen [Mass/volume] in Body fluid,Measurement,LOINC,Lab Test,S,3093-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51952,"Uric Acid, Stool",Stool,Chemistry,,3028566,Urate [Moles/volume] in Specimen,Measurement,LOINC,Lab Test,S,32343-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51953,Voided Specimen,Stool,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,341
-51954,CDT027,Stool,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,315
-51955,,Stool,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51956,CDT027,Stool,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,2214
-51957,17-Hydroxycorticosteroids,Urine,Chemistry,,3026205,17-Hydroxycorticosteroids [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,1666-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51958,"17-Ketosteroids, Urine",Urine,Chemistry,,3020027,17-Ketosteroids [Mass/time] in 24 hour Urine,Measurement,LOINC,Lab Test,S,6766-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51959,"5-HIAA, Urine",Urine,Chemistry,,3005148,5-Hydroxyindoleacetate [Mass/time] in 24 hour Urine,Measurement,LOINC,Lab Test,S,1695-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51960,Aldolase,Urine,Chemistry,,3032449,Aldolase [Enzymatic activity/volume] in Body fluid,Measurement,LOINC,Lab Test,S,49724-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-51961,Alpha-1,Urine,Chemistry,,3026665,Alpha 1 globulin/Protein.total in Urine by Electrophoresis,Measurement,LOINC,Lab Test,S,13990-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51962,Alpha-2,Urine,Chemistry,,3028558,Alpha 2 globulin/Protein.total in Urine by Electrophoresis,Measurement,LOINC,Lab Test,S,13993-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51963,Amylase/Creatinine Clearance,Urine,Chemistry,,3003046,Amylase/Creatinine renal clearance [Ratio] in Urine and Serum or Plasma,Measurement,LOINC,Lab Test,S,30077-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51964,"Amylase, Serum",Urine,Chemistry,,3017315,Amylase [Enzymatic activity/volume] in Urine,Measurement,LOINC,Lab Test,S,1799-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,"Conflict. Label is ""Serum"", Fluid is ""Urine""",0
-51965,Beta,Urine,Chemistry,,3009565,Beta globulin/Protein.total in Urine by Electrophoresis,Measurement,LOINC,Lab Test,S,13994-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51966,Bilirubin,Urine,Chemistry,N/A,3011258,Bilirubin.total [Presence] in Urine,Measurement,LOINC,Lab Test,S,1977-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,558
-51967,Blood,Urine,Chemistry,N/A,3051227,Blood [Presence] in Urine by Visual,Measurement,LOINC,Lab Test,S,53963-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,558
-51968,Camp,Urine,Chemistry,,3004131,Adenosine monophosphate.cyclic [Moles/volume] in Urine,Measurement,LOINC,Lab Test,S,22712-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1
-51969,"Catecholamines, Urine",Urine,Chemistry,,3033473,Catecholamines [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,2057-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51970,Cben,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,5
-51971,Ccoc,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51972,Chlamydia trachomatis,Urine,Chemistry,N/A,3007813,Chlamydia trachomatis [Presence] in Urine sediment by Organism specific culture,Measurement,LOINC,Lab Test,S,14467-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7286
-51973,Copi,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-51974,"Copper, Urine",Urine,Chemistry,,3028506,Copper [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,5632-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51975,Coproporphyrins,Urine,Chemistry,,3019954,Coproporphyrin [Presence] in Urine,Measurement,LOINC,Lab Test,S,2136-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51976,"Cortisol, Urine",Urine,Chemistry,,3037229,Cortisol [Presence] in Urine,Measurement,LOINC,Lab Test,S,28550-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51977,"Creatinine, Blood",Urine,Chemistry,,3017250,Creatinine [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,2161-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,"Conflict. Label is ""Blood"", Fluid is ""Urine""",0
-51978,DirList,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,2
-51979,"Estriol, Urine",Urine,Chemistry,,3013426,Estriol (E3) [Mass/time] in 24 hour Urine,Measurement,LOINC,Lab Test,S,2253-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51980,Fentanyl,Urine,Chemistry,N/A,3004176,fentaNYL [Presence] in Urine,Measurement,LOINC,Lab Test,S,11235-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,823
-51981,Glucose,Urine,Chemistry,mg/dL,3020399,Glucose [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,2350-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,558
-51982,"Immunoelectrophoresis, Urine",Urine,Chemistry,,3008366,Immunoelectrophoresis panel - Urine,Measurement,LOINC,Lab Test,S,29585-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51983,"Iron, Urine",Urine,Chemistry,,3001312,Iron [Mass/time] in 24 hour Urine,Measurement,LOINC,Lab Test,S,2499-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51984,Ketone,Urine,Chemistry,mg/dL,3032459,Ketones [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,49779-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,558
-51985,Leukocytes,Urine,Chemistry,N/A,3022547,Leukocytes [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,20455-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,558
-51986,Neisseria gonorrhoeae,Urine,Chemistry,N/A,40763311,Neisseria gonorrhoeae rRNA [Presence] in Urine by NAA with probe detection,Measurement,LOINC,Lab Test,S,60256-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,7286
-51987,Nitrite,Urine,Chemistry,N/A,3042812,Nitrite [Presence] in Urine,Measurement,LOINC,Lab Test,S,32710-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,558
-51988,O & P,Urine,Chemistry,,46235447,Ova and parasites identified in Urine by Trichrome stain,Measurement,LOINC,Lab Test,S,75665-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51989,Oxycodone,Urine,Chemistry,N/A,3000068,oxyCODONE [Presence] in Urine,Measurement,LOINC,Lab Test,S,10998-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,34168
-51990,"Phenothiazine Screen, Urine",Urine,Chemistry,,3020282,Phenothiazines [Presence] in Urine by Screen method,Measurement,LOINC,Lab Test,S,19670-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51991,"Propoxyphene, Urine",Urine,Chemistry,,3011802,Propoxyphene [Presence] in Urine,Measurement,LOINC,Lab Test,S,19141-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-51992,Protein,Urine,Chemistry,mg/dL,3014051,Protein [Presence] in Urine by Test strip,Measurement,LOINC,Lab Test,S,20454-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,558
-51993,Referred,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51994,Specific Gravity,Urine,Chemistry,,3033543,Specific gravity of Urine,Measurement,LOINC,Lab Test,S,2965-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,558
-51995,Study Urine,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,278
-51996,Trichomonas vaginalis,Urine,Chemistry,N/A,3002253,Trichomonas vaginalis [Presence] in Urine sediment by Light microscopy,Measurement,LOINC,Lab Test,S,5813-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,930
-51997,UIFEgel,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51998,UPEPgel,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-51999,Urine Amylase,Urine,Chemistry,,3017315,Amylase [Enzymatic activity/volume] in Urine,Measurement,LOINC,Lab Test,S,1799-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52000,Urine  Creatinine,Urine,Chemistry,,3017250,Creatinine [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,2161-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate ot itemid 51082,0
-52001,"Urine PEP, Gamma region",Urine,Chemistry,,3010157,Gamma globulin/Protein.total in Urine by Electrophoresis,Measurement,LOINC,Lab Test,S,13995-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52002,Urobilinogen,Urine,Chemistry,mg/dL,3007950,Urobilinogen [Mass/volume] in Urine,Measurement,LOINC,Lab Test,S,3107-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,558
-52003,Uroporphyrins,Urine,Chemistry,,3004961,Uroporphyrin [Presence] in Urine,Measurement,LOINC,Lab Test,S,3112-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52004,UTX1,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,27781
-52005,UTX2,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,27261
-52006,UTX3,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,27753
-52007,UTX4,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,27961
-52008,UTX5,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,27744
-52009,UTX6,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,26792
-52010,UTX7,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,27625
-52011,UTX8,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52012,UTX9,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,3030
-52013,Vanillylmandelic Acid,Urine,Chemistry,,3025591,Vanillylmandelate [Mass/time] in 24 hour Urine,Measurement,LOINC,Lab Test,S,3122-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52014,Voided Specimen,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,3678
-52015,Xylose,Urine,Chemistry,,3051069,Xylose [Presence] in Urine,Measurement,LOINC,Lab Test,S,47806-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52016,Z,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52017,"Zinc, Urine",Urine,Chemistry,,3041478,Zinc [Presence] in Urine,Measurement,LOINC,Lab Test,S,40957-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52018,PAN1,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,7300
-52019,PAN2,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,931
-52020,UTX10,Urine,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,823
-52021,Abz,Blood,Blood Gas,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52022,"Albumin, Blood",Blood,Blood Gas,,3024561,Albumin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1751-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-52023,Assist/Control,Blood,Blood Gas,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,22386
-52024,"Creatinine, Whole Blood",Blood,Blood Gas,mg/dL,3051825,Creatinine [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,38483-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4123
-52025,Delete,Blood,Blood Gas,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52026,Estimated GFR (MDRD equation),Blood,Blood Gas,,,,Measurement,LOINC,Lab Test,S,76633-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3538
-52027,"Glucose, Whole Blood",Blood,Blood Gas,,3000483,Glucose [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,2339-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52028,Hematocrit,Blood,Blood Gas,,3023230,Hematocrit [Volume Fraction] of Arterial blood,Measurement,LOINC,Lab Test,S,32354-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,0
-52029,% Ionized Calcium,Blood,Blood Gas,,3032710,Calcium.ionized/Calcium.total corrected for albumin in Blood,Measurement,LOINC,Lab Test,S,49936-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52030,Lithium,Blood,Blood Gas,,3001823,Lithium [Moles/volume] in Blood,Measurement,LOINC,Lab Test,S,25461-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52031,Osmolality,Blood,Blood Gas,,3008295,Osmolality of Serum or Plasma,Measurement,LOINC,Lab Test,S,2692-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52032,P50 of Hemoglobin,Blood,Blood Gas,mm Hg,3015968,Oxygen [Partial pressure] saturation adjusted to 0.5 in Arterial blood,Measurement,LOINC,Lab Test,S,19214-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1
-52033,Specimen Type,Blood,Blood Gas,,40769406,Specimen type,Measurement,LOINC,Lab Test,S,66746-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Not a lab test,664819
-52034,Total Calcium,Blood,Blood Gas,,3032503,Calcium [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,49765-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52035,Total Calcium,Blood,Blood Gas,,3032503,Calcium [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,49765-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,Duplicate of itemid 52034,0
-52036,Voided Specimen,Blood,Blood Gas,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,6397
-52037,WB tCO2,Blood,Blood Gas,,3014094,"Carbon dioxide, total [Moles/volume] in Blood",Measurement,LOINC,Lab Test,S,20565-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52038,Base Excess,Fluid,Blood Gas,,3003396,Base excess in Arterial blood by calculation,Measurement,LOINC,Lab Test,S,1925-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,No Fluid info,0
-52039,Calculated Bicarbonate,Fluid,Blood Gas,,3008152,Bicarbonate [Moles/volume] in Arterial blood,Measurement,LOINC,Lab Test,S,1960-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,No Fluid info,0
-52040,pCO2,Fluid,Blood Gas,,3027946,Carbon dioxide [Partial pressure] in Arterial blood,Measurement,LOINC,Lab Test,S,2019-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,No Fluid info,0
-52041,pH,Fluid,Blood Gas,,3019977,pH of Arterial blood,Measurement,LOINC,Lab Test,S,2744-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,No Fluid info,0
-52042,pO2,Fluid,Blood Gas,,3027801,Oxygen [Partial pressure] in Arterial blood,Measurement,LOINC,Lab Test,S,2703-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,No Fluid info,0
-52043,Voided Specimen,Other Body Fluid,Blood Gas,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,51
-52044,"Osmolality, Urine",Urine,Blood Gas,,3026782,Osmolality of Urine,Measurement,LOINC,Lab Test,S,2695-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52045,"pH, Urine",Urine,Blood Gas,,3015736,pH of Urine,Measurement,LOINC,Lab Test,S,2756-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52046,"Potassium, Urine",Urine,Blood Gas,,3016038,Potassium [Moles/volume] in Urine,Measurement,LOINC,Lab Test,S,2828-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,"Duplicate of itemid 51097. Conflict. Fluid is ""Urine"" while Category is ""Blood Gas""",0
-52047,"Sodium, Urine",Urine,Blood Gas,,3003181,Sodium [Moles/volume] in Urine,Measurement,LOINC,Lab Test,S,2955-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,"Duplicate of itemid 51100. Conflict. Fluid is ""Urine"" while Category is ""Blood Gas""",0
-52048,Atyps#,Ascites,Hematology,,3031744,Variant lymphocytes [#/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,35041-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52049,Bands#,Ascites,Hematology,,3032632,Band form neutrophils [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35014-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52050,Basos#,Ascites,Hematology,,3030877,Basophils [#/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,35073-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52051,Blasts#,Ascites,Hematology,,3031471,Blasts [#/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,35065-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52052,Eos#,Ascites,Hematology,,3032059,Eosinophils [#/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,35061-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52053,Histio#,Ascites,Hematology,,3030564,Histiocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35057-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52054,Histiocyte,Ascites,Hematology,,3041062,Histiocytes/100 cells in Peritoneal fluid by Manual count,Measurement,LOINC,Lab Test,S,40516-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52055,Hyperseg,Ascites,Hematology,%,3030345,Segmented neutrophils/100 leukocytes in Peritoneal fluid,Measurement,LOINC,Lab Test,S,33384-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1
-52056,Hyperseg#,Ascites,Hematology,,3032375,Segmented neutrophils [#/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,35010-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52057,Lymphs#,Ascites,Hematology,,3030833,Lymphocytes [#/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,35097-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52058,Metas#,Ascites,Hematology,,3003467,Lymphocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,26476-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52059,Monos#,Ascites,Hematology,,3030599,Monocytes [#/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,35027-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52060,Myelos#,Ascites,Hematology,,3032657,Myelocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35016-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52061,Nuc Rbcs#,Ascites,Hematology,,3028129,Nucleated erythrocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,26460-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52062,Plasma#,Ascites,Hematology,,3031165,Plasma cells [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35006-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52063,Polys#,Ascites,Hematology,,3031154,Polymorphonuclear cells [#/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,35005-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52064,Promyelo#,Ascites,Hematology,,3031780,Promyelocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,34996-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52065,"Total Nucleated Cells, Ascites",Ascites,Hematology,#/uL,3040145,Nucleated cells [#/volume] in Peritoneal fluid by Manual count,Measurement,LOINC,Lab Test,S,51926-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,12103
-52066,Voided Specimen,Ascites,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,1
-52067,Young#,Ascites,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52068,24 Hr,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52069,Absolute Basophil Count,Blood,Hematology,K/uL,3013429,Basophils [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,704-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,531922
-52070,Absolute CD19 Count,Blood,Hematology,,3010503,CD19 cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,8116-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52071,Absolute CD20 Count,Blood,Hematology,,3018071,CD20 cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,9558-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52072,Absolute CD56 Count,Blood,Hematology,,3026757,CD56 cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,14113-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52073,Absolute Eosinophil Count,Blood,Hematology,K/uL,3028615,Eosinophils [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,711-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,Duplicate of itemid 51199,531967
-52074,Absolute Monocyte Count,Blood,Hematology,K/uL,3033575,Monocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,742-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,Duplicate of itemid 51253,531923
-52075,Absolute Neutrophil Count,Blood,Hematology,K/uL,3013650,Neutrophils [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,751-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,1,,554993
-52076,Acid Phosphatase Stain,Blood,Hematology,,3006461,Microscopic observation [Identifier] in Blood or Marrow by Tartrate-resistant acid phosphatase stain,Measurement,LOINC,Lab Test,S,11020-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52077,Acidserum,Blood,Hematology,,3037556,Urate [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3084-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-52078,Antithrombin III,Blood,Hematology,,3000515,Antithrombin actual/normal in Platelet poor plasma by Chromogenic method,Measurement,LOINC,Lab Test,S,27811-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52079,ASA Tol,Blood,Hematology,,3019107,Acetylsalicylate [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3306-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-52080,Asd,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52081,ASD & NA-F,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52082,Aspirin Reactivity,Blood,Hematology,,3039998,Platelet aggregation arachidonate induced [Units/volume] in Blood,Measurement,LOINC,Lab Test,S,53814-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52083,Autohem+g,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52084,Autohem-g,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52085,Bleed Tm,Blood,Hematology,,3011625,Bleeding time,Measurement,LOINC,Lab Test,S,11067-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-52086,Bleed Tm,Blood,Hematology,,3011625,Bleeding time,Measurement,LOINC,Lab Test,S,11067-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-52087,CD15/56,Blood,Hematology,,3020358,CD16+CD56+ cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,20402-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,498
-52088,CD 1a,Blood,Hematology,,3033563,CD1a cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,20476-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3
-52089,CD30,Blood,Hematology,,3002041,CD30 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,17137-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52090,CD42,Blood,Hematology,,3002464,CD42 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,19122-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52091,CD52,Blood,Hematology,,3015771,CD52 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,17172-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52092,CD56 %,Blood,Hematology,%,3005460,CD56 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,8133-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,9
-52093,CD56 Absolute Count,Blood,Hematology,#/uL,3026757,CD56 cells [#/volume] in Blood,Measurement,LOINC,Lab Test,S,14113-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,9
-52094,CD61,Blood,Hematology,,3022458,CD61 cells/100 cells in Blood,Measurement,LOINC,Lab Test,S,20478-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52095,CD62,Blood,Hematology,,3042828,CD62 cells/100 cells in Specimen,Measurement,LOINC,Lab Test,S,32855-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-52096,Chloroacetate,Blood,Hematology,,3023435,Microscopic observation [Identifier] in Tissue by Chloracetate esterase stain,Measurement,LOINC,Lab Test,S,10780-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52097,Circ Ab,Blood,Hematology,,3044917,Immunoglobulin panel [Mass/volume] - Serum,Measurement,LOINC,Lab Test,S,34550-4,,,MIMIC-IV v2.0,,,,,0,,0
-52098,Clot Lysis,Blood,Hematology,,3023055,Clot Lysis [Time] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3244-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52099,Clot Retraction,Blood,Hematology,,3013528,Clot Retraction [Time] in Blood by Coagulation assay,Measurement,LOINC,Lab Test,S,3245-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52100,Clot Time,Blood,Hematology,,3041078,Clot formation [Time] in Blood by Thromboelastography,Measurement,LOINC,Lab Test,S,52768-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52101,Cr,Blood,Hematology,,3051825,Creatinine [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,38483-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52102,Crenated Cells,Blood,Hematology,,3005854,Burr cells [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,7790-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52103,Cross Imm,Blood,Hematology,,3044917,Immunoglobulin panel [Mass/volume] - Serum,Measurement,LOINC,Lab Test,S,34550-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-52104,Cryoglob,Blood,Hematology,,3021322,Cryoglobulin [Presence] in Serum,Measurement,LOINC,Lab Test,S,5117-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52105,Direct Antiplatelet Antibodies,Blood,Hematology,,3017451,Platelet associated Ab [Presence] in Blood,Measurement,LOINC,Lab Test,S,24374-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52106,Donath-l,Blood,Hematology,,3024486,Donath Landsteiner Ab [Presence] in Blood,Measurement,LOINC,Lab Test,S,18286-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52107,dRVVT - Confirmation,Blood,Hematology,N/A,3032493,dRVVT/dRVVT W excess phospholipid (screen to confirm ratio),Measurement,LOINC,Lab Test,S,50410-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,118
-52108,dRVVT - Normalized Ratio,Blood,Hematology,N/A,1616395,dRVVT/dRVVT.excess phospholipid [Ratio] normalized in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,97642-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,118
-52109,dRVVT - Screen,Blood,Hematology,N/A,3019174,dRVVT (LA screen),Measurement,LOINC,Lab Test,S,6303-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,450
-52110,DSmear,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52111,Echinocytes,Blood,Hematology,N/A,3005854,Burr cells [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,7790-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,42301
-52112,Euglobulin Lysis,Blood,Hematology,,3023055,Clot Lysis [Time] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3244-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52113,Factor IX Inhibitor,Blood,Hematology,BU,3004009,Coagulation factor IX inhibitor [Units/volume] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3185-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1
-52114,Factor VIII Antigen,Blood,Hematology,,3006728,Coagulation factor VIII Ag [Presence] in Tissue by Immune stain,Measurement,LOINC,Lab Test,S,10521-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52115,Fibrinoge,Blood,Hematology,,3016407,Fibrinogen [Mass/volume] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3255-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52116,Fibrinogen,Blood,Hematology,,3016407,Fibrinogen [Mass/volume] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3255-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 52115,0
-52117,"Fibrinogen, Immunologic",Blood,Hematology,,3016628,Fibrinogen Ag [Mass/volume] in Platelet poor plasma by Immunoassay,Measurement,LOINC,Lab Test,S,3256-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52118,Fingerstick,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52119,Fitzgerld,Blood,Hematology,,3012816,Kininogen HMW [Units/volume] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3276-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52120,Fitzgerld,Blood,Hematology,,3012816,Kininogen HMW [Units/volume] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3276-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,Duplicate of itemid 52119,0
-52121,Fletcher,Blood,Hematology,,3002315,Prekallikrein (Fletcher Factor) [Units/volume] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,6005-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52122,Fsp,Blood,Hematology,,3000401,Fibrin+Fibrinogen fragments [Mass/volume] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,30226-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52123,"G6PD, Qualitative",Blood,Hematology,,3037292,Glucose-6-Phosphate dehydrogenase [Presence] in Red Blood Cells,Measurement,LOINC,Lab Test,S,2356-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52124,G6pd Spec,Blood,Hematology,,3003994,Glucose-6-Phosphate dehydrogenase [Enzymatic activity/mass] in Red Blood Cells,Measurement,LOINC,Lab Test,S,32546-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52125,Glutathione,Blood,Hematology,,3015416,Glutathione [Mass/volume] in Red Blood Cells,Measurement,LOINC,Lab Test,S,2383-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52126,Heinz Aph,Blood,Hematology,,3022613,Heinz bodies [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,716-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52127,Helmet Cells,Blood,Hematology,,3023873,Helmet cells [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,10374-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52128,Hemoglobin H Inclusion,Blood,Hematology,,40762276,Hemoglobin H inclusion bodies [Presence] in Blood,Measurement,LOINC,Lab Test,S,59185-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52129,Hemoglobin Other,Blood,Hematology,%,3051396,Hemoglobin.other/Hemoglobin.total in Blood,Measurement,LOINC,Lab Test,S,48343-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,42
-52130,Histiocytes,Blood,Hematology,,3043564,Histiocytes [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,44721-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52131,HIT-Ab Interpreted Result,Blood,Hematology,N/A,43533839,Heparin induced platelet IgG Ab [Interpretation] in Serum Narrative,Measurement,LOINC,Lab Test,S,73816-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,244
-52132,HIT-Ab Numerical Result,Blood,Hematology,U/mL,3043870,Heparin induced platelet Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,45155-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,244
-52133,Hmwk,Blood,Hematology,,3012816,Kininogen HMW [Units/volume] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3276-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52134,IG,Blood,Hematology,,3044917,Immunoglobulin panel [Mass/volume] - Serum,Measurement,LOINC,Lab Test,S,34550-4,,,MIMIC-IV v2.0,,,,,,,0
-52135,Immature Granulocytes,Blood,Hematology,%,3050479,Immature granulocytes/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,38518-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,420731
-52136,Inhibitor,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52137,Inh Scr,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52138,Kct,Blood,Hematology,,3014712,Kaolin activated time [Units/volume] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,13053-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52139,LE Prep,Blood,Hematology,,3017650,Lupus erythematosus cells [Presence] in Blood,Measurement,LOINC,Lab Test,S,13507-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52140,LS,Blood,Hematology,,3044009,aPTT.lupus sensitive (LA screen),Measurement,LOINC,Lab Test,S,34571-0,,,MIMIC-IV v2.0,,,,,0,,0
-52141,Malaria Smear,Blood,Hematology,,3045707,Microscopic observation [Identifier] in Blood by Malaria smear,Measurement,LOINC,Lab Test,S,32700-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52142,Mean Platelet Volume,Blood,Hematology,,3043111,Platelet mean volume [Entitic volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,32623-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52143,Methemalb,Blood,Hematology,,3024807,Methemalbumin [Presence] in Serum or Plasma,Measurement,LOINC,Lab Test,S,17263-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52144,Methemoglobin,Blood,Hematology,,3004831,Methemoglobin [Presence] in Blood,Measurement,LOINC,Lab Test,S,2613-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52145,Mono Spot Test,Blood,Hematology,,3033533,Heterophile Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,31418-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52146,Naphtol Acetate Stain,Blood,Hematology,,3014679,Microscopic observation [Identifier] in Tissue by Acetate esterase stain,Measurement,LOINC,Lab Test,S,10765-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52147,NEUTX,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52148,NEUTY,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52149,NFletcher,Blood,Hematology,,3002315,Prekallikrein (Fletcher Factor) [Units/volume] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,6005-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-52150,Non-Specific Esterase,Blood,Hematology,,3024873,Microscopic observation [Identifier] in Blood or Marrow by Esterase stain.non-specific,Measurement,LOINC,Lab Test,S,11016-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52151,NRBC,Blood,Hematology,,3045168,Nucleated erythrocytes [Presence] in Blood,Measurement,LOINC,Lab Test,S,34188-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52152,"Osmotic Fragility, Incubated",Blood,Hematology,,3046583,Osmotic fragility [Interpretation] of Red Blood Cells--Incubated,Measurement,LOINC,Lab Test,S,32862-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52153,Other Inhibitor,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52154,P2Y12 Reaction Units,Blood,Hematology,,3048603,Platelet aggregation ADP induced [Units/volume] in Platelet rich plasma,Measurement,LOINC,Lab Test,S,49010-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52155,Periodic Acid Schiff Stain,Blood,Hematology,,3012525,Microscopic observation [Identifier] in Blood or Marrow by Periodic acid-Schiff stain,Measurement,LOINC,Lab Test,S,9786-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52156,Peroxidase Staining,Blood,Hematology,,3026228,Microscopic observation [Identifier] in Blood or Marrow by Peroxidase stain,Measurement,LOINC,Lab Test,S,11018-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52157,Plasma Hemoglobin,Blood,Hematology,,3022493,Free Hemoglobin [Mass/volume] in Plasma,Measurement,LOINC,Lab Test,S,721-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52158,Plasminogen,Blood,Hematology,,3002535,Plasminogen [Units/volume] in Platelet poor plasma by Chromogenic method,Measurement,LOINC,Lab Test,S,5970-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52159,Platelet Aggregation,Blood,Hematology,,3020174,Platelet aggregation [Interpretation] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,21027-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52160,Prekallekrein,Blood,Hematology,,3004231,Prekallikrein (Fletcher Factor) [Presence] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,13594-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52161,Problem Specimen,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52162,Protein S,Blood,Hematology,,3002346,Protein S [Units/volume] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,5892-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52163,PT Control,Blood,Hematology,,3033891,Prothrombin time (PT) in Control Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,5901-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52164,PT Mean,Blood,Hematology,,3034426,Prothrombin time (PT),Measurement,LOINC,Lab Test,S,5902-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52165,PTT Control,Blood,Hematology,,3038102,aPTT in Control Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,13488-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52166,PTT-LA,Blood,Hematology,,3044009,aPTT.lupus sensitive (LA screen),Measurement,LOINC,Lab Test,S,34571-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52167,PTT mea,Blood,Hematology,,3013176,aPTT normal/actual in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,5899-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52168,Pyruvate Kinase,Blood,Hematology,,3015478,Pyruvate kinase [Presence] in Blood,Measurement,LOINC,Lab Test,S,11227-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52169,QFib,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52170,Rbc,Blood,Hematology,,3020416,Erythrocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,789-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51279,0
-52171,RBC Morphology,Blood,Hematology,N/A,3012764,Erythrocyte morphology finding [Identifier] in Blood,Measurement,LOINC,Lab Test,S,6742-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,21772
-52172,RDW-SD,Blood,Hematology,fL,3015182,Erythrocyte distribution width [Entitic volume] by Automated count,Measurement,LOINC,Lab Test,S,21000-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1398444
-52173,Red Blood Cell Enzyme,Blood,Hematology,,43055529,Erythrocyte enzyme panel - Red Blood Cells,Measurement,LOINC,Lab Test,S,72695-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52174,"Reptilase Time, Control",Blood,Hematology,,3011893,Reptilase time in Control Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,5942-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52175,Ristocetin Response,Blood,Hematology,,3037533,von Willebrand factor (vWf) ristocetin cofactor actual/normal in Platelet poor plasma by Platelet aggregation,Measurement,LOINC,Lab Test,S,6014-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52176,Rouleaux,Blood,Hematology,N/A,3036273,Rouleaux [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,7797-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,62
-52177,SCT - Confirmation,Blood,Hematology,N/A,40769396,Normalized silica clotting time of Platelet poor plasma,Measurement,LOINC,Lab Test,S,66736-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,45
-52178,SCT - Normalized Ratio,Blood,Hematology,N/A,40769396,Normalized silica clotting time of Platelet poor plasma,Measurement,LOINC,Lab Test,S,66736-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,45
-52179,SCT - Screen,Blood,Hematology,N/A,40769396,Normalized silica clotting time of Platelet poor plasma,Measurement,LOINC,Lab Test,S,66736-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,335
-52180,STA-CLOT,Blood,Hematology,,46235691,dRVVT W excess hexagonal phospholipid (STA-StaClot confirm),Measurement,LOINC,Lab Test,S,75883-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52181,Stomatocyte,Blood,Hematology,N/A,3024783,Stomatocytes [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,10380-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,108
-52182,Sudan Black Staining,Blood,Hematology,,3012524,Microscopic observation [Identifier] in Blood or Marrow by Sudan black B stain,Measurement,LOINC,Lab Test,S,11019-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52183,Sulf Hgb,Blood,Hematology,,3010904,Sulfhemoglobin [Presence] in Blood,Measurement,LOINC,Lab Test,S,4684-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52184,TCR Alpha-Beta,Blood,Hematology,,21493682,TCR alpha beta cells/100 CD3 cells in Blood,Measurement,LOINC,Lab Test,S,80713-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6
-52185,TCR Gamma-Delta,Blood,Hematology,,21493683,TCR gamma delta cells/100 CD3 cells in Blood,Measurement,LOINC,Lab Test,S,80714-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6
-52186,Test,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52187,Thrombin Time,Blood,Hematology,,3036489,Thrombin time,Measurement,LOINC,Lab Test,S,3243-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52188,Thrombin Time Control,Blood,Hematology,,3005080,Thrombin time in Control Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,5955-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52189,Thrombin Time Control,Blood,Hematology,,3005080,Thrombin time in Control Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,5955-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52190,Tissue Thromboplastin Inhibitor,Blood,Hematology,,3033295,Lupus anticoagulant neutralization dilute phospholipid actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,50376-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Discouraged LOINC code,0
-52191,Tr- Acid,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52192,Trap Stain,Blood,Hematology,,3006461,Microscopic observation [Identifier] in Blood or Marrow by Tartrate-resistant acid phosphatase stain,Measurement,LOINC,Lab Test,S,11020-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52193,Viii Ag,Blood,Hematology,,3052074,Coagulation factor VIII Ag actual/normal in Platelet poor plasma by Immunoassay,Measurement,LOINC,Lab Test,S,38521-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52194,VIII-CIE,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52195,Voided Specimen,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,3236
-52196,WAM Manual Diff,Blood,Hematology,,40760892,CBC W Ordered Manual Differential panel - Blood,Measurement,LOINC,Lab Test,S,57782-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52197,WAM MANUAL DIFF 2,Blood,Hematology,,40760892,CBC W Ordered Manual Differential panel - Blood,Measurement,LOINC,Lab Test,S,57782-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,Duplicate of itemid 52196,0
-52198,ErytFlg,Blood,Hematology,,3020416,Erythrocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,789-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52199,FragFlg,Blood,Hematology,,3019880,Schistocytes [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,800-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52200,PltDist,Blood,Hematology,,3002736,Platelet distribution width [Entitic volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,32207-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52201,PltScat,Blood,Hematology,,3024929,Platelets [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,777-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52202,PltClmp,Blood,Hematology,,3035460,Platelet clump [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,7796-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52203,RBCAgg,Blood,Hematology,,3041228,Erythrocyte aggregates [Presence] in Blood by Light microscopy,Measurement,LOINC,Lab Test,S,51638-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52204,RBCDist,Blood,Hematology,,3019897,Erythrocyte distribution width [Ratio] by Automated count,Measurement,LOINC,Lab Test,S,788-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52205,RetScat,Blood,Hematology,,3023520,Reticulocytes [#/volume] in Blood,Measurement,LOINC,Lab Test,S,14196-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52206,RetFlg,Blood,Hematology,,3027945,Reticulocytes/100 erythrocytes in Blood,Measurement,LOINC,Lab Test,S,4679-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52207,TurbHbI,Blood,Hematology,,3000963,Hemoglobin [Mass/volume] in Blood,Measurement,LOINC,Lab Test,S,718-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-52208,BasoFlg,Blood,Hematology,,3013429,Basophils [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,704-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52209,EosFlg,Blood,Hematology,,3028615,Eosinophils [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,711-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52210,LeftShf,Blood,Hematology,,3014099,Leukocytes Left Shift [Presence] in Blood,Measurement,LOINC,Lab Test,S,30411-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52211,LymFlg,Blood,Hematology,,3004327,Lymphocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,731-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52212,MonoFlg,Blood,Hematology,,3011948,Monocytes/100 leukocytes in Blood by Automated count,Measurement,LOINC,Lab Test,S,5905-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52213,NRBCFlg,Blood,Hematology,,3007238,Nucleated erythrocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,771-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52214,AbnLymp,Blood,Hematology,,3008943,Abnormal lymphocytes [#/volume] in Blood,Measurement,LOINC,Lab Test,S,30412-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52215,ATLFlg,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52216,BlasFlg,Blood,Hematology,,3005105,Blasts [#/volume] in Blood,Measurement,LOINC,Lab Test,S,30376-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52217,Bl/AbLy,Blood,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52218,IG Flg,Blood,Hematology,,3044917,Immunoglobulin panel [Mass/volume] - Serum,Measurement,LOINC,Lab Test,S,34550-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52219,WBCScat,Blood,Hematology,,3000905,Leukocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,6690-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52220,wbcp,Blood,Hematology,%,3013727,Leukocytes other/100 leukocytes in Blood,Measurement,LOINC,Lab Test,S,26471-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,4921
-52221,Atypical Lymphocytes,Cerebrospinal Fluid,Hematology,%,3008266,Variant lymphocytes/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,30416-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,961
-52222,Atyps#,Cerebrospinal Fluid,Hematology,,3031773,Variant lymphocytes [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,35043-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52223,Bands,Cerebrospinal Fluid,Hematology,%,3007905,Band form neutrophils/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,26509-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,655
-52224,Bands#,Cerebrospinal Fluid,Hematology,,3032644,Band form neutrophils [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,35015-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52225,Basophils,Cerebrospinal Fluid,Hematology,%,3020829,Basophils/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,30374-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,351
-52226,Basos#,Cerebrospinal Fluid,Hematology,,3030870,Basophils [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,35072-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52227,Blasts,Cerebrospinal Fluid,Hematology,%,3025698,Blasts/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,26447-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,88
-52228,Blasts#,Cerebrospinal Fluid,Hematology,,3032352,Blasts [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,35068-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52229,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52230,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52231,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52232,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52233,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52234,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52235,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52236,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52237,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52238,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52239,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52240,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52241,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52242,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52243,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52244,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52245,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52246,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52247,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52248,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52249,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52250,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52251,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52252,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52253,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52254,Delete,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52255,Eos#,Cerebrospinal Fluid,Hematology,,3031163,Eosinophils [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,34958-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52256,Eosinophils,Cerebrospinal Fluid,Hematology,%,3022640,Eosinophils/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,26451-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1881
-52257,"Hematocrit, CSF",Cerebrospinal Fluid,Hematology,%,3013811,Hematocrit [Volume Fraction] of Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,30398-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,146
-52258,Histiocyte,Cerebrospinal Fluid,Hematology,,3007666,Histiocytes/100 cells in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,20504-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52259,Histiocytes#,Cerebrospinal Fluid,Hematology,,3030553,Histiocytes [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,35056-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52260,Hypersegmented Neutrophils,Cerebrospinal Fluid,Hematology,,3017900,Segmented neutrophils/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,26506-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52261,Hypersegmented Neutrophils #,Cerebrospinal Fluid,Hematology,,3032385,Segmented neutrophils [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,35011-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52262,Immunophenotyping,Cerebrospinal Fluid,Hematology,,40758359,Immunophenotyping study,Measurement,LOINC,Lab Test,S,55230-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,631
-52263,Lining Cell,Cerebrospinal Fluid,Hematology,%,3016512,Cerebroventricular lining cells [Presence] in Cerebral spinal fluid by Light microscopy,Measurement,LOINC,Lab Test,S,21176-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,45
-52264,Lymphs,Cerebrospinal Fluid,Hematology,,3020951,Lymphocytes/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,26479-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52265,Lymphs#,Cerebrospinal Fluid,Hematology,,3004560,Lymphocytes [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,26475-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52266,Macrophage,Cerebrospinal Fluid,Hematology,%,3028502,Macrophages/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,30426-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4025
-52267,Macrophage#,Cerebrospinal Fluid,Hematology,,3033163,Macrophages [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,35038-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52268,Mesothelial cells,Cerebrospinal Fluid,Hematology,%,3011271,Mesothelial cells/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,30429-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,93
-52269,Mesothelial cells #,Cerebrospinal Fluid,Hematology,,3032331,Mesothelial cells [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,35034-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52270,Metamyelocytes,Cerebrospinal Fluid,Hematology,%,3009788,Metamyelocytes/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,30366-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,138
-52271,Metas#,Cerebrospinal Fluid,Hematology,,3032891,Metamyelocytes [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,35030-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52272,Monocytes,Cerebrospinal Fluid,Hematology,%,3037577,Monocytes/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,26486-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,18948
-52273,Monos#,Cerebrospinal Fluid,Hematology,,3030850,Monocytes [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,35026-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52274,Myelocytes,Cerebrospinal Fluid,Hematology,%,3021345,Myelocytes/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,30447-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,68
-52275,Myelos#,Cerebrospinal Fluid,Hematology,,3032670,Myelocytes [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,35017-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52276,NRBC,Cerebrospinal Fluid,Hematology,%,3053315,Nucleated erythrocytes/100 cells in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,48778-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,414
-52277,NRBC#,Cerebrospinal Fluid,Hematology,,3015637,Nucleated erythrocytes [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,26459-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52278,Other,Cerebrospinal Fluid,Hematology,%,46234850,Other cells/100 leukocytes in Cerebral spinal fluid by Manual count,Measurement,LOINC,Lab Test,S,75374-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2000
-52279,Plasma,Cerebrospinal Fluid,Hematology,%,3053157,Plasma cells/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,47413-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,200
-52280,Plasma#,Cerebrospinal Fluid,Hematology,,3031165,Plasma cells [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35006-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52281,Polys,Cerebrospinal Fluid,Hematology,%,3022356,Polymorphonuclear cells/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,26517-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,18948
-52282,Polys#,Cerebrospinal Fluid,Hematology,,3030884,Polymorphonuclear cells [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,35001-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52283,Promyelocytes,Cerebrospinal Fluid,Hematology,%,3036234,Promyelocytes/100 leukocytes in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,30467-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,60
-52284,Promyelocytes#,Cerebrospinal Fluid,Hematology,,3031768,Promyelocytes [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,34995-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52285,"RBC, CSF",Cerebrospinal Fluid,Hematology,#/uL,3027475,Erythrocytes [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,26454-9,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,18801
-52286,"Total Nucleated Cells, CSF",Cerebrospinal Fluid,Hematology,#/uL,40761570,Nucleated cells [#/volume] in Cerebral spinal fluid,Measurement,LOINC,Lab Test,S,58470-6,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,18939
-52287,Voided Specimen,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,3
-52288,Young,Cerebrospinal Fluid,Hematology,%,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,4
-52289,Young#,Cerebrospinal Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52290,Dna,I,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52291,Atyps#,Joint Fluid,Hematology,,3031784,Variant lymphocytes [#/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,35044-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52292,Bands#,Joint Fluid,Hematology,,3032620,Band form neutrophils [#/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,35013-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52293,Basos#,Joint Fluid,Hematology,,3030892,Basophils [#/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,35074-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52294,Blasts,Joint Fluid,Hematology,%,3028907,Blasts/100 leukocytes in Synovial fluid,Measurement,LOINC,Lab Test,S,33374-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1
-52295,Blasts#,Joint Fluid,Hematology,,3032088,Blasts [#/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,35064-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52296,Eos#,Joint Fluid,Hematology,,3032048,Eosinophils [#/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,35060-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52297,Histio#,Joint Fluid,Hematology,,3030564,Histiocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35057-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52298,Histiocyte,Joint Fluid,Hematology,,3040382,Histiocytes/100 cells in Synovial fluid by Manual count,Measurement,LOINC,Lab Test,S,40489-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52299,Hypersegmented Neutrophils,Joint Fluid,Hematology,,3030913,Segmented neutrophils/100 leukocytes in Synovial fluid,Measurement,LOINC,Lab Test,S,33386-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52300,Hypersegmented Neutrophils #,Joint Fluid,Hematology,,3031201,Segmented neutrophils [#/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,35009-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52301,Lining Cell,Joint Fluid,Hematology,%,3034891,Synovial lining cells/100 cells in Synovial fluid,Measurement,LOINC,Lab Test,S,35651-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,134
-52302,Lymphs#,Joint Fluid,Hematology,,3032064,Lymphocytes [#/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,35049-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52303,Metas#,Joint Fluid,Hematology,,3032903,Metamyelocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35031-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52304,Monos#,Joint Fluid,Hematology,,3012175,Monocytes [#/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,30435-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52305,Myelocytes,Joint Fluid,Hematology,%,3024394,Myelocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17800-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,9
-52306,Myelos#,Joint Fluid,Hematology,,3032657,Myelocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35016-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52307,Plasma,Joint Fluid,Hematology,%,3044515,Plasma cells/100 leukocytes in Synovial fluid by Manual count,Measurement,LOINC,Lab Test,S,40492-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,14
-52308,Plasma#,Joint Fluid,Hematology,,3031165,Plasma cells [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35006-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52309,Polys#,Joint Fluid,Hematology,,3031142,Polymorphonuclear cells [#/volume] in Synovial fluid,Measurement,LOINC,Lab Test,S,35004-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52310,Promyelo#,Joint Fluid,Hematology,,3031780,Promyelocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,34996-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52311,Promyelocytes,Joint Fluid,Hematology,%,3023316,Promyelocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,17799-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,10
-52312,"Total Nucleated Cells, Joint",Joint Fluid,Hematology,#/uL,3039497,Nucleated cells [#/volume] in Synovial fluid by Manual count,Measurement,LOINC,Lab Test,S,53557-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6395
-52313,Voided Specimen,Joint Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,3
-52314,Young,Joint Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52315,Young#,Joint Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52316,Acid Phosphatase Stain,Bone Marrow,Hematology,,3022960,Microscopic observation [Identifier] in Bone by Acid phosphatase stain,Measurement,LOINC,Lab Test,S,21391-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52317,Asd,Bone Marrow,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52318,Asd&na-f,Bone Marrow,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52319,CD 1a,Bone Marrow,Hematology,,3039636,CD1a cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,52874-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,6
-52320,CD30,Bone Marrow,Hematology,,3030293,CD30 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51289-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52321,CD42,Bone Marrow,Hematology,,3030517,CD42 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51323-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52322,CD52,Bone Marrow,Hematology,,3031510,CD52 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,42886-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52323,CD61,Bone Marrow,Hematology,,3029330,CD61 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51361-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52324,CD62,Bone Marrow,Hematology,,3042828,CD62 cells/100 cells in Specimen,Measurement,LOINC,Lab Test,S,32855-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52325,Chloroacetate Esterase,Bone Marrow,Hematology,,3025107,Microscopic observation [Identifier] in Blood or Marrow by Chloracetate esterase stain,Measurement,LOINC,Lab Test,S,11017-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52326,Naphthol Acetate Stain,Bone Marrow,Hematology,,21493420,Microscopic observation [Identifier] in Bone marrow by Acetate esterase stain,Measurement,LOINC,Lab Test,S,81423-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52327,Naphthol Butryrate,Bone Marrow,Hematology,,3017994,Microscopic observation [Identifier] in Bone marrow by Butyrate esterase stain,Measurement,LOINC,Lab Test,S,13512-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52328,Periodic Schiff Stain,Bone Marrow,Hematology,,3012525,Microscopic observation [Identifier] in Blood or Marrow by Periodic acid-Schiff stain,Measurement,LOINC,Lab Test,S,9786-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52329,Peroxidase Stain,Bone Marrow,Hematology,,3026228,Microscopic observation [Identifier] in Blood or Marrow by Peroxidase stain,Measurement,LOINC,Lab Test,S,11018-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52330,Sudan Black Stain,Bone Marrow,Hematology,,3012524,Microscopic observation [Identifier] in Blood or Marrow by Sudan black B stain,Measurement,LOINC,Lab Test,S,11019-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52331,TCR Alpha-Beta,Bone Marrow,Hematology,,3046019,TCR alpha beta cells/100 cells in Specimen,Measurement,LOINC,Lab Test,S,32860-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4
-52332,TCR Gamma-Delta,Bone Marrow,Hematology,,3046045,TCR gamma delta cells/100 cells in Specimen,Measurement,LOINC,Lab Test,S,32861-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,4
-52333,Tr-acid,Bone Marrow,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52334,Voided Specimen,Bone Marrow,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52335,TdT,Bone Marrow,Hematology,,3032522,Terminal deoxyribonucleotidyl transferase cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,42620-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,64
-52336,Atyps#,Other Body Fluid,Hematology,,3031796,Variant lymphocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35045-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52337,Bands#,Other Body Fluid,Hematology,,3032632,Band form neutrophils [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35014-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52338,Basos#,Other Body Fluid,Hematology,,3030548,Basophils [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35071-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52339,Blasts,Other Body Fluid,Hematology,%,3026596,Blasts/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,26448-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3
-52340,Blasts#,Other Body Fluid,Hematology,,3031492,Blasts [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35067-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52341,CD 1a,Other Body Fluid,Hematology,,3039924,CD1a cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,52873-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2
-52342,CD30,Other Body Fluid,Hematology,,3030734,CD30 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51290-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52343,CD42,Other Body Fluid,Hematology,,3029687,CD42 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51324-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52344,CD52,Other Body Fluid,Hematology,,3031091,CD52 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,42885-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52345,CD55,Other Body Fluid,Hematology,,3043265,CD55 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,43935-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52346,CD59,Other Body Fluid,Hematology,,3043227,CD59 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,43938-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52347,CD61,Other Body Fluid,Hematology,,3031011,CD61 cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,51362-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52348,CD62,Other Body Fluid,Hematology,,3042828,CD62 cells/100 cells in Specimen,Measurement,LOINC,Lab Test,S,32855-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52349,Chloroac,Other Body Fluid,Hematology,,3033233,Microscopic observation [Identifier] in Specimen by Chloracetate esterase stain,Measurement,LOINC,Lab Test,S,32814-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-52350,Eos#,Other Body Fluid,Hematology,,3032084,Eosinophils [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35063-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52351,Fetal Hgb,Other Body Fluid,Hematology,,3019561,Hemoglobin F [Presence] in Amniotic fluid,Measurement,LOINC,Lab Test,S,28067-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52352,FETAL LUNG MATURITY - LBC,Other Body Fluid,Hematology,10E9 Bodies/L,3000788,Lamellar bodies [#/volume] in Amniotic fluid,Measurement,LOINC,Lab Test,S,19114-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,3
-52353,Histiocyte#,Other Body Fluid,Hematology,,3030564,Histiocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35057-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52354,Histiocytes,Other Body Fluid,Hematology,,3030588,Histiocytes/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,35055-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52355,Hypersegmented Neutrophils,Other Body Fluid,Hematology,%,3022005,Segmented neutrophils/100 leukocytes in Body fluid,Measurement,LOINC,Lab Test,S,30453-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2
-52356,Hypersegmented Neutrophils#,Other Body Fluid,Hematology,,3019355,Segmented neutrophils [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,30452-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52357,Iron,Other Body Fluid,Hematology,,3043264,Iron [Presence] in Body fluid,Measurement,LOINC,Lab Test,S,44327-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52358,Lining Cell,Other Body Fluid,Hematology,%,3035196,Ciliated columnar lining cells/100 leukocytes [# Ratio] in Body fluid,Measurement,LOINC,Lab Test,S,35477-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,154
-52359,Lymphs#,Other Body Fluid,Hematology,,3003467,Lymphocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,26476-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52360,Metamyelocytes#,Other Body Fluid,Hematology,,3032903,Metamyelocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35031-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52361,Monos#,Other Body Fluid,Hematology,,3031141,Monocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35076-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52362,Myelos#,Other Body Fluid,Hematology,,3032657,Myelocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35016-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52363,NRBC#,Other Body Fluid,Hematology,,3028129,Nucleated erythrocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,26460-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52364,Plasma#,Other Body Fluid,Hematology,,3031165,Plasma cells [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35006-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52365,Polys#,Other Body Fluid,Hematology,,3030894,Polymorphonuclear cells [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35002-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52366,Promyelocyte#,Other Body Fluid,Hematology,,3031780,Promyelocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,34996-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52367,TCR Alpha-Beta,Other Body Fluid,Hematology,,40760521,CD3+TCR alpha beta+ cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,57409-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52368,TCR Gamma-Delta,Other Body Fluid,Hematology,,40760541,CD3+TCR gamma delta+ cells/100 cells in Body fluid,Measurement,LOINC,Lab Test,S,57429-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52369,"Total Nucleated Cells, Other",Other Body Fluid,Hematology,#/uL,40758914,Nucleated cells [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,55793-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,2258
-52370,Voided Specimen,Other Body Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,6
-52371,Young,Other Body Fluid,Hematology,%,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,1
-52372,Young#,Other Body Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52373,TdT,Other Body Fluid,Hematology,,3041975,Terminal deoxyribonucleotidyl transferase cells/100 cells in Body fluid by Flow cytometry (FC),Measurement,LOINC,Lab Test,S,52997-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,13
-52374,,Other Body Fluid,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52375,Atyps#,Pleural,Hematology,,3031758,Variant lymphocytes [#/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,35042-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52376,Bands#,Pleural,Hematology,,3032632,Band form neutrophils [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35014-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52377,Basos#,Pleural,Hematology,,3030902,Basophils [#/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,35075-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52378,Blasts#,Pleural,Hematology,,3031481,Blasts [#/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,35066-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52379,Eos#,Pleural,Hematology,,3032072,Eosinophils [#/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,35062-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52380,Histiocyte#,Pleural,Hematology,,3030564,Histiocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35057-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52381,Histiocytes,Pleural,Hematology,,3041613,Histiocytes/100 cells in Pleural fluid by Manual count,Measurement,LOINC,Lab Test,S,40519-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52382,Hypersegmented  Neutrophils#,Pleural,Hematology,,3032608,Segmented neutrophils [#/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,35012-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52383,Hypersegmented Neutrophils,Pleural,Hematology,,3030924,Segmented neutrophils/100 leukocytes in Pleural fluid,Measurement,LOINC,Lab Test,S,33385-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52384,Lymphs#,Pleural,Hematology,,3030845,Lymphocytes [#/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,35098-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52385,Metas#,Pleural,Hematology,,3032903,Metamyelocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35031-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52386,Monos#,Pleural,Hematology,,3031735,Monocytes [#/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,35028-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52387,Myelos#,Pleural,Hematology,,3032657,Myelocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35016-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52388,Plasma#,Pleural,Hematology,,3031165,Plasma cells [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,35006-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52389,Polys#,Pleural,Hematology,,3030872,Polymorphonuclear cells [#/volume] in Pleural fluid,Measurement,LOINC,Lab Test,S,35000-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52390,Promyelocytes#,Pleural,Hematology,,3031780,Promyelocytes [#/volume] in Body fluid,Measurement,LOINC,Lab Test,S,34996-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-52391,"Total Nucleated Cells, Pleural",Pleural,Hematology,#/uL,3041079,Nucleated cells [#/volume] in Pleural fluid by Automated count,Measurement,LOINC,Lab Test,S,52819-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,7931
-52392,Voided Specimen,Pleural,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,1
-52393,Young#,Pleural,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52394,FL1-D,Q,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52395,FL1-%FL2,Q,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52396,FL1-S,Q,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52397,FL2-D,Q,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52398,FL2-%FL1,Q,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52399,FL2-S,Q,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52400,FSC-S,Q,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52401,SSC-D,Q,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52402,SSC-S,Q,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-52403,Bile,Stool,Hematology,,3007153,Bile [Presence] in Stool,Measurement,LOINC,Lab Test,S,1965-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52404,Fat,Stool,Hematology,,3022481,Fat [Presence] in Stool,Measurement,LOINC,Lab Test,S,2270-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52405,Prblm,Stool,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52406,Voided Specimen,Stool,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,3
-52407,WBC,Stool,Hematology,,3014441,Leukocytes [Presence] in Stool by Light microscopy,Measurement,LOINC,Lab Test,S,13655-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52408,Bacturia,Urine,Hematology,,3026008,Bacteria identified in Urine by Culture,Measurement,LOINC,Lab Test,S,630-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52409,Budding Yeast,Urine,Hematology,,3020830,Yeast.budding [Presence] in Urine sediment,Measurement,LOINC,Lab Test,S,21033-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52410,Fatty Casts,Urine,Hematology,#/lpf,3015913,Fatty casts [#/area] in Urine sediment by Microscopy low power field,Measurement,LOINC,Lab Test,S,5789-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,5
-52411,Hgb,Urine,Hematology,,3011397,Hemoglobin [Presence] in Urine by Test strip,Measurement,LOINC,Lab Test,S,5794-3,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52412,HPF,Urine,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52413,Leuks,Urine,Hematology,,3035583,Leukocytes [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,5821-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52414,LEUKS,Urine,Hematology,,3035583,Leukocytes [#/area] in Urine sediment by Microscopy high power field,Measurement,LOINC,Lab Test,S,5821-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 52413,0
-52415,LPF,Urine,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52416,Myoglobin,Urine,Hematology,,3011470,Myoglobin [Presence] in Urine,Measurement,LOINC,Lab Test,S,2640-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52417,Pku,Urine,Hematology,,3001962,Phenylalanine [Presence] in DBS,Measurement,LOINC,Lab Test,S,29571-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,,0
-52418,Problem Specimen,Urine,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52419,Voided Specimen,Urine,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,696
-52420,ZZDUMMY,Urine,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,0
-52421,GATE,Urine,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,2
-52422,RUN,Urine,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,5
-52423,SKIP,Urine,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,4
-52424,RFXUCU,Urine,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,1516
-52425,XUCU,Urine,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,3963
-52426,UCU1,Urine,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,859
-52427,UCU2,Urine,Hematology,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,2289
-52434,"Chloride, Whole Blood",Blood,Blood Gas,,41650-3,Chloride [Moles/volume] in Arterial blood,Measurement,LOINC,Lab Test,S,41650-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,0
-52442,Lactate,Blood,Blood Gas,,3018405,Lactate [Moles/volume] in Arterial blood,Measurement,LOINC,Lab Test,S,2518-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,0
-52452,"Potassium, Whole Blood",Blood,Blood Gas,,3043409,Potassium [Moles/volume] in Arterial blood,Measurement,LOINC,Lab Test,S,32713-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,0
-52455,"Sodium, Whole Blood",Blood,Blood Gas,,3043706,Sodium [Moles/volume] in Arterial blood,Measurement,LOINC,Lab Test,S,32717-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.5,,0
-52500,Anion Gap,Blood,Chemistry,mEq/L,3045716,Anion gap in Serum or Plasma,Measurement,LOINC,Lab Test,S,33037-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,355
-52535,Chloride,Blood,Chemistry,mEq/L,3014576,Chloride [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2075-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,357
-52546,Creatinine,Blood,Chemistry,mg/dL,3016723,Creatinine [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2160-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,360
-52548,Cryoglobulin,Blood,Chemistry,,3021322,Cryoglobulin [Presence] in Serum,Measurement,LOINC,Lab Test,S,5117-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52551,D-Dimer,Blood,Chemistry,ng/mL DDU,3048530,Fibrin D-dimer DDU [Mass/volume] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,48066-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,40
-52562,Folate,Blood,Chemistry,,3036987,Folate [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2284-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52569,Glucose,Blood,Chemistry,mg/dL,3004501,Glucose [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2345-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,386
-52610,Potassium,Blood,Chemistry,mEq/L,3023103,Potassium [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2823-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 50971,386
-52623,Sodium,Blood,Chemistry,mEq/L,3019550,Sodium [Moles/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,2951-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,386
-52642,Troponin I,Blood,Chemistry,ng/mL,3021337,Troponin I.cardiac [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,10839-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,153
-52647,Urea Nitrogen,Blood,Chemistry,mg/dL,3013682,Urea nitrogen [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3094-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,357
-52703,"Albumin, Urine",Urine,Chemistry,,3025987,Albumin [Presence] in Urine,Measurement,LOINC,Lab Test,S,1753-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52720,"HCG, Urine, Qualitative",Urine,Chemistry,N/A,3018954,Choriogonadotropin (pregnancy test) [Presence] in Urine,Measurement,LOINC,Lab Test,S,2106-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,241
-52730,pH,Urine,Chemistry,units,3015736,pH of Urine,Measurement,LOINC,Lab Test,S,2756-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,558
-52769,Absolute Lymphocyte Count,Blood,Hematology,#/uL,3004327,Lymphocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,731-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51133.,27336
-52786,Bleeding Time,Blood,Hematology,,3011625,Bleeding time,Measurement,LOINC,Lab Test,S,11067-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52838,Factor II,Blood,Hematology,,3005353,Prothrombin activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3289-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52840,Factor IX,Blood,Hematology,,3026498,Coagulation factor IX activity [Units/volume] in Platelet poor plasma by Chromogenic method,Measurement,LOINC,Lab Test,S,3188-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52842,Factor V,Blood,Hematology,,3005757,Coagulation factor V activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3193-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52844,Factor VII,Blood,Hematology,,3011547,Coagulation factor VII activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3198-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52846,Factor VIII,Blood,Hematology,,3019250,Coagulation factor VIII activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3209-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52849,Factor X,Blood,Hematology,,3004409,Coagulation factor X activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3218-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52851,Factor XI,Blood,Hematology,,3001850,Coagulation factor XI activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3226-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52853,Factor XII,Blood,Hematology,,3002348,Coagulation factor XII activity actual/normal in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3232-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52855,Factor XIII,Blood,Hematology,,3019757,Coagulation factor XIII coagulum dissolution [Units/volume] in Platelet poor plasma by Coagulation assay,Measurement,LOINC,Lab Test,S,3240-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52858,Fibrin Degradation Products,Blood,Hematology,,3000401,Fibrin+Fibrinogen fragments [Mass/volume] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,30226-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52889,Lupus Anticoagulant,Blood,Hematology,,3027184,Lupus anticoagulant [Interpretation] in Platelet poor plasma,Measurement,LOINC,Lab Test,S,3281-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-52921,PT,Blood,Hematology,,3034426,Prothrombin time (PT),Measurement,LOINC,Lab Test,S,5902-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52923,PTT,Blood,Hematology,,3013466,aPTT in Blood by Coagulation assay,Measurement,LOINC,Lab Test,S,3173-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52929,Reptilase Time,Blood,Hematology,,3005308,Reptilase time,Measurement,LOINC,Lab Test,S,6683-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52934,"Reticulocyte Count, Manual",Blood,Hematology,,3041154,Reticulocytes [#/volume] in Blood by Manual count,Measurement,LOINC,Lab Test,S,40665-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52948,Thrombin,Blood,Hematology,,3036489,Thrombin time,Measurement,LOINC,Lab Test,S,3243-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-52955,CD10,Bone Marrow,Hematology,,3030454,CD10 cells/100 cells in Bone marrow,Measurement,LOINC,Lab Test,S,51216-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1541
-52992,Iron Stain,Bone Marrow,Hematology,,3018543,Iron.microscopic observation [Identifier] in Bone marrow by Potassium ferrocyanide stain,Measurement,LOINC,Lab Test,S,13513-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,1335
-53012,NRBC,Joint Fluid,Hematology,,40771130,Nucleated erythrocytes/100 leukocytes [Ratio] in Synovial fluid,Measurement,LOINC,Lab Test,S,68545-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53083,NRBC,Pleural,Hematology,,42868644,Nucleated erythrocytes/100 cells in Pleural fluid,Measurement,LOINC,Lab Test,S,70170-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53116,(Albumin),Ascites,Chemistry,,3026692,Albumin [Mass/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,1749-1,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53117,Alpha-1,Ascites,Chemistry,,3019891,Alpha 1 globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17812-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-53118,Alpha-2,Ascites,Chemistry,,3005504,Alpha 2 globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17814-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-53119,Beta,Ascites,Chemistry,,3003304,Beta globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17816-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-53120,Clostrid,Ascites,Chemistry,,46236184,Clostridium perfringens [Presence] in Specimen by Organism specific culture,Measurement,LOINC,Lab Test,S,77496-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-53121,Cryptococ,Ascites,Chemistry,,3024255,Cryptococcus sp Ag [Presence] in Specimen,Measurement,LOINC,Lab Test,S,29533-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-53122,Fl Scan,Ascites,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Unknown Abbreviation,0
-53123,"Immunoelectrophoresis, Ascites",Ascites,Chemistry,,3000265,Immunoelectrophoresis for Serum or Plasma,Measurement,LOINC,Lab Test,S,13169-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-53124,"Immunoglobulin G, Ascites",Ascites,Chemistry,,40758032,IgG [Mass/volume] in Peritoneal fluid,Measurement,LOINC,Lab Test,S,54901-4,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53125,"PEP, Ascites, Gamma Region",Ascites,Chemistry,,3023700,Gamma globulin/Protein.total in Body fluid by Electrophoresis,Measurement,LOINC,Lab Test,S,17818-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-53126,"Uric Acid, Ascites",Ascites,Chemistry,,3028566,Urate [Moles/volume] in Specimen,Measurement,LOINC,Lab Test,S,32343-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0,No suitable LOINC code,0
-53127,Voided Specimen,Ascites,Chemistry,,,,Measurement,LOINC,Lab Test,S,,,,MIMIC-IV v2.0,,,,,,Not a lab test,68
-53128,11-Deoxycorticosterone,Blood,Chemistry,,3008895,11-Deoxycorticosterone [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1656-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53129,3t,Blood,Chemistry,,3010340,Triiodothyronine (T3) [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3053-6,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-53130,4t,Blood,Chemistry,,3016991,Thyroxine (T4) [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,3026-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,0.1,,0
-53131,5' Nucleotidase,Blood,Chemistry,,3013614,5'-Nucleotidase [Enzymatic activity/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1690-7,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53132,Absolute Lymphocyte Count,Blood,Chemistry,,3004327,Lymphocytes [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,731-0,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 51133,0
-53133,Absolute Neutrophil,Blood,Chemistry,,3013650,Neutrophils [#/volume] in Blood by Automated count,Measurement,LOINC,Lab Test,S,751-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 52075,0
-53134,Absolute Other WBC,Blood,Chemistry,,3008511,Leukocytes other [#/volume] in Blood,Measurement,LOINC,Lab Test,S,30406-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53135,"Acid Phosphatase, Prostatic Fraction",Blood,Chemistry,,3035029,Prostatic acid phosphatase [Enzymatic activity/volume] in Serum,Measurement,LOINC,Lab Test,S,1714-5,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53136,Adrenocorticotrophic Hormone,Blood,Chemistry,,3033768,Corticotropin IgE Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,6016-0,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53137,Afp Mom,Blood,Chemistry,,3024370,Alpha-1-Fetoprotein [Multiple of the median] in Serum or Plasma,Measurement,LOINC,Lab Test,S,20450-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53138,(Albumin),Blood,Chemistry,,3028286,Albumin [Mass/volume] in Serum or Plasma by Electrophoresis,Measurement,LOINC,Lab Test,S,2862-1,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53139,Aldosterone,Blood,Chemistry,,3011337,Aldosterone [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1763-2,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53140,Aldosterone,Blood,Chemistry,,3011337,Aldosterone [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1763-2,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,Duplicate of itemid 53139,0
-53141,Alpha-1,Blood,Chemistry,,3015322,Alpha 1 globulin [Mass/volume] in Serum or Plasma by Electrophoresis,Measurement,LOINC,Lab Test,S,2865-4,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53142,Alpha-1-antitrypsin,Blood,Chemistry,,3026285,Alpha 1 antitrypsin [Mass/volume] in Serum or Plasma,Measurement,LOINC,Lab Test,S,1825-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53143,Alpha-2,Blood,Chemistry,,3005229,Alpha 2 globulin [Mass/volume] in Serum or Plasma by Electrophoresis,Measurement,LOINC,Lab Test,S,2868-8,,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53144,ANCA Titer,Blood,Chemistry,,3026712,Neutrophil cytoplasmic Ab [Titer] in Serum,Measurement,LOINC,Lab Test,S,21023-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,57
-53145,Anti-GBM Antibody,Blood,Chemistry,,3032700,Glomerular basement membrane Ab [Units/volume] in Serum,Measurement,LOINC,Lab Test,S,49774-3,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53146,Anti Hav,Blood,Chemistry,,3035456,Hepatitis A virus Ab [Presence] in Serum by Immunoassay,Measurement,LOINC,Lab Test,S,13951-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53147,Anti Hbc,Blood,Chemistry,,3036282,Hepatitis B virus core Ab [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,13952-7,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53148,Anti Hbe,Blood,Chemistry,,3036806,Hepatitis B virus e Ab [Presence] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,13953-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53149,Anti-hbs,Blood,Chemistry,,3013731,Hepatitis B virus surface Ab [Units/volume] in Serum or Plasma by Immunoassay,Measurement,LOINC,Lab Test,S,5193-8,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53150,Anti Hbs,Blood,Chemistry,,3006453,Hepatitis B virus surface Ab [Presence] in Serum by Immunoassay,Measurement,LOINC,Lab Test,S,10900-9,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
-53151,Anti-la,Blood,Chemistry,,3008914,Sjogrens syndrome-B extractable nuclear Ab [Presence] in Serum,Measurement,LOINC,Lab Test,S,8094-5,0000-0001-8822-1884,0000-0002-9348-9284,MIMIC-IV v2.0,2.71,https://loinc.org/relma/,v4.7,3/1/2022,,,0
+subject_id,subject_label,predicate_id,object_id,object_label,mapping_justification,author_id,reviewer_id,confidence,comment
+mimic:51221,Hematocrit,skos:exactMatch,loinc:4544-3,Hematocrit [Volume Fraction] of Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:50912,Creatinine,skos:exactMatch,loinc:2160-0,Creatinine [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51265,Platelet Count,skos:exactMatch,loinc:777-3,Platelets [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:51006,Urea Nitrogen,skos:exactMatch,loinc:3094-0,Urea nitrogen [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51222,Hemoglobin,skos:exactMatch,loinc:718-7,Hemoglobin [Mass/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:51301,White Blood Cells,skos:exactMatch,loinc:6690-2,Leukocytes [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 51300
+mimic:51249,MCHC,skos:exactMatch,loinc:786-4,MCHC [Mass/volume] by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:51279,Red Blood Cells,skos:exactMatch,loinc:789-8,Erythrocytes [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:51250,MCV,skos:exactMatch,loinc:787-2,MCV [Entitic volume] by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:51248,MCH,skos:exactMatch,loinc:785-6,MCH [Entitic mass] by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:51277,RDW,skos:exactMatch,loinc:788-0,Erythrocyte distribution width [Ratio] by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:50971,Potassium,skos:exactMatch,loinc:2823-3,Potassium [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50983,Sodium,skos:exactMatch,loinc:2951-2,Sodium [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50902,Chloride,skos:exactMatch,loinc:2075-0,Chloride [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50882,Bicarbonate,skos:exactMatch,loinc:1963-8,Bicarbonate [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50868,Anion Gap,skos:exactMatch,loinc:1863-0,Anion gap 4 in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50931,Glucose,skos:exactMatch,loinc:2345-7,Glucose [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50893,"Calcium, Total",skos:exactMatch,loinc:17861-6,Calcium [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50960,Magnesium,skos:exactMatch,loinc:19123-9,Magnesium [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50970,Phosphate,skos:exactMatch,loinc:2777-1,Phosphate [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50934,H,,,,,,,,Not a lab test
+mimic:51678,L,,,,,,,,Not a lab test
+mimic:50947,I,,,,,,,,Not a lab test
+mimic:51237,INR(PT),skos:exactMatch,loinc:6301-6,INR in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51274,PT,skos:exactMatch,loinc:5902-2,Prothrombin time (PT),HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50920,Estimated GFR (MDRD equation),skos:exactMatch,loinc:77147-7,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52172,RDW-SD,skos:exactMatch,loinc:21000-5,Erythrocyte distribution width [Entitic volume] by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50861,Alanine Aminotransferase (ALT),skos:exactMatch,loinc:1742-6,Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50878,Asparate Aminotransferase (AST),skos:exactMatch,loinc:1920-8,Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51275,PTT,skos:exactMatch,loinc:14979-9,aPTT in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51244,Lymphocytes,skos:exactMatch,loinc:736-9,Lymphocytes/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,1,
+mimic:51256,Neutrophils,skos:exactMatch,loinc:770-8,Neutrophils/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,1,
+mimic:51254,Monocytes,skos:exactMatch,loinc:5905-5,Monocytes/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,1,
+mimic:51146,Basophils,skos:exactMatch,loinc:706-2,Basophils/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,1,
+mimic:51200,Eosinophils,skos:exactMatch,loinc:713-8,Eosinophils/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,1,
+mimic:50885,"Bilirubin, Total",skos:exactMatch,loinc:1975-2,Bilirubin.total [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50863,Alkaline Phosphatase,skos:exactMatch,loinc:6768-6,Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50862,Albumin,skos:exactMatch,loinc:1751-7,Albumin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51486,Leukocytes,skos:exactMatch,loinc:20455-2,Leukocytes [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51491,pH,skos:exactMatch,loinc:5803-2,pH of Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 51094
+mimic:51498,Specific Gravity,skos:exactMatch,loinc:5811-5,Specific gravity of Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51506,Urine Appearance,skos:exactMatch,loinc:5767-9,Appearance of Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51508,Urine Color,skos:exactMatch,loinc:5778-6,Color of Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51466,Blood,skos:exactMatch,loinc:53963-5,Blood [Presence] in Urine by Visual,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51478,Glucose,skos:exactMatch,loinc:5792-7,Glucose [Mass/volume] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51492,Protein,skos:exactMatch,loinc:5804-0,Protein [Mass/volume] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51464,Bilirubin,skos:exactMatch,loinc:5770-3,Bilirubin.total [Presence] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51484,Ketone,skos:exactMatch,loinc:5797-6,Ketones [Mass/volume] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51487,Nitrite,skos:exactMatch,loinc:5802-4,Nitrite [Presence] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51514,Urobilinogen,skos:exactMatch,loinc:20405-7,Urobilinogen [Mass/volume] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51087,Length of Urine Collection,skos:exactMatch,loinc:13362-9,Collection duration of Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52033,Specimen Type,skos:exactMatch,loinc:66746-9,Specimen type,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50820,pH,skos:exactMatch,loinc:11558-4,pH of Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52075,Absolute Neutrophil Count,skos:exactMatch,loinc:751-8,Neutrophils [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:52073,Absolute Eosinophil Count,skos:exactMatch,loinc:711-2,Eosinophils [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,Duplicate of itemid 51199
+mimic:52074,Absolute Monocyte Count,skos:exactMatch,loinc:742-7,Monocytes [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,Duplicate of itemid 51253
+mimic:51133,Absolute Lymphocyte Count,skos:exactMatch,loinc:731-0,Lymphocytes [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:52069,Absolute Basophil Count,skos:exactMatch,loinc:704-7,Basophils [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:50821,pO2,skos:exactMatch,loinc:11556-8,Oxygen [Partial pressure] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50802,Base Excess,skos:exactMatch,loinc:11555-0,Base excess in Blood by calculation,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50804,Calculated Total CO2,skos:exactMatch,loinc:34728-6,"Carbon dioxide, total [Moles/volume] in Blood by calculation",HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50818,pCO2,skos:exactMatch,loinc:11557-6,Carbon dioxide [Partial pressure] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50813,Lactate,skos:exactMatch,loinc:32693-4,Lactate [Moles/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51493,RBC,skos:exactMatch,loinc:13945-1,Erythrocytes [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51516,WBC,skos:exactMatch,loinc:5821-4,Leukocytes [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51463,Bacteria,skos:exactMatch,loinc:5769-5,Bacteria [#/area] in Urine sediment by Microscopy high power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51476,Epithelial Cells,skos:exactMatch,loinc:5787-7,Epithelial cells [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51519,Yeast,skos:exactMatch,loinc:5822-2,Yeast [#/area] in Urine sediment by Microscopy high power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50954,Lactate Dehydrogenase (LD),skos:closeMatch,loinc:2532-0,Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Discouraged LOINC code
+mimic:52135,Immature Granulocytes,skos:exactMatch,loinc:38518-7,Immature granulocytes/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51003,Troponin T,skos:exactMatch,loinc:6598-7,Troponin T.cardiac [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51512,Urine Mucous,skos:exactMatch,loinc:8247-9,Mucus [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50993,Thyroid Stimulating Hormone,skos:exactMatch,loinc:3016-3,Thyrotropin [Units/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50933,Green Top Hold (plasma),,,,,,,,Not a lab test
+mimic:50910,Creatine Kinase (CK),skos:exactMatch,loinc:2157-6,Creatine kinase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50808,Free Calcium,skos:exactMatch,loinc:1994-3,Calcium.ionized [Moles/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50887,Blue Top Hold,,,,,,,,Not a lab test
+mimic:51266,Platelet Smear,skos:exactMatch,loinc:9317-9,Platelet adequacy [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50907,"Cholesterol, Total",skos:exactMatch,loinc:2093-3,Cholesterol [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51000,Triglycerides,skos:exactMatch,loinc:2571-8,Triglyceride [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50822,"Potassium, Whole Blood",skos:exactMatch,loinc:6298-4,Potassium [Moles/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50904,"Cholesterol, HDL",skos:exactMatch,loinc:2085-9,Cholesterol in HDL [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50903,Cholesterol Ratio (Total/HDL),skos:exactMatch,loinc:9830-1,Cholesterol.total/Cholesterol in HDL [Mass Ratio] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51137,Anisocytosis,skos:exactMatch,loinc:38892-6,Anisocytosis [Presence] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51267,Poikilocytosis,skos:exactMatch,loinc:779-9,Poikilocytosis [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50956,Lipase,skos:exactMatch,loinc:3040-3,Lipase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50955,Light Green Top Hold,,,,,,,,Not a lab test
+mimic:51246,Macrocytes,skos:exactMatch,loinc:30424-6,Macrocytes [Presence] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51268,Polychromasia,skos:exactMatch,loinc:10378-8,Polychromasia [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51252,Microcytes,skos:exactMatch,loinc:30434-5,Microcytes [Presence] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50911,"Creatine Kinase, MB Isoenzyme",skos:exactMatch,loinc:13969-1,Creatine kinase.MB [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51233,Hypochromia,skos:exactMatch,loinc:728-6,Hypochromia [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50852,% Hemoglobin A1c,skos:exactMatch,loinc:4548-4,Hemoglobin A1c/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50905,"Cholesterol, LDL, Calculated",skos:exactMatch,loinc:13457-7,Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51144,Bands,skos:exactMatch,loinc:26508-2,Band form neutrophils/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50809,Glucose,skos:exactMatch,loinc:2339-0,Glucose [Mass/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51251,Metamyelocytes,skos:exactMatch,loinc:28541-1,Metamyelocytes/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51255,Myelocytes,skos:exactMatch,loinc:26498-6,Myelocytes/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51143,Atypical Lymphocytes,skos:exactMatch,loinc:13046-8,Variant lymphocytes/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51613,eAG,skos:exactMatch,loinc:27353-2,Glucose mean value [Mass/volume] in Blood Estimated from glycated hemoglobin,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51082,"Creatinine, Urine",skos:exactMatch,loinc:2161-8,Creatinine [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50817,Oxygen Saturation,skos:exactMatch,loinc:20564-1,Oxygen saturation in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50979,Red Top Hold,,,,,,,,Not a lab test
+mimic:50976,"Protein, Total",skos:exactMatch,loinc:2885-2,Protein [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51103,Uhold,,,,,,,,Not a lab test
+mimic:50812,Intubated,,,,,,,,Not a lab test
+mimic:50924,Ferritin,skos:exactMatch,loinc:2276-4,Ferritin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51007,Uric Acid,skos:exactMatch,loinc:3084-1,Urate [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51107,"Urine tube, held",,,,,,,,Not a lab test
+mimic:50930,Globulin,skos:exactMatch,loinc:2336-6,Globulin [Mass/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50889,C-Reactive Protein,skos:exactMatch,loinc:1988-5,C reactive protein [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50952,Iron,skos:exactMatch,loinc:2498-4,Iron [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51260,Ovalocytes,skos:exactMatch,loinc:774-0,Ovalocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50824,"Sodium, Whole Blood",skos:exactMatch,loinc:2947-0,Sodium [Moles/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50810,"Hematocrit, Calculated",skos:exactMatch,loinc:48703-3,Hematocrit [Volume Fraction] of Blood by Estimated,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50811,Hemoglobin,skos:exactMatch,loinc:718-7,Hemoglobin [Mass/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51214,"Fibrinogen, Functional",skos:exactMatch,loinc:3255-7,Fibrinogen [Mass/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51482,Hyaline Casts,skos:exactMatch,loinc:5796-8,Hyaline casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50998,Transferrin,skos:exactMatch,loinc:3034-6,Transferrin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50953,"Iron Binding Capacity, Total",skos:exactMatch,loinc:2500-7,Iron binding capacity [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51010,Vitamin B12,skos:exactMatch,loinc:2132-9,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50825,Temperature,skos:exactMatch,loinc:8310-5,Body temperature,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50995,"Thyroxine (T4), Free",skos:exactMatch,loinc:3024-7,Thyroxine (T4) free [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51009,Vancomycin,skos:exactMatch,loinc:20578-1,Vancomycin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50986,tacroFK,skos:exactMatch,loinc:11253-2,Tacrolimus [Mass/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51218,Granulocyte Count,skos:exactMatch,loinc:30394-1,Granulocytes [#/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50883,"Bilirubin, Direct",skos:exactMatch,loinc:1968-7,Bilirubin.direct [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51102,"Total Protein, Urine",skos:exactMatch,loinc:2888-6,Protein [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50922,Ethanol,skos:exactMatch,loinc:5640-8,Ethanol [Mass/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50884,"Bilirubin, Indirect",skos:exactMatch,loinc:1971-1,Bilirubin.indirect [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50856,Acetaminophen,skos:exactMatch,loinc:3298-7,Acetaminophen [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50981,Salicylate,skos:exactMatch,loinc:4024-6,Salicylates [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50806,"Chloride, Whole Blood",skos:exactMatch,loinc:2069-3,Chloride [Moles/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50999,Tricyclic Antidepressant Screen,skos:exactMatch,loinc:80146-4,Tricyclic antidepressants [Presence] in Blood by Screen method,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50867,Amylase,skos:exactMatch,loinc:1798-8,Amylase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51085,"HCG, Urine, Qualitative",skos:exactMatch,loinc:2106-3,Choriogonadotropin (pregnancy test) [Presence] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50919,EDTA Hold,,,,,,,,Not a lab test
+mimic:51092,"Opiate Screen, Urine",skos:exactMatch,loinc:19295-5,Opiates [Presence] in Urine by Screen method,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51079,"Cocaine, Urine",skos:exactMatch,loinc:3397-7,Cocaine [Presence] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51075,"Benzodiazepine Screen, Urine",skos:exactMatch,loinc:14316-4,Benzodiazepines [Presence] in Urine by Screen method,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51071,"Amphetamine Screen, Urine",skos:exactMatch,loinc:19343-3,Amphetamine [Presence] in Urine by Screen method,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51090,"Methadone, Urine",skos:exactMatch,loinc:3773-9,Methadone [Presence] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51074,"Barbiturate Screen, Urine",skos:exactMatch,loinc:19270-8,Barbiturates [Presence] in Urine by Screen method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50853,25-OH Vitamin D,skos:exactMatch,loinc:1989-3,25-hydroxyvitamin D3 [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51099,Protein/Creatinine Ratio,skos:exactMatch,loinc:2890-2,Protein/Creatinine [Mass Ratio] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51296,Teardrop Cells,skos:exactMatch,loinc:7791-7,Dacrocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50880,Benzodiazepine Screen,skos:exactMatch,loinc:42662-7,Benzodiazepines [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50879,Barbiturate Screen,skos:exactMatch,loinc:3376-1,"Barbiturates [Presence] in Serum, Plasma or Blood",HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50816,Oxygen,skos:exactMatch,loinc:3150-0,Inhaled oxygen concentration,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51257,Nucleated Red Cells,skos:exactMatch,loinc:58413-6,Nucleated erythrocytes/100 leukocytes [Ratio] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:50963,NTproBNP,skos:exactMatch,loinc:33762-6,Natriuretic peptide.B prohormone N-Terminal [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51100,"Sodium, Urine",skos:exactMatch,loinc:2955-3,Sodium [Moles/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51501,Transitional Epithelial Cells,skos:exactMatch,loinc:30089-7,Transitional cells [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50941,Hepatitis B Surface Antigen,skos:exactMatch,loinc:5196-1,Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50943,Hepatitis C Virus Antibody,skos:exactMatch,loinc:13955-0,Hepatitis C virus Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51288,Sedimentation Rate,skos:exactMatch,loinc:4537-7,Erythrocyte sedimentation rate by Westergren method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50944,HIV Antibody,skos:exactMatch,loinc:5220-9,HIV 1 Ab [Units/volume] in Serum or Plasma by Immunoassay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50974,Prostate Specific Antigen,skos:exactMatch,loinc:2857-1,Prostate specific Ag [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51287,Schistocytes,skos:exactMatch,loinc:800-3,Schistocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51069,"Albumin, Urine",skos:exactMatch,loinc:14957-5,Microalbumin [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50819,PEEP,skos:exactMatch,loinc:20077-4,Positive end expiratory pressure setting Ventilator,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50828,Ventilator,skos:exactMatch,loinc:20124-4,Ventilation mode Ventilator,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51070,"Albumin/Creatinine, Urine",skos:exactMatch,loinc:14958-3,Microalbumin/Creatinine [Mass Ratio] in 24 hour Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50827,Ventilation Rate,skos:exactMatch,loinc:76526-3,Ventilation rate by Carbon dioxide measurement,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:50940,Hepatitis B Surface Antibody,skos:exactMatch,loinc:22322-2,Hepatitis B virus surface Ab [Presence] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50925,Folate,skos:exactMatch,loinc:2284-8,Folate [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51093,"Osmolality, Urine",skos:exactMatch,loinc:2695-5,Osmolality of Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50965,Parathyroid Hormone,skos:exactMatch,loinc:2731-8,Parathyrin.intact [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50826,Tidal Volume,skos:exactMatch,loinc:20112-9,Tidal volume setting Ventilator,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51283,"Reticulocyte Count, Automated",skos:exactMatch,loinc:60474-4,Reticulocytes [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,"Conflict. Label is ""Count"", Unit is ""%"""
+mimic:50950,Immunoglobulin G,skos:exactMatch,loinc:2465-3,IgG [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50935,Haptoglobin,skos:exactMatch,loinc:4542-7,Haptoglobin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50975,Protein Electrophoresis,skos:exactMatch,loinc:12851-2,Protein Fractions [Interpretation] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50949,Immunoglobulin A,skos:exactMatch,loinc:2458-8,IgA [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50964,"Osmolality, Measured",skos:exactMatch,loinc:2692-2,Osmolality of Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51097,"Potassium, Urine",skos:exactMatch,loinc:2828-2,Potassium [Moles/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50900,Carcinoembyronic Antigen (CEA),skos:exactMatch,loinc:2039-6,Carcinoembryonic Ag [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50906,"Cholesterol, LDL, Measured",skos:exactMatch,loinc:18262-6,Cholesterol in LDL [Mass/volume] in Serum or Plasma by Direct assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51078,"Chloride, Urine",skos:exactMatch,loinc:2078-4,Chloride [Moles/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50942,Hepatitis B Virus Core Antibody,skos:exactMatch,loinc:13952-7,Hepatitis B virus core Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50951,Immunoglobulin M,skos:exactMatch,loinc:2472-9,IgM [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50946,Human Chorionic Gonadotropin,skos:exactMatch,loinc:19080-1,Choriogonadotropin [Units/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51104,"Urea Nitrogen, Urine",skos:exactMatch,loinc:3095-7,Urea nitrogen [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52111,Echinocytes,skos:exactMatch,loinc:7790-9,Burr cells [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51462,Amorphous Crystals,skos:exactMatch,loinc:60340-7,Crystals.amorphous [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51989,Oxycodone,skos:exactMatch,loinc:10998-3,oxyCODONE [Presence] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50864,Alpha-Fetoprotein,skos:exactMatch,loinc:1834-1,Alpha-1-Fetoprotein [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51733,STX2,,,,,,,,Ambiguous name
+mimic:51176,"CD3 Cells, Percent",skos:exactMatch,loinc:8124-0,CD3 cells/100 cells in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 51174
+mimic:51734,STX3,,,,,,,,Ambiguous name
+mimic:52007,UTX4,,,,,,,,Ambiguous name
+mimic:51180,"CD4 Cells, Percent",skos:exactMatch,loinc:8123-2,CD3+CD4+ (T4 helper) cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51194,"CD8 Cells, Percent",skos:exactMatch,loinc:8101-8,CD3+CD8+ (T8 suppressor cells) cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52004,UTX1,,,,,,,,Ambiguous name
+mimic:52006,UTX3,,,,,,,,Ambiguous name
+mimic:52008,UTX5,,,,,,,,Ambiguous name
+mimic:52010,UTX7,,,,,,,,Ambiguous name
+mimic:51732,STX1,,,,,,,,Ambiguous name
+mimic:51737,STX6,,,,,,,,Ambiguous name
+mimic:52005,UTX2,,,,,,,,Ambiguous name
+mimic:50873,Anti-Nuclear Antibody,skos:exactMatch,loinc:8061-4,Nuclear Ab [Presence] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51131,Absolute CD4 Count,skos:exactMatch,loinc:24467-3,CD3+CD4+ (T4 helper) cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51130,Absolute CD3 Count,skos:exactMatch,loinc:8122-4,CD3 cells [#/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51132,Absolute CD8 Count,skos:exactMatch,loinc:14135-8,CD3+CD8+ (T8 suppressor cells) cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51181,CD4/CD8 Ratio,skos:exactMatch,loinc:54218-3,CD3+CD4+ (T4 helper) cells/CD3+CD8+ (T8 suppressor cells) cells [# Ratio] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51245,"Lymphocytes, Percent",skos:exactMatch,loinc:736-9,Lymphocytes/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51244
+mimic:51300,WBC Count,skos:exactMatch,loinc:6690-2,Leukocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,1,
+mimic:52769,Absolute Lymphocyte Count,skos:exactMatch,loinc:731-0,Lymphocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51133
+mimic:52009,UTX6,,,,,,,,Ambiguous name
+mimic:50909,Cortisol,skos:exactMatch,loinc:2143-6,Cortisol [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51564,ARCH-1,,,,,,,,Ambiguous name
+mimic:50908,CK-MB Index,skos:exactMatch,loinc:49136-5,Creatine kinase.MB/Creatine kinase.total [Ratio] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51706,Problem Specimen,,,,,,,,Not a lab test
+mimic:51148,Blasts,skos:exactMatch,loinc:26446-5,Blasts/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51282,"Reticulocyte Count, Absolute",skos:exactMatch,loinc:14196-0,Reticulocytes [#/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50803,"Calculated Bicarbonate, Whole Blood",skos:exactMatch,loinc:1959-6,Bicarbonate [Moles/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50967,Phenytoin,skos:exactMatch,loinc:3968-5,Phenytoin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50915,D-Dimer,skos:exactMatch,loinc:48065-7,Fibrin D-dimer FEU [Mass/volume] in Platelet poor plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51657,HPE1,,,,,,,,Ambiguous name
+mimic:52171,RBC Morphology,skos:exactMatch,loinc:6742-1,Erythrocyte morphology finding [Identifier] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51663,HPE7,,,,,,,,Ambiguous name
+mimic:50994,Thyroxine (T4),skos:exactMatch,loinc:3026-2,Thyroxine (T4) [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52023,Assist/Control,,,,,,,,Not a lab test
+mimic:51294,Target Cells,skos:exactMatch,loinc:10381-2,Target cells [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50914,Cyclosporin,skos:exactMatch,loinc:3520-4,cycloSPORINE [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51098,"Prot. Electrophoresis, Urine",skos:exactMatch,loinc:13438-7,Protein Fractions [Interpretation] in Urine by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51001,Triiodothyronine (T3),skos:exactMatch,loinc:3053-6,Triiodothyronine (T3) [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51658,HPE2,,,,,,,,Ambiguous name
+mimic:51518,WBC Clumps,skos:exactMatch,loinc:67848-2,Leukocyte clumps [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51865,Influenza A by PCR,skos:exactMatch,loinc:34487-9,Influenza virus A RNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51864
+mimic:51873,Influenza B by PCR,skos:exactMatch,loinc:40982-1,Influenza virus B RNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51872
+mimic:50937,Hepatitis A Virus Antibody,skos:exactMatch,loinc:13951-9,Hepatitis A virus Ab [Presence] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50988,Testosterone,skos:exactMatch,loinc:2986-8,Testosterone [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52264,Lymphs,skos:exactMatch,loinc:26479-6,Lymphocytes/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52272,Monocytes,skos:exactMatch,loinc:26486-1,Monocytes/100 leukocytes in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52281,Polys,skos:exactMatch,loinc:26517-3,Polymorphonuclear cells/100 leukocytes in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52286,"Total Nucleated Cells, CSF",skos:exactMatch,loinc:58470-6,Nucleated cells [#/volume] in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52285,"RBC, CSF",skos:exactMatch,loinc:26454-9,Erythrocytes [#/volume] in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51292,Spherocytes,skos:exactMatch,loinc:802-9,Spherocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51752,Voided Specimen,,,,,,,,Not a lab test
+mimic:50927,Gamma Glutamyltransferase,skos:exactMatch,loinc:2324-2,Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51659,HPE3,,,,,,,,Ambiguous name
+mimic:50996,"Tissue Transglutaminase Ab, IgA",skos:exactMatch,loinc:31017-7,Tissue transglutaminase IgA Ab [Units/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51469,Calcium Oxalate Crystals,skos:exactMatch,loinc:5774-5,Calcium oxalate crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51479,Granular Casts,skos:exactMatch,loinc:5793-5,Granular casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51625,Free Kappa,skos:exactMatch,loinc:36916-5,Kappa light chains.free [Mass/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51627,Free Lambda,skos:exactMatch,loinc:33944-0,Lambda light chains.free [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51626,Free Kappa/Free Lambda Ratio,skos:exactMatch,loinc:48378-4,Kappa light chains.free/Lambda light chains.free [Mass Ratio] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51219,H/O Smear,skos:broadMatch,loinc:5909-7,Blood smear finding [Identifier] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51197,Elliptocytes,skos:exactMatch,loinc:11274-8,Elliptocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50892,CA-125,skos:exactMatch,loinc:10334-1,Cancer Ag 125 [Units/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51145,Basophilic Stippling,skos:exactMatch,loinc:703-9,Basophilic stippling [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51802,"Total Protein, CSF",skos:exactMatch,loinc:2880-3,Protein [Mass/volume] in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50823,Required O2,skos:exactMatch,loinc:3150-0,Inhaled oxygen concentration,HumanCurated,orcid:0000-0002-9348-9284,orcid:0000-0001-8822-1884,,
+mimic:50801,Alveolar-arterial Gradient,skos:exactMatch,loinc:19991-9,Alveolar-arterial oxygen Partial pressure difference,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51790,"Glucose, CSF",skos:exactMatch,loinc:2342-4,Glucose [Mass/volume] in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51736,STX5,,,,,,,,Ambiguous name
+mimic:51735,STX4,,,,,,,,Ambiguous name
+mimic:50891,C4,skos:exactMatch,loinc:4498-2,Complement C4 [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51134,Acanthocytes,skos:exactMatch,loinc:7789-1,Acanthocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50917,Digoxin,skos:exactMatch,loinc:10535-3,Digoxin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51008,Valproic Acid,skos:exactMatch,loinc:4086-5,Valproate [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51116,Lymphocytes,skos:exactMatch,loinc:26482-0,Lymphocytes/100 leukocytes in Peritoneal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51120,Monocytes,skos:exactMatch,loinc:26488-7,Monocytes/100 leukocytes in Peritoneal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51125,Polys,skos:exactMatch,loinc:26520-7,Polymorphonuclear cells/100 leukocytes in Peritoneal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52065,"Total Nucleated Cells, Ascites",skos:exactMatch,loinc:51926-4,Nucleated cells [#/volume] in Peritoneal fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51127,"RBC, Ascites",skos:exactMatch,loinc:26457-2,Erythrocytes [#/volume] in Peritoneal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50890,C3,skos:exactMatch,loinc:4485-9,Complement C3 [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50978,Rapamycin,skos:exactMatch,loinc:29247-4,Sirolimus [Mass/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51089,Marijuana,skos:exactMatch,loinc:3426-4,Tetrahydrocannabinol [Presence] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50980,Rheumatoid Factor,skos:exactMatch,loinc:11572-5,Rheumatoid factor [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51108,Urine Volume,skos:exactMatch,loinc:28009-9,Volume of Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51094,pH,skos:exactMatch,loinc:2756-5,pH of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50898,Cancer Antigen 27.29,skos:exactMatch,loinc:17842-6,Cancer Ag 27-29 [Units/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50973,Prolactin,skos:exactMatch,loinc:2842-3,Prolactin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51117,Macrophage,skos:exactMatch,loinc:40517-5,Macrophages/100 leukocytes in Peritoneal fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Manual count only
+mimic:51259,Other Cells,skos:exactMatch,loinc:26471-3,Leukocytes other/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51269,Promyelocytes,skos:exactMatch,loinc:783-1,Promyelocytes/100 leukocytes in Blood by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50815,O2 Flow,skos:exactMatch,loinc:3151-8,Inhaled oxygen flow rate,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50948,Immunofixation,skos:exactMatch,loinc:25700-6,Immunofixation for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51196,D-Dimer,skos:exactMatch,loinc:48065-7,Fibrin D-dimer FEU [Mass/volume] in Platelet poor plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 50915
+mimic:50926,Follicle Stimulating Hormone,skos:exactMatch,loinc:15067-2,Follitropin [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51846,Chlamydia trachomatis,skos:exactMatch,loinc:43304-5,Chlamydia trachomatis rRNA [Presence] in Specimen by NAA with probe detection,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51879,Neisseria gonorrhoeae,skos:exactMatch,loinc:43305-2,Neisseria gonorrhoeae rRNA [Presence] in Specimen by NAA with probe detection,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51903,PAN1,,,,,,,,Ambiguous name
+mimic:51067,24 hr Creatinine,skos:exactMatch,loinc:2162-6,Creatinine [Mass/time] in 24 hour Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50881,Beta-2 Microglobulin,skos:exactMatch,loinc:1952-1,Beta-2-Microglobulin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51118,Mesothelial Cell,skos:exactMatch,loinc:30432-9,Mesothelial cells/100 leukocytes in Peritoneal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50895,Calculated TBG,skos:exactMatch,loinc:3027-0,Thyroxine (T4)/Thyroxine binding globulin [Mass Ratio] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51005,Uptake Ratio,skos:exactMatch,loinc:3050-2,Triiodothyronine resin uptake (T3RU) in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50896,Calculated Thyroxine (T4) Index,skos:exactMatch,loinc:32215-6,Thyroxine (T4) free index in Serum or Plasma by calculation,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52391,"Total Nucleated Cells, Pleural",skos:narrowMatch,loinc:52819-0,Nucleated cells [#/volume] in Pleural fluid by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51446,Lymphocytes,skos:exactMatch,loinc:26481-2,Lymphocytes/100 leukocytes in Pleural fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51450,Monos,skos:exactMatch,loinc:33362-5,Monocytes/100 leukocytes in Pleural fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51455,Polys,skos:exactMatch,loinc:26519-9,Polymorphonuclear cells/100 leukocytes in Pleural fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50874,"Anti-Nuclear Antibody, Titer",skos:exactMatch,loinc:5048-4,Nuclear Ab [Titer] in Serum by Immunofluorescence,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51054,"Lactate Dehydrogenase, Pleural",skos:closeMatch,loinc:2530-4,Lactate dehydrogenase [Enzymatic activity/volume] in Pleural fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Discouraged LOINC code
+mimic:51059,"Total Protein, Pleural",skos:exactMatch,loinc:2882-9,Protein [Mass/volume] in Pleural fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50957,Lithium,skos:exactMatch,loinc:14334-7,Lithium [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50918,Double Stranded DNA,skos:exactMatch,loinc:31348-6,DNA double strand Ab [Presence] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,5718 labevents have U/mL as unit of measurement (wrong)
+mimic:50849,"Total Protein, Ascites",skos:exactMatch,loinc:2883-7,Protein [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52018,PAN1,,,,,,,,Ambiguous name
+mimic:51972,Chlamydia trachomatis,skos:exactMatch,loinc:14467-5,Chlamydia trachomatis [Presence] in Urine sediment by Organism specific culture,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51986,Neisseria gonorrhoeae,skos:exactMatch,loinc:60256-5,Neisseria gonorrhoeae rRNA [Presence] in Urine by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50932,Gray Top Hold (plasma),,,,,,,,Not a lab test
+mimic:50982,Sex Hormone Binding Globulin,skos:exactMatch,loinc:13967-5,Sex hormone binding globulin [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51497,Renal Epithelial Cells,skos:exactMatch,loinc:26052-1,Epithelial cells.renal [#/area] in Urine sediment by Microscopy high power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51147,Bite Cells,skos:exactMatch,loinc:10371-3,Bite cells [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51457,"RBC, Pleural",skos:exactMatch,loinc:26456-4,Erythrocytes [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50866,Ammonia,skos:exactMatch,loinc:16362-6,Ammonia [Moles/volume] in Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51053,"Glucose, Pleural",skos:exactMatch,loinc:2346-5,Glucose [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51474,Eosinophils,skos:exactMatch,loinc:25156-1,Eosinophils [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50894,Calculated Free Testosterone,skos:exactMatch,loinc:96559-0,Testosterone Free [Moles/volume] in Serum or Plasma by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50877,Anti-Thyroglobulin Antibodies,skos:exactMatch,loinc:8098-6,Thyroglobulin Ab [Units/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51598,Cytomegalovirus Viral Load,skos:exactMatch,loinc:54206-8,Cytomegalovirus DNA [Log #/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50872,Anti-Neutrophil Cytoplasmic Antibody,skos:exactMatch,loinc:17351-8,Neutrophil cytoplasmic Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50876,Anti-Smooth Muscle Antibody,skos:exactMatch,loinc:14252-1,Smooth muscle Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51086,"Immunofixation, Urine",skos:exactMatch,loinc:13440-3,Immunofixation for Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51660,HPE4,,,,,,,,Ambiguous name
+mimic:52312,"Total Nucleated Cells, Joint",skos:exactMatch,loinc:53557-5,Nucleated cells [#/volume] in Synovial fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51375,Lymphocytes,skos:exactMatch,loinc:26483-8,Lymphocytes/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51379,Monocytes,skos:exactMatch,loinc:17835-0,Monocytes/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51382,Polys,skos:exactMatch,loinc:26522-3,Polymorphonuclear cells/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50835,"Albumin, Ascites",skos:exactMatch,loinc:1749-1,Albumin [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50871,Anti-Mitochondrial Antibody,skos:exactMatch,loinc:17284-1,Mitochondria Ab [Presence] in Serum by Immunofluorescence,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51240,Large Platelets,skos:exactMatch,loinc:32146-3,Platelets Large [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50961,Methotrexate,skos:exactMatch,loinc:14836-1,Methotrexate [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52036,Voided Specimen,,,,,,,,Not a lab test
+mimic:50805,Carboxyhemoglobin,skos:exactMatch,loinc:20563-3,Carboxyhemoglobin/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50958,Luteinizing Hormone,skos:exactMatch,loinc:10501-5,Lutropin [Units/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51447,Macrophages,skos:exactMatch,loinc:40520-9,Macrophages/100 leukocytes in Pleural fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Manual count only
+mimic:51373,"Joint Crystals, Number",skos:broadMatch,loinc:38458-6,Crystals [Presence] in Synovial fluid by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51383,"RBC, Joint Fluid",skos:exactMatch,loinc:26458-0,Erythrocytes [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51216,Fragmented Cells,skos:exactMatch,loinc:10373-9,Fragments [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51224,Hemoglobin C,skos:exactMatch,loinc:4563-3,Hemoglobin C/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51226,Hemogloblin A,skos:exactMatch,loinc:4546-8,Hemoglobin A/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51227,Hemogloblin S,skos:exactMatch,loinc:4625-0,Hemoglobin S/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50831,pH,skos:closeMatch,loinc:2748-2,pH of Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas"""
+mimic:51424,Immunophenotyping,skos:broadMatch,loinc:55230-7,Immunophenotyping study,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:50938,Hepatitis A Virus IgM Antibody,skos:exactMatch,loinc:22314-9,Hepatitis A virus IgM Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51513,Urine Specimen Type,skos:exactMatch,loinc:19159-3,Urinalysis specimen collection method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50992,Thyroid Peroxidase Antibodies,skos:exactMatch,loinc:8099-4,Thyroperoxidase Ab [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50814,Methemoglobin,skos:exactMatch,loinc:2614-6,Methemoglobin/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50842,"Glucose, Ascites",skos:exactMatch,loinc:2347-3,Glucose [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51427,Lymphocytes,skos:exactMatch,loinc:11031-2,Lymphocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51431,Monos,skos:exactMatch,loinc:26487-9,Monocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51436,Polys,skos:exactMatch,loinc:26518-1,Polymorphonuclear cells/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50991,Thyroglobulin,skos:exactMatch,loinc:3013-0,Thyroglobulin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51338,Immunophenotyping,skos:broadMatch,loinc:55230-7,Immunophenotyping study,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52220,wbcp,skos:broadMatch,loinc:26471-3,Leukocytes other/100 leukocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51046,"Albumin, Pleural",skos:exactMatch,loinc:1748-3,Albumin [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51236,Inpatient Hematology/Oncology Smear,skos:broadMatch,loinc:5909-7,Blood smear finding [Identifier] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51077,"Calcium, Urine",skos:exactMatch,loinc:17862-4,Calcium [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52425,XUCU,,,,,,,,Ambiguous name
+mimic:51243,Lupus Anticoagulant,skos:broadMatch,loinc:3281-3,Lupus anticoagulant [Interpretation] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51051,"Cholesterol, Pleural",skos:exactMatch,loinc:9618-0,Cholesterol [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51150,Blood Parasite Smear,skos:exactMatch,loinc:91900-1,Parasite [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52024,"Creatinine, Whole Blood",skos:exactMatch,loinc:38483-4,Creatinine [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51213,Fibrin Degradation Products,skos:exactMatch,loinc:30226-5,Fibrin+Fibrinogen fragments [Mass/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51651,Hepatitis C Viral Load,skos:exactMatch,loinc:38180-6,Hepatitis C virus RNA [log units/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51448,Mesothelial Cells,skos:exactMatch,loinc:30431-1,Mesothelial cells/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51231,Howell-Jolly Bodies,skos:exactMatch,loinc:7793-3,Howell-Jolly bodies [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51068,24 hr Protein,skos:exactMatch,loinc:2889-4,Protein [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51654,HIV 1 Viral Load,skos:exactMatch,loinc:29541-0,HIV 1 RNA [Log #/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52026,Estimated GFR (MDRD equation),skos:exactMatch,loinc:76633-7,Glomerular filtration rate/1.73 sq M.predicted by Creatinine-based formula (MDRD) in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51228,Heparin,skos:exactMatch,loinc:66483-9,Heparin unfractionated [Units/volume] in Platelet poor plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50939,"Hepatitis B Core Antibody, IgM",skos:exactMatch,loinc:31204-1,Hepatitis B virus core IgM Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52014,Voided Specimen,,,,,,,,Not a lab test
+mimic:50843,"Lactate Dehydrogenase, Ascites",skos:closeMatch,loinc:2531-2,Lactate dehydrogenase [Enzymatic activity/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Discouraged LOINC code
+mimic:50966,Phenobarbital,skos:exactMatch,loinc:3948-7,PHENobarbital [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51748,Treponema pallidum (Syphilis) Ab,skos:exactMatch,loinc:22587-0,Treponema pallidum Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52266,Macrophage,skos:exactMatch,loinc:30426-1,Macrophages/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51749,Treponema pallidum (syphilis) value,skos:exactMatch,loinc:11597-2,Treponema pallidum Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51225,Hemoglobin F,skos:exactMatch,loinc:4576-5,Hemoglobin F/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 51212
+mimic:51428,Macrophage,skos:exactMatch,loinc:30427-9,Macrophages/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50836,"Amylase, Ascites",skos:exactMatch,loinc:1797-0,Amylase [Enzymatic activity/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51284,"Reticulocyte Count, Manual",skos:exactMatch,loinc:40665-2,Reticulocytes [#/volume] in Blood by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,"Conflict. Label is ""Count"", Unit is ""%"""
+mimic:51648,Hepatitis B Viral Load,skos:exactMatch,loinc:48398-2,Hepatitis B virus DNA [log units/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50921,Estradiol,skos:exactMatch,loinc:2243-4,Estradiol (E2) [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51223,Hemoglobin A2,skos:exactMatch,loinc:4551-8,Hemoglobin A2/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50899,Carbamazepine,skos:exactMatch,loinc:3432-2,carBAMazepine [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50929,Gentamicin,skos:exactMatch,loinc:35668-3,Gentamicin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51261,Pappenheimer Bodies,skos:exactMatch,loinc:7795-8,Pappenheimer bodies [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51411,CD45,skos:exactMatch,loinc:17823-6,CD45 (Lymphs) cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52195,Voided Specimen,,,,,,,,Not a lab test
+mimic:51095,"Phosphate, Urine",skos:exactMatch,loinc:2778-9,Phosphate [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51453,Other,skos:exactMatch,loinc:30408-9,Leukocytes other/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51342,Wright Giemsa,skos:exactMatch,loinc:10355-6,Microscopic observation [Identifier] in Bone marrow by Wright Giemsa stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51398,CD19,skos:exactMatch,loinc:17829-3,CD19 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51376,Macrophage,skos:exactMatch,loinc:33376-5,Macrophages/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52012,UTX9,,,,,,,,Ambiguous name
+mimic:51933,C. diff PCR,skos:exactMatch,loinc:54067-4,Clostridioides difficile toxin genes [Presence] in Stool by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51460,"Blood, Occult",skos:broadMatch,loinc:2335-8,Hemoglobin.gastrointestinal [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51234,Immunophenotyping,skos:exactMatch,loinc:55230-7,Immunophenotyping study,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51123,Other,skos:exactMatch,loinc:30409-7,Leukocytes other/100 leukocytes in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51956,CDT027,,,,,,,,Ambiguous name
+mimic:51425,Kappa,skos:exactMatch,loinc:46238-2,Kappa lymphocytes/100 lymphocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51426,Lambda,skos:broadMatch,loinc:20618-5,Lambda lymphocytes/100 lymphocytes in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51076,"Bicarbonate, Urine",skos:exactMatch,loinc:1964-6,Bicarbonate [Moles/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51276,Quantitative G6PD,skos:exactMatch,loinc:32546-4,Glucose-6-Phosphate dehydrogenase [Enzymatic activity/mass] in Red Blood Cells,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51839,Anat Path Hold,,,,,,,,Not a lab test
+mimic:51138,Anticardiolipin Antibody IgG,skos:exactMatch,loinc:3181-5,Cardiolipin IgG Ab [Units/volume] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51139,Anticardiolipin Antibody IgM,skos:exactMatch,loinc:3182-3,Cardiolipin IgM Ab [Units/volume] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51229,"Heparin, LMW",skos:exactMatch,loinc:32684-3,LMW Heparin [Units/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51444,Eosinophils,skos:exactMatch,loinc:30379-2,Eosinophils/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51505,Uric Acid Crystals,skos:exactMatch,loinc:5817-2,Urate crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50945,Homocysteine,skos:exactMatch,loinc:13965-9,Homocysteine [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51899,Trichomonas vaginalis,skos:exactMatch,loinc:32766-8,Trichomonas vaginalis [Presence] in Specimen by Wet preparation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51206,Factor VIII,skos:exactMatch,loinc:3209-4,Coagulation factor VIII activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51904,PAN2,,,,,,,,Ambiguous name
+mimic:51262,Pencil Cells,skos:exactMatch,loinc:10377-0,Pencil cells [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51795,"Lactate Dehydrogenase, CSF",skos:exactMatch,loinc:2528-8,Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52427,UCU2,,,,,,,,Ambiguous name
+mimic:50913,Cryoglobulin,skos:exactMatch,loinc:5117-7,Cryoglobulin [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52369,"Total Nucleated Cells, Other",skos:exactMatch,loinc:55793-4,Nucleated cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50989,"Testosterone, Free",skos:exactMatch,loinc:2991-8,Testosterone Free [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51198,Envelope Cells,skos:exactMatch,loinc:681-7,Microscopic observation [Identifier] in Specimen by Wright stain,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51140,Antithrombin,skos:exactMatch,loinc:27811-9,Antithrombin actual/normal in Platelet poor plasma by Chromogenic method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50838,"Bilirubin, Total, Ascites",skos:exactMatch,loinc:14422-0,Bilirubin.total [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51325,CD45,skos:exactMatch,loinc:51340-8,CD45 (Lymphs) cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51066,24 hr Calcium,skos:exactMatch,loinc:6874-2,Calcium [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50841,"Creatinine, Ascites",skos:exactMatch,loinc:12191-3,Creatinine [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51662,HPE6,,,,,,,,Ambiguous name
+mimic:51297,Thrombin,skos:exactMatch,loinc:3243-3,Thrombin time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50997,Tobramycin,skos:exactMatch,loinc:35670-9,Tobramycin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50916,DHEA-Sulfate,skos:exactMatch,loinc:2191-5,Dehydroepiandrosterone sulfate (DHEA-S) [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51412,CD5,skos:exactMatch,loinc:57423-6,CD5 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51047,"Amylase, Pleural",skos:exactMatch,loinc:1796-2,Amylase [Enzymatic activity/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51404,CD3,skos:exactMatch,loinc:17826-9,CD3 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51438,"RBC, Other Fluid",skos:exactMatch,loinc:26455-6,Erythrocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51388,CD10,skos:exactMatch,loinc:51217-8,CD10 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51400,CD20,skos:exactMatch,loinc:57418-6,CD20 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51263,Plasma Cells,skos:exactMatch,loinc:13047-6,Plasma cells/100 leukocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52278,Other,skos:exactMatch,loinc:75374-9,Other cells/100 leukocytes in Cerebral spinal fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52424,RFXUCU,,,,,,,,Ambiguous name
+mimic:51114,Eosinophils,skos:exactMatch,loinc:30380-0,Eosinophils/100 leukocytes in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51434,Other Cell,skos:exactMatch,loinc:76350-8,Other cells/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51105,"Uric Acid, Urine",skos:exactMatch,loinc:3086-6,Urate [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51271,"Protein C, Functional",skos:exactMatch,loinc:27819-2,Protein C actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51060,"Triglycerides, Pleural",skos:exactMatch,loinc:9619-8,Triglyceride [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51313,CD19,skos:exactMatch,loinc:32525-8,CD19 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50857,Acetone,skos:exactMatch,loinc:5567-3,Acetone [Presence] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51419,Eosinophils,skos:exactMatch,loinc:26452-3,Eosinophils/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51056,"Miscellaneous, Pleural",,,,,,,,Not a lab test
+mimic:51722,RFXLDLM,skos:broadMatch,loinc:2089-1,Cholesterol in LDL [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52256,Eosinophils,skos:exactMatch,loinc:26451-5,Eosinophils/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51319,CD3,skos:exactMatch,loinc:32529-0,CD3 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51088,"Magnesium, Urine",skos:exactMatch,loinc:19124-7,Magnesium [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51337,HLA-DR,skos:broadMatch,loinc:51380-4,HLA-DR+ cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51945,Norovirus Genogroup I,skos:exactMatch,loinc:54905-5,Norovirus genogroup I RNA [Presence] in Stool by NAA with probe detection,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51946,Norovirus Genogroup II,skos:exactMatch,loinc:54906-3,Norovirus genogroup II RNA [Presence] in Stool by NAA with probe detection,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51273,"Protein S, Functional",skos:exactMatch,loinc:27822-6,Protein S actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52955,CD10,skos:exactMatch,loinc:51216-0,CD10 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51423,HLA-DR,skos:exactMatch,loinc:51381-2,HLA-DR+ cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51315,CD20,skos:closeMatch,loinc:51115-4,CD20 blasts/100 blasts in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51289,Serum Viscosity,skos:exactMatch,loinc:3128-6,Viscosity of Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51420,FMC-7,skos:exactMatch,loinc:57428-5,FMC7 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51402,CD23,skos:exactMatch,loinc:51269-9,CD23 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51340,Kappa,skos:broadMatch,loinc:46237-4,Kappa lymphocytes/100 lymphocytes in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51341,Lambda,skos:broadMatch,loinc:20618-5,Lambda lymphocytes/100 lymphocytes in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51326,CD5,skos:exactMatch,loinc:35640-2,CD5 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50869,Anti-DGP (IgA/IgG),skos:exactMatch,loinc:63420-4,Gliadin peptide+tissue transglutaminase IgA+IgG Ab [Presence] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51980,Fentanyl,skos:exactMatch,loinc:11235-9,fentaNYL [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52020,UTX10,,,,,,,,Ambiguous name
+mimic:51183,CD45,skos:closeMatch,loinc:8130-7,CD45 (Lymphs) cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51164,CD19,skos:closeMatch,loinc:8117-4,CD19 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,Duplicate of itemid 51165
+mimic:51026,"Amylase, Body Fluid",skos:exactMatch,loinc:1795-4,Amylase [Enzymatic activity/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51174,CD3 %,skos:exactMatch,loinc:8124-0,CD3 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51175,CD3 Absolute Count,skos:exactMatch,loinc:8122-4,CD3 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51052,"Creatinine, Pleural",skos:exactMatch,loinc:14399-0,Creatinine [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51370,"Joint Crystals, Birefringence",skos:broadMatch,loinc:5781-0,Crystals [type] in Synovial fluid by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51371,"Joint Crystals, Comment",skos:exactMatch,loinc:14271-1,Character of Synovial fluid,HumanCurated,orcid:0000-0002-9348-9284,orcid:0000-0001-8822-1884,,
+mimic:51372,"Joint Crystals, Location",skos:broadMatch,loinc:38458-6,Crystals [Presence] in Synovial fluid by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51374,"Joint Crystals, Shape",skos:broadMatch,loinc:5781-0,Crystals [type] in Synovial fluid by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51033,FetalFN,skos:exactMatch,loinc:20404-0,Fibronectin.fetal [Presence] in Vaginal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52992,Iron Stain,skos:exactMatch,loinc:13513-7,Iron.microscopic observation [Identifier] in Bone marrow by Potassium ferrocyanide stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51168,CD20,skos:closeMatch,loinc:8119-0,CD20 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,Duplicate of itemid 51169
+mimic:51152,CD10,skos:closeMatch,loinc:8107-5,CD10 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51894,"Strep A, Rapid Antigen",skos:broadMatch,loinc:78012-2,Streptococcus pyogenes Ag [Presence] in Throat by Rapid immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51184,CD5,skos:closeMatch,loinc:8132-3,CD5 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,Duplicate of itemid 51185
+mimic:51238,Kappa,skos:broadMatch,loinc:17096-9,Kappa lymphocytes/100 lymphocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51239,Lambda,skos:broadMatch,loinc:17224-7,Lambda lymphocytes/100 lymphocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51772,PAN3,,,,,,,,Ambiguous name
+mimic:51230,HLA-DR,skos:closeMatch,loinc:32621-5,HLA-DR [Presence],HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51664,HPE8,,,,,,,,Ambiguous name
+mimic:51503,Triple Phosphate Crystals,skos:exactMatch,loinc:5814-9,Triple phosphate crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51921,"proBNP, Pleural",skos:exactMatch,loinc:77621-1,Natriuretic peptide.B prohormone N-Terminal [Mass/volume] in Pleural fluid by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52123,"G6PD, Qualitative",skos:exactMatch,loinc:2356-4,Glucose-6-Phosphate dehydrogenase [Presence] in Red Blood Cells,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51165,CD19 %,skos:exactMatch,loinc:8117-4,CD19 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51166,CD19 Absolute Count,skos:exactMatch,loinc:8116-6,CD19 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51169,CD20 %,skos:exactMatch,loinc:8119-0,CD20 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51170,CD20 Absolute Count,skos:exactMatch,loinc:9558-8,CD20 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51162,CD16/56 Absolute Count,skos:exactMatch,loinc:20402-4,CD16+CD56+ cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51163,CD16/56%,skos:exactMatch,loinc:18267-5,CD16+CD56+ cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51429,Mesothelial cells,skos:exactMatch,loinc:28544-5,Mesothelial cells/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51299,Von Willebrand Factor Antigen,skos:exactMatch,loinc:27816-8,von Willebrand factor (vWf) Ag actual/normal in Platelet poor plasma by Immunoassay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51298,Von Willebrand Factor Activity,skos:exactMatch,loinc:6014-5,von Willebrand factor (vWf) ristocetin cofactor actual/normal in Platelet poor plasma by Platelet aggregation,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51688,Lyme C6 Ab,skos:exactMatch,loinc:38173-1,Borrelia burgdorferi C6 Ab [Units/volume] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51689,Lyme G and M Value,skos:exactMatch,loinc:34148-7,Borrelia burgdorferi IgG+IgM Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51317,CD23,skos:exactMatch,loinc:51268-1,CD23 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51335,FMC-7,skos:broadMatch,loinc:44061-0,CD20+FMC7+ cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51368,Eosinophils,skos:exactMatch,loinc:17834-3,Eosinophils/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51215,FMC-7,skos:exactMatch,loinc:17220-5,FMC7 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51754,VZV IgG Ab Value,skos:exactMatch,loinc:8047-3,Varicella zoster virus IgG Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51753,VZV IgG Ab,skos:exactMatch,loinc:19162-7,Varicella zoster virus IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51416,CD7,skos:exactMatch,loinc:57425-1,CD7 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51172,CD23,skos:closeMatch,loinc:14018-6,CD23 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51399,CD2,skos:exactMatch,loinc:17827-7,CD2 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51406,CD34,skos:exactMatch,loinc:58939-0,CD34 cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51769,RUBIgGV,skos:exactMatch,loinc:5334-8,Rubella virus IgG Ab [Units/volume] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51724,Rubella IgG Ab,skos:exactMatch,loinc:25514-1,Rubella virus IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51471,Cellular Cast,skos:exactMatch,loinc:38995-7,Mixed cellular casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52019,PAN2,,,,,,,,Ambiguous name
+mimic:51996,Trichomonas vaginalis,skos:exactMatch,loinc:5813-1,Trichomonas vaginalis [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51321,CD34,skos:exactMatch,loinc:57400-4,CD34 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51445,"Hematocrit, Pleural",skos:exactMatch,loinc:70169-8,Hematocrit [Volume Fraction] of Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51192,CD7,skos:closeMatch,loinc:8135-6,CD7 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51877,MRSA PCR,skos:exactMatch,loinc:35492-8,Methicillin resistant Staphylococcus aureus (MRSA) DNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51893,Staph aureus PCR,skos:exactMatch,loinc:61404-0,Staphylococcus aureus DNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51167,CD2,skos:closeMatch,loinc:8118-2,CD2 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51661,HPE5,,,,,,,,Ambiguous name
+mimic:51235,Inhibitor Screen,skos:broadMatch,loinc:40744-5,Factor inhibitor XXX [Presence] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51381,Other,skos:exactMatch,loinc:30410-5,Leukocytes other/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51587,CMV IgG Ab Value,skos:exactMatch,loinc:5124-3,Cytomegalovirus IgG Ab [Units/volume] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51586,CMV IgG Ab,skos:exactMatch,loinc:22244-8,Cytomegalovirus IgG Ab [Presence] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51332,CD7,skos:exactMatch,loinc:35641-0,CD7 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51579,CA 19-9,skos:exactMatch,loinc:24108-3,Cancer Ag 19-9 [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51314,CD2,skos:exactMatch,loinc:32527-4,CD2 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51307,CD13,skos:exactMatch,loinc:51237-6,CD13 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52221,Atypical Lymphocytes,skos:broadMatch,loinc:30416-2,Variant lymphocytes/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52426,UCU1,,,,,,,,Ambiguous name
+mimic:51768,EE6,,,,,,,,Ambiguous name
+mimic:51762,EE1,,,,,,,,Ambiguous name
+mimic:51499,Sperm,skos:exactMatch,loinc:8248-7,Spermatozoa [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51798,"PEP, CSF",skos:broadMatch,loinc:13439-5,Protein Fractions [Interpretation] in Cerebral spinal fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51291,Sickle Cells,skos:exactMatch,loinc:801-1,Sickle cells [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 51290
+mimic:51369,"Hematocrit, Joint Fluid",skos:exactMatch,loinc:70168-0,Hematocrit [Volume Fraction] of Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51588,CMV IgM Ab,skos:exactMatch,loinc:30325-5,Cytomegalovirus IgM Ab [Presence] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51590,CMV Interpretation,skos:exactMatch,loinc:20475-0,Cytomegalovirus IgG Ab [Interpretation] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50968,"Phenytoin, Free",skos:exactMatch,loinc:3969-3,Phenytoin Free [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51305,CD117,skos:exactMatch,loinc:42866-4,CD117 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51489,NonSquamous Epithelial Cell,skos:exactMatch,loinc:41284-1,Epithelial cells.non-squamous [#/area] in Urine sediment by Microscopy high power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51488
+mimic:50969,"Phenytoin, Percent Free",skos:exactMatch,loinc:10548-6,Phenytoin Free/Phenytoin.total in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51034,"Glucose, Body Fluid",skos:exactMatch,loinc:2344-0,Glucose [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51763,EE2,,,,,,,,Ambiguous name
+mimic:51247,MacroOvalocytes,skos:exactMatch,loinc:10376-2,Oval macrocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51290,Sickle Cell Preparation,skos:exactMatch,loinc:801-1,Sickle cells [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51043,"Total Protein, Body Fluid",skos:exactMatch,loinc:2881-1,Protein [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51038,"Miscellaneous, Body Fluid",,,,,,,,Not a lab test
+mimic:51310,CD15,skos:exactMatch,loinc:51251-7,CD15 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51614,Epstein-Barr Virus  EBNA IgG Ab,skos:exactMatch,loinc:7883-2,Epstein Barr virus nuclear IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51618,Epstein-Barr Virus Interpretation,skos:broadMatch,loinc:49564-8,Epstein Barr virus band pattern [Interpretation] in Specimen by Immunoblot Narrative,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51619,Epstein-Barr Virus VCA IgG Ab,skos:exactMatch,loinc:7885-7,Epstein Barr virus capsid IgG Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51620,Epstein-Barr Virus VCA IgM Ab,skos:exactMatch,loinc:7886-5,Epstein Barr virus capsid IgM Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52419,Voided Specimen,,,,,,,,Not a lab test
+mimic:51615,Epstein-Barr Virus EBNA IgG Ab,skos:exactMatch,loinc:7883-2,Epstein Barr virus nuclear IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51614
+mimic:51481,Hemosiderin,skos:exactMatch,loinc:4644-1,Hemosiderin [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51616,Epstein-Barr Virus IgG Ab Value,skos:exactMatch,loinc:31374-2,Epstein Barr virus nuclear IgG Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51617,Epstein-Barr Virus IgM Ab Value,skos:exactMatch,loinc:31375-9,Epstein Barr virus nuclear IgM Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51124,Plasma,skos:exactMatch,loinc:40518-3,Plasma cells/100 leukocytes in Peritoneal fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52262,Immunophenotyping,skos:broadMatch,loinc:55230-7,Immunophenotyping study,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51320,CD33,skos:exactMatch,loinc:51293-9,CD33 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51080,Creatinine Clearance,skos:exactMatch,loinc:2164-2,Creatinine renal clearance in 24 hour Urine and Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51081,"Creatinine, Serum",skos:exactMatch,loinc:2160-0,Creatinine [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,"Conflict. Label is ""Creatinine, Serum"", fluid is ""Urine"""
+mimic:51101,Total Collection Time,skos:exactMatch,loinc:13362-9,Collection duration of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51106,Urine Creatinine,skos:exactMatch,loinc:2161-8,Creatinine [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate ot itemid 51082
+mimic:51109,"Urine Volume, Total",skos:exactMatch,loinc:28009-9,Volume of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51726,Rubeola IgG Ab Value,skos:exactMatch,loinc:5244-9,Measles virus IgG Ab [Units/volume] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51725,Rubeola IgG Ab,skos:exactMatch,loinc:20479-2,Measles virus IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51025,"Albumin, Body Fluid",skos:exactMatch,loinc:1747-5,Albumin [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51035,"LD, Body Fluid",skos:closeMatch,loinc:2529-6,Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Discouraged LOINC code
+mimic:51517,WBC Casts,skos:exactMatch,loinc:5820-6,WBC casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51232,Hypersegmented Neutrophils,skos:exactMatch,loinc:30450-1,Neutrophils.hypersegmented/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51309,CD14,skos:exactMatch,loinc:32507-6,CD14 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51966,Bilirubin,skos:exactMatch,loinc:1977-8,Bilirubin.total [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51967,Blood,skos:exactMatch,loinc:53963-5,Blood [Presence] in Urine by Visual,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51981,Glucose,skos:exactMatch,loinc:2350-7,Glucose [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51984,Ketone,skos:exactMatch,loinc:49779-2,Ketones [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51985,Leukocytes,skos:exactMatch,loinc:20455-2,Leukocytes [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51987,Nitrite,skos:exactMatch,loinc:32710-6,Nitrite [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51992,Protein,skos:exactMatch,loinc:20454-5,Protein [Presence] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51994,Specific Gravity,skos:exactMatch,loinc:2965-2,Specific gravity of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52002,Urobilinogen,skos:exactMatch,loinc:3107-0,Urobilinogen [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52730,pH,skos:exactMatch,loinc:2756-5,pH of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51694,Mumps IgG Ab Value,skos:exactMatch,loinc:7966-5,Mumps virus IgG Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51693,Mumps IgG Ab,skos:exactMatch,loinc:22415-4,Mumps virus IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51741,Toxoplasma IgG Ab,skos:exactMatch,loinc:22580-5,Toxoplasma gondii IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51745,Toxoplasma Interpretation,skos:exactMatch,loinc:20464-4,Toxoplasma gondii Ab [Interpretation] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51764,EE7,,,,,,,,Ambiguous name
+mimic:51742,Toxoplasma IgG Ab Value,skos:exactMatch,loinc:5388-4,Toxoplasma gondii IgG Ab [Units/volume] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50901,Centromere,skos:exactMatch,loinc:16137-2,Centromere Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50854,Absolute A1c,skos:exactMatch,loinc:41995-2,Hemoglobin A1c [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50855,Absolute Hemoglobin,skos:exactMatch,loinc:718-7,Hemoglobin [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52223,Bands,skos:exactMatch,loinc:26509-0,Band form neutrophils/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50865,Amikacin,skos:exactMatch,loinc:35669-1,Amikacin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51454,Plasma Cells,skos:exactMatch,loinc:40522-5,Plasma cells/100 leukocytes in Pleural fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Manual count only
+mimic:51199,Eosinophil Count,skos:exactMatch,loinc:711-2,Eosinophils [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51323,CD4,skos:exactMatch,loinc:32533-2,CD3+CD4+ (T4 helper) cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51796,"Miscellaneous, CSF",,,,,,,,Not a lab test
+mimic:51934,C Diff Toxin Antigen Assay,skos:exactMatch,loinc:34713-8,Clostridioides difficile toxin A+B [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52087,CD15/56,skos:broadMatch,loinc:20402-4,CD16+CD56+ cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51567,Beta Hydroxybutyrate,skos:exactMatch,loinc:6873-4,Beta hydroxybutyrate [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51096,Porphobilinogen Screen,skos:exactMatch,loinc:2809-2,Porphobilinogen [Presence] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51334,CD8,skos:exactMatch,loinc:32535-7,CD3+CD8+ (T8 suppressor) cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51442,Basophils,skos:exactMatch,loinc:35070-2,Basophils/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52109,dRVVT - Screen,skos:broadMatch,loinc:6303-2,dRVVT (LA screen),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51422,"Hematocrit, Other Fluid",skos:exactMatch,loinc:11153-4,Hematocrit [Volume Fraction] of Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51205,Factor VII,skos:exactMatch,loinc:3198-9,Coagulation factor VII activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51677,K (GREEN),skos:exactMatch,loinc:2823-3,Potassium [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 50971
+mimic:51110,Atypical Lymphocytes,skos:exactMatch,loinc:33369-0,Variant lymphocytes/100 leukocytes in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51142,Arachadonic Acid,skos:exactMatch,loinc:35168-4,Arachidonate (C20:4w6) [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51328,CD56,skos:broadMatch,loinc:51280-6,CD3+CD56+ cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51331,CD64,skos:exactMatch,loinc:51365-5,CD64 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50850,"Triglycerides, Ascites",skos:exactMatch,loinc:14447-7,Triglyceride [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51135,ADP,skos:broadMatch,loinc:1724-4,Adenosine diphosphate [Mass/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51091,"Myoglobin, Urine",skos:exactMatch,loinc:2640-1,Myoglobin [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51032,"Creatinine, Body Fluid",skos:exactMatch,loinc:12190-5,Creatinine [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51195,Collagen,skos:broadMatch,loinc:78685-5,Platelet aggregation collagen induced [Units/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51306,CD11c,skos:exactMatch,loinc:33202-3,CD11c cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51638,Hematocrit,skos:exactMatch,loinc:4544-3,Hematocrit [Volume Fraction] of Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51221
+mimic:51645,"Hemoglobin, Calculated",skos:exactMatch,loinc:20509-6,Hemoglobin [Mass/volume] in Blood by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52569,Glucose,skos:exactMatch,loinc:2345-7,Glucose [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52610,Potassium,skos:exactMatch,loinc:2823-3,Potassium [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 50971
+mimic:52623,Sodium,skos:exactMatch,loinc:2951-2,Sodium [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51507,"Urine Casts, Other",skos:exactMatch,loinc:9842-6,Casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51028,"Bilirubin, Total, Body Fluid",skos:exactMatch,loinc:1974-5,Bilirubin.total [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52546,Creatinine,skos:exactMatch,loinc:2160-0,Creatinine [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51212,Fetal Hemoglobin,skos:exactMatch,loinc:4576-5,Hemoglobin F/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51510,"Urine Crystals, Other",skos:exactMatch,loinc:5783-6,Unidentified crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51440,Atypical Lymphocytes,skos:exactMatch,loinc:33370-8,Variant lymphocytes/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52535,Chloride,skos:exactMatch,loinc:2075-0,Chloride [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52647,Urea Nitrogen,skos:exactMatch,loinc:3094-0,Urea nitrogen [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51624,Free Calcium,skos:exactMatch,loinc:1994-3,Calcium.ionized [Moles/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51739,Total CO2,skos:exactMatch,loinc:2028-9,"Carbon dioxide, total [Moles/volume] in Serum or Plasma",HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52500,Anion Gap,skos:exactMatch,loinc:33037-3,Anion gap in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51901,Voided Specimen,,,,,,,,Not a lab test
+mimic:51953,Voided Specimen,,,,,,,,Not a lab test
+mimic:51666,H. pylori IgG Ab,skos:exactMatch,loinc:17859-0,Helicobacter pylori IgG Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51324,CD41,skos:exactMatch,loinc:51319-2,CD41 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51112,Basophils,skos:exactMatch,loinc:35069-4,Basophils/100 leukocytes in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52179,SCT - Screen,skos:broadMatch,loinc:66736-0,Normalized silica clotting time of Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51509,Urine Comments,skos:exactMatch,loinc:11279-7,Urine sediment comments by Light microscopy Narrative,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51188,CD56,skos:closeMatch,loinc:8133-1,CD56 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51115,"Hematocrit, Ascites",skos:broadMatch,loinc:11153-4,Hematocrit [Volume Fraction] of Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51667,H. pylori IgG Ab Value,skos:exactMatch,loinc:5176-3,Helicobacter pylori IgG Ab [Units/volume] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51333,CD71,skos:broadMatch,loinc:21169-8,CD71 cells/100 cells in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51242,LUC,skos:exactMatch,loinc:26463-0,Large unstained cells/100 leukocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51377,Mesothelial Cells,skos:exactMatch,loinc:33365-8,Mesothelial cells/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51264,Platelet Clumps,skos:exactMatch,loinc:7796-6,Platelet clump [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50888,Blue Top Hold Frozen,,,,,,,,Not a lab test
+mimic:51336,Glyco A,skos:broadMatch,loinc:55864-3,Glycolate [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51954,CDT027,,,,,,,,Ambiguous name
+mimic:52225,Basophils,skos:exactMatch,loinc:30374-3,Basophils/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51203,Factor IX,skos:exactMatch,loinc:3187-2,Coagulation factor IX activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51209,Factor XI,skos:exactMatch,loinc:3226-8,Coagulation factor XI activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51178,CD34,skos:exactMatch,loinc:8125-7,CD34 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51515,Waxy Casts,skos:exactMatch,loinc:5819-8,Waxy casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51204,Factor V,skos:exactMatch,loinc:3193-0,Coagulation factor V activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51111,Bands,skos:exactMatch,loinc:99603-3,Band form neutrophils/100 leukocytes in Peritoneal fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Manual count only
+mimic:51156,CD13,skos:closeMatch,loinc:8110-9,CD13 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51869,"Influenza A, Rapid Antigen",skos:exactMatch,loinc:31859-2,Influenza virus A Ag [Presence] in Specimen,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51874,"Influenza B, Rapid Antigen",skos:exactMatch,loinc:31864-2,Influenza virus B Ag [Presence] in Specimen,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51895,"Strep A, Rapid Antigen",skos:broadMatch,loinc:78012-2,Streptococcus pyogenes Ag [Presence] in Throat by Rapid immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,Duplicate of itemid 51894
+mimic:52720,"HCG, Urine, Qualitative",skos:exactMatch,loinc:2106-3,Choriogonadotropin (pregnancy test) [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51155,CD11c,skos:closeMatch,loinc:8109-1,CD11c cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51653,HIV 1 Ab Confirmation,skos:exactMatch,loinc:29893-5,HIV 1 Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51655,HIV 2 Ab Confirmation,skos:exactMatch,loinc:30361-0,HIV 2 Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52131,HIT-Ab Interpreted Result,skos:exactMatch,loinc:73816-1,Heparin induced platelet IgG Ab [Interpretation] in Serum Narrative,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52132,HIT-Ab Numerical Result,skos:exactMatch,loinc:45155-9,Heparin induced platelet Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51065,"Sodium, Stool",skos:exactMatch,loinc:15207-4,Sodium [Moles/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51202,Factor II,skos:exactMatch,loinc:3289-6,Prothrombin activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51064,"Potassium, Stool",skos:exactMatch,loinc:15202-5,Potassium [Moles/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51154,CD117,skos:closeMatch,loinc:17107-4,CD117 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51208,Factor X,skos:exactMatch,loinc:3218-5,Coagulation factor X activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51063,"Osmolality, Stool",skos:exactMatch,loinc:2693-0,Osmolality of Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51765,EE3,,,,,,,,Ambiguous name
+mimic:51652,High-Sensitivity CRP,skos:exactMatch,loinc:30522-7,C reactive protein [Mass/volume] in Serum or Plasma by High sensitivity method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51755,White Blood Cells,skos:exactMatch,loinc:6690-2,Leukocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51300
+mimic:51159,CD15,skos:closeMatch,loinc:17117-3,CD15 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51408,CD4,skos:exactMatch,loinc:17822-8,CD3+CD4+ (T4 helper) cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51158,CD14,skos:closeMatch,loinc:8111-7,CD14 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51177,CD33,skos:closeMatch,loinc:8102-6,CD33 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51418,CD8,skos:exactMatch,loinc:17824-4,CD3+CD8+ (T8 suppressor) cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51366,Bands,skos:exactMatch,loinc:33361-7,Band form neutrophils/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51864,Influenza A by PCR,skos:exactMatch,loinc:34487-9,Influenza virus A RNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51872,Influenza B by PCR,skos:exactMatch,loinc:40982-1,Influenza virus B RNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51187,CD55,skos:closeMatch,loinc:17175-1,CD55 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51190,CD59,skos:closeMatch,loinc:17177-7,CD59 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51185,CD5 %,skos:exactMatch,loinc:8132-3,CD5 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51186,CD5 Absolute Count,skos:exactMatch,loinc:9559-6,CD5 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51191,CD64,skos:closeMatch,loinc:17183-5,CD64 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51220,Heinz Body Prep,skos:exactMatch,loinc:716-1,Heinz bodies [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52279,Plasma,skos:exactMatch,loinc:47413-0,Plasma cells/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51387,Basophils,skos:exactMatch,loinc:28543-7,Basophils/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51027,"Bicarbonate, Other Fluid",skos:exactMatch,loinc:16459-0,Bicarbonate [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51193,CD71,skos:closeMatch,loinc:8136-4,CD71 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:52276,NRBC,skos:exactMatch,loinc:48778-5,Nucleated erythrocytes/100 cells in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51207,Factor VIII Inhibitor,skos:exactMatch,loinc:3204-5,Coagulation factor VIII inhibitor [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51488,Non-squamous Epithelial Cells,skos:exactMatch,loinc:41284-1,Epithelial cells.non-squamous [#/area] in Urine sediment by Microscopy high power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51217,Glyco A,skos:exactMatch,loinc:42502-5,Glycolate [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51182,CD41,skos:closeMatch,loinc:17148-8,CD41 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51386,Bands,skos:exactMatch,loinc:26510-8,Band form neutrophils/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51441,Bands,skos:exactMatch,loinc:99604-1,Band form neutrophils/100 leukocytes in Pleural fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Manual count only
+mimic:51272,"Protein S, Antigen",skos:exactMatch,loinc:27823-4,Protein S Ag actual/normal in Platelet poor plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51367,Basophils,skos:exactMatch,loinc:17833-5,Basophils/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51049,"Bilirubin, Total, Pleural",skos:exactMatch,loinc:14421-2,Bilirubin.total [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52642,Troponin I,skos:exactMatch,loinc:10839-9,Troponin I.cardiac [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51022,"Glucose, Joint Fluid",skos:exactMatch,loinc:2348-1,Glucose [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51621,Ethylene Glycol,skos:exactMatch,loinc:5646-5,"Ethylene glycol [Mass/volume] in Serum, Plasma or Blood",HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52358,Lining Cell,skos:exactMatch,loinc:35477-9,Ciliated columnar lining cells/100 leukocytes [# Ratio] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51122,Nucleated RBC,skos:exactMatch,loinc:70171-4,Nucleated erythrocytes/100 cells in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51189,CD57,skos:closeMatch,loinc:8134-9,CD57 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51201,Epinepherine,skos:exactMatch,loinc:2230-1,EPINEPHrine [Mass/volume] in Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51502,Trichomonas,skos:exactMatch,loinc:33905-1,Trichomonas sp [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52301,Lining Cell,skos:exactMatch,loinc:35651-9,Synovial lining cells/100 cells in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50875,Anti-Parietal Cell Antibody,skos:exactMatch,loinc:14241-4,Parietal cell Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51312,CD16/56,skos:exactMatch,loinc:51255-8,CD16+CD56+ cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51302,Young Cells,skos:broadMatch,loinc:55433-7,Immature cells/100 leukocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51385,Atypical Lymphocytes,skos:exactMatch,loinc:30417-0,Variant lymphocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51044,Triglycer,skos:exactMatch,loinc:12228-3,Triglyceride [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51365,Atypical Lymphocytes,skos:exactMatch,loinc:33371-6,Variant lymphocytes/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51743,Toxoplasma IgM Ab,skos:exactMatch,loinc:40678-5,Toxoplasma gondii IgM Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51452,NRBC,skos:exactMatch,loinc:70170-6,Nucleated erythrocytes/100 cells in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51084,"Glucose, Urine",skos:exactMatch,loinc:2350-7,Glucose [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51286,Ristocetin,skos:exactMatch,loinc:18975-3,Ristocetin [Susceptibility],HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51270,"Protein C, Antigen",skos:exactMatch,loinc:27820-0,Protein C Ag actual/normal in Platelet poor plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51024,"Total Protein, Joint Fluid",skos:exactMatch,loinc:2886-0,Protein [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51744,Toxoplasma IgM Ab Value,skos:exactMatch,loinc:5390-0,Toxoplasma gondii IgM Ab [Units/volume] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52107,dRVVT - Confirmation,skos:broadMatch,loinc:50410-0,dRVVT/dRVVT W excess phospholipid (screen to confirm ratio),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52108,dRVVT - Normalized Ratio,skos:broadMatch,loinc:97642-3,dRVVT/dRVVT.excess phospholipid [Ratio] normalized in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52270,Metamyelocytes,skos:exactMatch,loinc:30366-9,Metamyelocytes/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51870,"Influenza A, Rapid Antigen",skos:exactMatch,loinc:31859-2,Influenza virus A Ag [Presence] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51869
+mimic:51875,"Influenza B, Rapid Antigen",skos:broadMatch,loinc:80383-3,Influenza virus B Ag [Presence] in Upper respiratory specimen by Rapid immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,Duplicate of itemid 51874
+mimic:50870,"Anti-Gliadin Antibody, IgA",skos:exactMatch,loinc:58709-7,Gliadin peptide IgA Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52181,Stomatocyte,skos:exactMatch,loinc:10380-4,Stomatocytes [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51072,"Amylase, Urine",skos:exactMatch,loinc:1799-6,Amylase [Enzymatic activity/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51073,"Amylase/Creatinine Ratio, Urine",skos:exactMatch,loinc:34235-2,Amylase/Creatinine [Ratio] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52257,"Hematocrit, CSF",skos:exactMatch,loinc:30398-2,Hematocrit [Volume Fraction] of Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50990,Theophylline,skos:exactMatch,loinc:4049-3,Theophylline [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51083,"Ethanol, Urine",skos:exactMatch,loinc:5644-0,Ethanol [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51161,CD16,skos:closeMatch,loinc:8115-8,CD16 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51392,CD13,skos:exactMatch,loinc:51238-4,CD13 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51467,Broad Casts,skos:exactMatch,loinc:18487-9,Broad casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51767,EE5,,,,,,,,Ambiguous name
+mimic:50844,"Lipase, Ascites",skos:exactMatch,loinc:32722-1,Lipase [Enzymatic activity/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51062,"Chloride, Stool",skos:exactMatch,loinc:15158-9,Chloride [Moles/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51179,CD38,skos:closeMatch,loinc:8126-5,CD38 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51494,RBC Casts,skos:exactMatch,loinc:5807-3,RBC casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52227,Blasts,skos:exactMatch,loinc:26447-3,Blasts/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51465,Bilirubin Crystals,skos:exactMatch,loinc:5771-1,Bilirubin crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51697,Neutrophils,skos:exactMatch,loinc:751-8,Neutrophils [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Incorrect Unit (mmol/l)
+mimic:51433,NRBC,skos:exactMatch,loinc:49229-8,Nucleated erythrocytes/100 leukocytes [Ratio] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51397,CD16/56,skos:exactMatch,loinc:18268-3,CD16+CD56+ cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51713,Reflex Confirmatory Hepatitis C Viral Load,skos:broadMatch,loinc:11011-4,Hepatitis C virus RNA [Units/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51211,Factor XIII,skos:exactMatch,loinc:27815-0,Coagulation factor XIII activity actual/normal in Platelet poor plasma by Chromogenic method,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52268,Mesothelial cells,skos:exactMatch,loinc:30429-5,Mesothelial cells/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51173,CD25,skos:closeMatch,loinc:8121-6,CD25 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51511,Urine Fat Bodies,skos:exactMatch,loinc:25158-7,Oval fat bodies (globules) [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51380,NRBC,skos:exactMatch,loinc:68545-3,Nucleated erythrocytes/100 leukocytes [Ratio] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51149,Bleeding Time,skos:exactMatch,loinc:11067-6,Bleeding time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51171,CD22,skos:closeMatch,loinc:14017-8,CD22 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:53127,Voided Specimen,,,,,,,,Not a lab test
+mimic:51413,CD56,skos:exactMatch,loinc:57424-4,CD56 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51210,Factor XII,skos:exactMatch,loinc:3232-6,Coagulation factor XII activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51153,CD103,skos:exactMatch,loinc:17100-9,CD103 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52335,TdT,skos:exactMatch,loinc:42620-5,Terminal deoxyribonucleotidyl transferase cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51318,CD25,skos:exactMatch,loinc:32493-9,CD25 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51390,CD117,skos:exactMatch,loinc:42867-2,CD117 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52176,Rouleaux,skos:exactMatch,loinc:7797-4,Rouleaux [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51435,Plasma,skos:exactMatch,loinc:17803-8,Plasma cells/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51395,CD15,skos:exactMatch,loinc:51252-5,CD15 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52274,Myelocytes,skos:exactMatch,loinc:30447-7,Myelocytes/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51470,Calcium Phosphate Crystals,skos:exactMatch,loinc:5775-2,Calcium phosphate crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51045,"Urea Nitrogen, Body Fluid",skos:exactMatch,loinc:3093-2,Urea nitrogen [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51692,"Monospot, Rapid Antigen",skos:exactMatch,loinc:31418-7,Heterophile Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52283,Promyelocytes,skos:exactMatch,loinc:30467-5,Promyelocytes/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53144,ANCA Titer,skos:exactMatch,loinc:21023-7,Neutrophil cytoplasmic Ab [Titer] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51036,"Lipase, Body Fluid",skos:exactMatch,loinc:15212-4,Lipase [Enzymatic activity/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50848,"Sodium, Ascites",skos:exactMatch,loinc:49790-9,Sodium [Moles/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51241,Leukocyte Alkaline Phosphatase,skos:exactMatch,loinc:4659-9,Leukocyte phosphatase [Enzymatic activity/volume] in Leukocytes,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51407,CD38,skos:exactMatch,loinc:51299-6,CD38 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52043,Voided Specimen,,,,,,,,Not a lab test
+mimic:51405,CD33,skos:exactMatch,loinc:51294-7,CD33 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51409,CD4/CD8 Ratio,skos:exactMatch,loinc:18266-7,CD3+CD4+ (T4 helper) cells/CD3+CD8+ (T8 suppressor cells) cells [# Ratio] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50840,"Cholesterol, Ascites",skos:exactMatch,loinc:14441-0,Cholesterol [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51061,"Bicarbonate, Stool",skos:broadMatch,loinc:22735-5,Bicarbonate [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52177,SCT - Confirmation,skos:broadMatch,loinc:66736-0,Normalized silica clotting time of Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52178,SCT - Normalized Ratio,skos:exactMatch,loinc:66736-0,Normalized silica clotting time of Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52263,Lining Cell,skos:exactMatch,loinc:21176-3,Cerebroventricular lining cells [Presence] in Cerebral spinal fluid by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51322,CD38,skos:exactMatch,loinc:51298-8,CD38 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51295,TdT,skos:broadMatch,loinc:2983-5,Terminal deoxyribonucleotidyl transferase [Enzymatic activity/volume] in Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52551,D-Dimer,skos:exactMatch,loinc:48066-5,Fibrin D-dimer DDU [Mass/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51316,CD22,skos:broadMatch,loinc:51124-6,CD22 blasts/100 blasts in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51393,CD138,skos:exactMatch,loinc:42871-4,CD138 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51042,"Sodium, Body Fluid",skos:exactMatch,loinc:2950-4,Sodium [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52129,Hemoglobin Other,skos:exactMatch,loinc:48343-8,Hemoglobin.other/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51023,"LD, Joint Fluid",skos:closeMatch,loinc:2533-8,Lactate dehydrogenase [Enzymatic activity/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Discouraged LOINC code
+mimic:51394,CD14,skos:exactMatch,loinc:51248-3,CD14 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51675,INR(PT),skos:exactMatch,loinc:6301-6,INR in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51897,Surfactant/Albumin,skos:exactMatch,loinc:30562-3,Surfactant/Albumin [Mass Ratio] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50847,"Potassium, Ascites",skos:exactMatch,loinc:49789-1,Potassium [Moles/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51041,"Potassium, Body Fluid",skos:exactMatch,loinc:2821-7,Potassium [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51304,CD103,skos:exactMatch,loinc:51221-0,CD103 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51776,<Albumin>,skos:exactMatch,loinc:1746-7,Albumin [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51775
+mimic:51329,CD57,skos:exactMatch,loinc:32497-0,CD57 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50845,"Miscellaneous, Ascites",,,,,,,,Not a lab test
+mimic:51253,Monocyte Count,skos:exactMatch,loinc:742-7,Monocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50839,"Chloride, Ascites",skos:exactMatch,loinc:33366-6,Chloride [Moles/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51806,Voided Specimen,,,,,,,,Not a lab test
+mimic:51495,RBC Clumps,skos:exactMatch,loinc:58449-0,Erythrocyte clumps [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50837,"Bicarbonate, Ascites",skos:exactMatch,loinc:54360-3,Bicarbonate [Moles/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51030,"Chloride, Body Fluid",skos:exactMatch,loinc:2072-7,Chloride [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51415,CD64,skos:exactMatch,loinc:51366-3,CD64 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51490,Oval Fat Body,skos:exactMatch,loinc:5788-5,Oval fat bodies (globules) [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50959,Macro Prolactin,skos:exactMatch,loinc:72680-2,Macroprolactin [Presence] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51456,Promyelocytes,skos:broadMatch,loinc:17799-8,Promyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51475,Epithelial Casts,skos:exactMatch,loinc:5786-9,Epithelial casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51391,CD11c,skos:exactMatch,loinc:51232-7,CD11c cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51311,CD16,skos:broadMatch,loinc:51086-7,CD16 blasts/100 blasts in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51714,Reflex HIV Confirmation,skos:broadMatch,loinc:56888-1,HIV 1+2 Ab+HIV1 p24 Ag [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51449,Metamyelocytes,skos:broadMatch,loinc:17801-2,Metamyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51461,Ammonium Biurate,skos:exactMatch,loinc:25144-7,Ammonium urate crystals [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50962,N-Acetylprocainamide (NAPA),skos:exactMatch,loinc:3834-9,N-acetylprocainamide [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50972,Procainamide,skos:exactMatch,loinc:3982-6,Procainamide [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51403,CD25,skos:exactMatch,loinc:51271-5,CD25 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50851,"Urea Nitrogen, Ascites",skos:exactMatch,loinc:12265-5,Urea nitrogen [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51430,Metamyelocytes,skos:exactMatch,loinc:17801-2,Metamyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51119,Metamyelocytes,skos:broadMatch,loinc:17801-2,Metamyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51401,CD22,skos:exactMatch,loinc:42875-5,CD22 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51472,Cholesterol Crystals,skos:exactMatch,loinc:5777-8,Cholesterol crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51126,Promyelocytes,skos:broadMatch,loinc:17799-8,Promyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51308,CD138,skos:exactMatch,loinc:42870-6,CD138 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51924,Voided Specimen,,,,,,,,Not a lab test
+mimic:51378,Metamyelocytes,skos:broadMatch,loinc:17801-2,Metamyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51396,CD16,skos:exactMatch,loinc:17828-5,CD16 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51410,CD41,skos:exactMatch,loinc:51320-0,CD41 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51414,CD57,skos:exactMatch,loinc:51351-5,CD57 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51417,CD71,skos:exactMatch,loinc:57426-9,CD71 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51451,Myelocytes,skos:broadMatch,loinc:17800-4,Myelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51468,Calcium Carbonate Crystals,skos:exactMatch,loinc:5773-7,Calcium carbonate crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51473,Cysteine Crystals,skos:exactMatch,loinc:5784-4,Cystine crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51480,Hematocrit,skos:exactMatch,loinc:17809-5,Hematocrit [Volume Fraction] of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51791,HIV 1 Viral Load,skos:exactMatch,loinc:29541-0,HIV 1 RNA [Log #/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52307,Plasma,skos:exactMatch,loinc:40492-1,Plasma cells/100 leukocytes in Synovial fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51031,"Cholesterol, Body Fluid",skos:exactMatch,loinc:12183-0,Cholesterol [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51121,Myelocytes,skos:broadMatch,loinc:17800-4,Myelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51421,Glyco A,skos:exactMatch,loinc:55864-3,Glycolate [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52373,TdT,skos:exactMatch,loinc:52997-4,Terminal deoxyribonucleotidyl transferase cells/100 cells in Body fluid by Flow cytometry (FC),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51157,CD138,skos:closeMatch,loinc:42869-8,CD138 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51029,"Calcium, Body Fluid",skos:exactMatch,loinc:15155-5,Calcium [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51040,"Phosphate, Body Fluid",skos:exactMatch,loinc:12242-4,Phosphate [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51389,CD103,skos:exactMatch,loinc:42864-9,CD103 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51432,Myelocytes,skos:exactMatch,loinc:17800-4,Myelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51437,Promyelocytes,skos:exactMatch,loinc:17799-8,Promyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51665,HPE9,,,,,,,,Ambiguous name
+mimic:51827,Voided Specimen,,,,,,,,Not a lab test
+mimic:51039,"Osmolality, Body Fluid",skos:exactMatch,loinc:15200-9,Osmolality of Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51443,Blasts,skos:exactMatch,loinc:33373-2,Blasts/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51477,Free Fat,skos:exactMatch,loinc:2272-3,Fat [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52311,Promyelocytes,skos:broadMatch,loinc:17799-8,Promyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51019,"Albumin, Joint Fluid",skos:exactMatch,loinc:1752-5,Albumin [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51037,"Magnesium, Body Fluid",skos:exactMatch,loinc:29365-4,Magnesium [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51055,"Lipase, Pleural",skos:exactMatch,loinc:47418-9,Lipase [Enzymatic activity/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52092,CD56 %,skos:exactMatch,loinc:8133-1,CD56 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52093,CD56 Absolute Count,skos:exactMatch,loinc:14113-5,CD56 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52305,Myelocytes,skos:broadMatch,loinc:17800-4,Myelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51500,Sulfonamides,skos:exactMatch,loinc:5812-3,Sulfonamide crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51504,Tyrosine Crystals,skos:exactMatch,loinc:5815-6,Tyrosine crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50846,"Osmolality, Ascites",skos:exactMatch,loinc:2691-4,Osmolality of Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51058,"Sodium, Pleural",skos:broadMatch,loinc:32340-2,Sodium [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51020,"Amylase, Joint Fluid",skos:exactMatch,loinc:14388-3,Amylase [Enzymatic activity/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51258,Osmotic Fragility,skos:closeMatch,loinc:34964-7,Osmotic fragility [Interpretation] of Red Blood Cells,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51280,Reptilase Time,skos:exactMatch,loinc:6683-7,Reptilase time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51327,CD55,skos:exactMatch,loinc:51344-0,CD55 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52184,TCR Alpha-Beta,skos:exactMatch,loinc:80713-1,TCR alpha beta cells/100 CD3 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52185,TCR Gamma-Delta,skos:exactMatch,loinc:80714-9,TCR gamma delta cells/100 CD3 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52319,CD 1a,skos:exactMatch,loinc:52874-5,CD1a cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51057,"Potassium, Pleural",skos:broadMatch,loinc:32336-0,Potassium [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51278,Red Blood Cell Fragments,skos:exactMatch,loinc:800-3,Schistocytes [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51287
+mimic:51281,Reptilase Time Control,skos:exactMatch,loinc:5942-8,Reptilase time in Control Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51330,CD59,skos:exactMatch,loinc:51358-0,CD59 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51483,Hyphenated Yeast,skos:exactMatch,loinc:41865-7,Yeast.hyphae [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51485,Leucine Crystals,skos:exactMatch,loinc:5798-4,Leucine crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51496,"Reducing Substances, Urine",skos:exactMatch,loinc:5809-9,Reducing substances [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52370,Voided Specimen,,,,,,,,Not a lab test
+mimic:51783,"Bilirubin, Total, CSF",skos:exactMatch,loinc:1973-7,Bilirubin.total [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52288,Young,,,,,,,,Ambiguous name
+mimic:52331,TCR Alpha-Beta,skos:exactMatch,loinc:32860-9,TCR alpha beta cells/100 cells in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52332,TCR Gamma-Delta,skos:exactMatch,loinc:32861-7,TCR gamma delta cells/100 cells in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51021,"Creatinine, Joint Fluid",skos:exactMatch,loinc:14401-4,Creatinine [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51048,"Bicarbonate, Pleural",skos:exactMatch,loinc:54361-1,Bicarbonate [Moles/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51113,Blasts,skos:exactMatch,loinc:33372-4,Blasts/100 leukocytes in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51129,Young,,,,,,,,Ambiguous name
+mimic:52088,CD 1a,skos:exactMatch,loinc:20476-8,CD1a cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52287,Voided Specimen,,,,,,,,Not a lab test
+mimic:52313,Voided Specimen,,,,,,,,Not a lab test
+mimic:52339,Blasts,skos:exactMatch,loinc:26448-1,Blasts/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52406,Voided Specimen,,,,,,,,Not a lab test
+mimic:50830,"pCO2, Body Fluid",skos:exactMatch,loinc:2023-0,Carbon dioxide [Partial pressure] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas"""
+mimic:50832,"pO2, Body Fluid",skos:exactMatch,loinc:2706-0,Oxygen [Partial pressure] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas"""
+mimic:51050,"Chloride, Pleural",skos:exactMatch,loinc:53627-6,Chloride [Moles/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52341,CD 1a,skos:exactMatch,loinc:52873-7,CD1a cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52355,Hypersegmented Neutrophils,skos:exactMatch,loinc:30453-5,Segmented neutrophils/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52410,Fatty Casts,skos:exactMatch,loinc:5789-3,Fatty casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50829,Fluid Type,,,,,,,,Not a lab test
+mimic:50833,Potassium,skos:broadMatch,loinc:2821-7,Potassium [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas"""
+mimic:50834,"Sodium, Body Fluid",skos:broadMatch,loinc:2950-4,Sodium [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas"""
+mimic:50858,Acid Phosphatase,skos:broadMatch,loinc:1715-2,Acid phosphatase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50859,"Acid Phosphatase, Non-Prostatic",skos:broadMatch,loinc:12173-1,Non prostatic acid phosphatase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50860,"AFP, Maternal Screen",skos:broadMatch,loinc:1834-1,Alpha-1-Fetoprotein [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50886,Blood Culture Hold,,,,,,,,Not a lab test
+mimic:50897,Call,,,,,,,,Not a lab test
+mimic:50923,Fax,,,,,,,,Not a lab test
+mimic:50928,Gastrin,skos:broadMatch,loinc:2333-3,Gastrin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50936,"HCG, Maternal Screen",skos:broadMatch,loinc:19080-1,Choriogonadotropin [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50977,Quinidine,skos:broadMatch,loinc:6694-4,quiNIDine [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50984,Stat,,,,,,,,Not a lab test
+mimic:50985,Study Tubes,,,,,,,,Not a lab test
+mimic:51002,Troponin I,skos:broadMatch,loinc:10839-9,Troponin I.cardiac [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51004,"UE3, Maternal Screen",skos:broadMatch,loinc:2250-9,Estriol (E3).unconjugated [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51136,Alpha Antiplasmin,skos:broadMatch,loinc:27810-1,Plasmin inhibitor actual/normal in Platelet poor plasma by Chromogenic method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51141,APT Test,skos:broadMatch,loinc:4632-6,Hemoglobin F [Presence] in Blood by Alkali denaturation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51285,"Reticulocyte, Cellular Hemoglobin",skos:broadMatch,loinc:76686-5,Reticulocyte cellular hemoglobin distribution width [Entitic mass] in Blood by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51293,Sugar Water Test,skos:broadMatch,loinc:13534-3,Sucrose hemolysis [Presence] of Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51303,CD10,skos:broadMatch,loinc:51216-0,CD10 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51339,Iron Stain,skos:broadMatch,loinc:13513-7,Iron.microscopic observation [Identifier] in Bone marrow by Potassium ferrocyanide stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51459,Young Cells,,,,,,,,Ambiguous name
+mimic:51556,Anti-Microsomal Antibodies,skos:broadMatch,loinc:5382-7,Thyroperoxidase Ab [Units/volume] in Serum or Plasma by Radioimmunoassay (RIA),HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51557,Anti-Microsomal Antibody,skos:broadMatch,loinc:8077-0,Mitochondria Ab [Units/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51558,Antirnp,skos:broadMatch,loinc:8091-1,Ribonucleoprotein extractable nuclear Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51559,Anti-ro,skos:broadMatch,loinc:8093-7,Sjogrens syndrome-A extractable nuclear Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51560,Anti-SARS-CoV-2 IgA,skos:broadMatch,loinc:94562-6,SARS-CoV-2 (COVID-19) IgA Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51562,Anti-Skin Antibody,skos:broadMatch,loinc:66878-0,Skin Ab [Titer] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51563,Anti-sm,skos:broadMatch,loinc:14252-1,Smooth muscle Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51565,Argon,skos:broadMatch,loinc:76127-0,Argon [VFr/PPres] Gas delivery system,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51566,Beta,skos:broadMatch,loinc:2871-2,Beta globulin [Mass/volume] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51568,"Bilirubin, Neonatal",skos:broadMatch,loinc:33898-8,Bilirubin.conjugated+indirect [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51569,"Bilirubin, Neonatal, Direct",skos:broadMatch,loinc:15152-2,Bilirubin.conjugated [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51570,"Bilirubin, Neonatal, Indirect",skos:broadMatch,loinc:1971-1,Bilirubin.indirect [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51571,Billed,,,,,,,,Not a lab test
+mimic:51572,Bioavailable Testosterone,skos:broadMatch,loinc:6891-6,Testosterone.free+weakly bound/Testosterone.total in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51573,Bromide,skos:broadMatch,loinc:1984-4,Bromide [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51574,C1 Inhibitor,skos:broadMatch,loinc:4477-6,Complement C1 esterase inhibitor [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51575,C1q,skos:broadMatch,loinc:4478-4,Complement C1q [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51576,C2,skos:broadMatch,loinc:4484-2,Complement C2 [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51577,C5,skos:broadMatch,loinc:4505-4,Complement C5 [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51578,C6,skos:broadMatch,loinc:4507-0,Complement C6 [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51580,Calculated CK-MB,skos:broadMatch,loinc:12189-7,Creatine kinase.MB/Creatine kinase.total in Serum or Plasma by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51581,Carotene,skos:broadMatch,loinc:2053-7,Carotene [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51582,CH50,skos:broadMatch,loinc:4532-8,Complement total hemolytic CH50 [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51583,Chol Estr,skos:broadMatch,loinc:2083-4,Cholesterol esterase [Enzymatic activity/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51584,Chylomicrons,skos:broadMatch,loinc:2121-2,Chylomicrons [Presence] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51585,Clostrid,skos:broadMatch,loinc:26643-7,Clostridium tetani toxoid Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51589,CMV IgM Ab Value,skos:broadMatch,loinc:5126-8,Cytomegalovirus IgM Ab [Units/volume] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51591,Confirmation,,,,,,,,Not a lab test
+mimic:51592,Conj Bili,skos:broadMatch,loinc:1968-7,Bilirubin.direct [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51593,Copper,skos:broadMatch,loinc:5631-7,Copper [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51594,"Creatine Kinase, Isoenzyme BB",skos:broadMatch,loinc:9642-0,Creatine kinase.BB/Creatine kinase.total in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51595,"Creatine Kinase, Isoenzyme MB",skos:broadMatch,loinc:20569-0,Creatine kinase.MB/Creatine kinase.total in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51596,"Creatine Kinase, Isoenzyme MM",skos:broadMatch,loinc:9643-8,Creatine kinase.MM/Creatine kinase.total in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51597,Cvhlc,,,,,,,,Ambiguous name
+mimic:51599,D,,,,,,,,Not a lab test
+mimic:51600,Delete,,,,,,,,Not a lab test
+mimic:51601,Delete,,,,,,,,Not a lab test
+mimic:51602,Delete,,,,,,,,Not a lab test
+mimic:51603,Delete,,,,,,,,Not a lab test
+mimic:51604,Delete,,,,,,,,Not a lab test
+mimic:51605,Delta/Dlt,,,,,,,,Ambiguous name
+mimic:51606,Digitoxin,skos:broadMatch,loinc:3559-2,Digitoxin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51607,"Dimeric Inhibin A, Maternal Screen",skos:broadMatch,loinc:23883-2,Inhibin A [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51608,DirLst,,,,,,,,Not a lab test
+mimic:51609,Disopyramide,skos:broadMatch,loinc:3576-6,Disopyramide [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51610,Dlta Bili,skos:broadMatch,loinc:1970-3,Bilirubin.delta [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51611,Down Syndrome Risk,skos:broadMatch,loinc:43995-0,Trisomy 21 risk [Likelihood] in Fetus,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51612,Dr. X,,,,,,,,Not a lab test
+mimic:51623,Fibrinogen,skos:broadMatch,loinc:3255-7,Fibrinogen [Mass/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51628,Fructosamine,skos:broadMatch,loinc:15069-8,Fructosamine [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51629,Fructosamine Plus,skos:broadMatch,loinc:15069-8,Fructosamine [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51630,Gamma,skos:broadMatch,loinc:2874-6,Gamma globulin [Mass/volume] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51631,Glycated Hemoglobin,skos:broadMatch,loinc:4548-4,Hemoglobin A1c/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51632,Growth Hormone,skos:broadMatch,loinc:2963-7,Somatotropin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51633,Hbeag,skos:broadMatch,loinc:13954-3,Hepatitis B virus e Ag [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51634,Hbsag,skos:broadMatch,loinc:5196-1,Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51635,Hbsag,skos:broadMatch,loinc:5196-1,Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51634
+mimic:51636,"HCG, Multiples of Median",skos:broadMatch,loinc:20465-1,Choriogonadotropin [Multiple of the median] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51637,"HCG, Qualitative",skos:broadMatch,loinc:2110-5,Choriogonadotropin.beta subunit (pregnancy test) [Presence] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51639,Hematocrit,skos:broadMatch,loinc:4544-3,Hematocrit [Volume Fraction] of Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51221
+mimic:51640,Hemoglobin,skos:broadMatch,loinc:718-7,Hemoglobin [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 50811
+mimic:51641,Hemoglobin  A,skos:broadMatch,loinc:4546-8,Hemoglobin A/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51642,Hemoglobin  A1,skos:broadMatch,loinc:4547-6,Hemoglobin A1/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51643,Hemoglobin  A2,skos:broadMatch,loinc:4551-8,Hemoglobin A2/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51223
+mimic:51644,Hemoglobin  C,skos:broadMatch,loinc:4563-3,Hemoglobin C/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51646,Hemoglobin  F,skos:broadMatch,loinc:4576-5,Hemoglobin F/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51212
+mimic:51647,Hemoglobin  S,skos:broadMatch,loinc:4625-0,Hemoglobin S/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51227
+mimic:51649,Hepatitis B Virus E Antibody,skos:broadMatch,loinc:5189-6,Hepatitis B virus e Ab [Units/volume] in Serum by Immunoassay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51650,Hepatitis B Virus E Antigen,skos:broadMatch,loinc:5191-2,Hepatitis B virus e Ag [Units/volume] in Serum by Immunoassay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51656,Hlap,skos:broadMatch,loinc:32351-9,Alkaline phosphatase.heat labile [Enzymatic activity/volume] in Serum or Plasma by Heat stability,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51668,Hsap,skos:broadMatch,loinc:32352-7,Alkaline phosphatase.heat stable [Enzymatic activity/volume] in Serum or Plasma by Heat stability,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51669,Htlv Ab,skos:broadMatch,loinc:22362-8,HTLV I+II Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51670,Icd9,skos:broadMatch,loinc:39222-5,"Diagnosis recommendations, ICD9-CM CPHS",HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51671,IFEgel,,,,,,,,Not a lab test
+mimic:51672,Immune Complexes,skos:broadMatch,loinc:5228-2,Immune complex [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51673,Immunoelectrophoresis,skos:broadMatch,loinc:13169-8,Immunoelectrophoresis for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51674,Immunoglobulin E,skos:broadMatch,loinc:2462-0,IgE [Mass/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51676,Insulin,skos:broadMatch,loinc:20448-7,Insulin [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51679,Lap,skos:broadMatch,loinc:4659-9,Leukocyte phosphatase [Enzymatic activity/volume] in Leukocytes,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51680,"LD, Isoenzyme 1",skos:broadMatch,loinc:2536-1,Lactate dehydrogenase 1/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51681,"LD, Isoenzyme 2",skos:broadMatch,loinc:2539-5,Lactate dehydrogenase 2/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51682,"LD, Isoenzyme 3",skos:broadMatch,loinc:2542-9,Lactate dehydrogenase 3/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51683,"LD, Isoenzyme 4",skos:broadMatch,loinc:2545-2,Lactate dehydrogenase 4/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51684,"LD, Isoenzyme 5",skos:broadMatch,loinc:2548-6,Lactate dehydrogenase 5/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51685,Lidocaine,skos:broadMatch,loinc:3714-3,Lidocaine [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51686,Lip2,,,,,,,,Ambiguous name
+mimic:51687,Lipo Electrophoresis,skos:broadMatch,loinc:20510-4,Lipoprotein fractions [Interpretation] in Serum or Plasma by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51690,Lymphocytes,skos:broadMatch,loinc:736-9,Lymphocytes/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,Duplicate of itemid 51244
+mimic:51691,MCV,skos:broadMatch,loinc:787-2,MCV [Entitic volume] by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of Itemid 51250
+mimic:51695,Myoglobin,skos:broadMatch,loinc:2639-3,Myoglobin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51696,Neural Tube Defect Risk,skos:broadMatch,loinc:48803-1,Neural tube defect risk [Likelihood] in Fetus,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51698,No MD,,,,,,,,Not a lab test
+mimic:51699,Not Done,,,,,,,,Not a lab test
+mimic:51700,Np-fx,,,,,,,,Not a lab test
+mimic:51701,"Osmolality, Calculated",skos:broadMatch,loinc:18182-6,Osmolality of Serum or Plasma by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51702,Park,,,,,,,,Not a lab test
+mimic:51703,PEPgel,,,,,,,,Not a lab test
+mimic:51704,Platelet Count,skos:broadMatch,loinc:777-3,Platelets [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51265
+mimic:51705,Primidone,skos:broadMatch,loinc:3978-4,Primidone [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51707,Progesterone,skos:broadMatch,loinc:2839-9,Progesterone [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51708,Qnthbsab,skos:broadMatch,loinc:16935-9,Hepatitis B virus surface Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51709,Quantitative RPR Test,skos:broadMatch,loinc:31147-2,Reagin Ab [Titer] in Serum by RPR,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51710,Rapid Plasma Reagin Test,skos:broadMatch,loinc:20507-0,Reagin Ab [Presence] in Serum by RPR,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51712,Referred,,,,,,,,Not a lab test
+mimic:51715,Renin,skos:broadMatch,loinc:2915-7,Renin [Enzymatic activity/volume] in Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51717,Reserved,,,,,,,,Not a lab test
+mimic:51718,Reserved1,,,,,,,,Not a lab test
+mimic:51719,Reserved3,,,,,,,,Not a lab test
+mimic:51720,Reserved4,,,,,,,,Not a lab test
+mimic:51721,Reverse T3,skos:broadMatch,loinc:3052-8,Triiodothyronine (T3).reverse [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51723,Rubella,skos:broadMatch,loinc:22496-4,Rubella virus Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51727,Send Out,,,,,,,,Not a lab test
+mimic:51728,Serum B12,skos:broadMatch,loinc:2132-9,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51010
+mimic:51729,Serum B12,skos:broadMatch,loinc:2132-9,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51010
+mimic:51730,Serum Folate,skos:broadMatch,loinc:2284-8,Folate [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 50925
+mimic:51731,Single Stranded DNA,skos:broadMatch,loinc:5132-6,DNA single strand Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51738,Thyroid Binding Globulin,skos:broadMatch,loinc:3021-3,Thyroxine binding globulin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51740,Toxic Screen,skos:broadMatch,loinc:29587-3,Toxicology panel - Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51746,Transferrin Saturation,skos:broadMatch,loinc:2502-3,Iron saturation [Mass Fraction] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51747,Treponemal Antibody Test,skos:broadMatch,loinc:22587-0,Treponema pallidum Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51750,"UE3, Multiples of Median",skos:broadMatch,loinc:20466-9,Estriol (E3).unconjugated [Multiple of the median] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51751,Uncon Bil,skos:broadMatch,loinc:1971-1,Bilirubin.indirect [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 50885
+mimic:51756,White Blood Cells,skos:broadMatch,loinc:6690-2,Leukocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51300
+mimic:51757,Xxx,,,,,,,,Not a lab test
+mimic:51758,Xylose,skos:broadMatch,loinc:32347-7,Xylose [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51759,Z,,,,,,,,Not a lab test
+mimic:51760,Z,,,,,,,,Not a lab test
+mimic:51761,Zinc,skos:broadMatch,loinc:5763-8,Zinc [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51770,MDRDgfr,skos:broadMatch,loinc:77147-7,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51771,,,,,,,,,Not a lab test
+mimic:51773,RFXFRKL,skos:broadMatch,loinc:36913-2,FMR1 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51774,RFXHCV,skos:broadMatch,loinc:48159-8,Hepatitis C virus Ab Signal/Cutoff in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51775,(Albumin),skos:broadMatch,loinc:1746-7,Albumin [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51777,"Albumin, CSF",skos:broadMatch,loinc:1746-7,Albumin [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51775
+mimic:51778,Alpha-1,skos:broadMatch,loinc:13972-5,Alpha 1 globulin/Protein.total in Cerebral spinal fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51779,Alpha-2,skos:broadMatch,loinc:13975-8,Alpha 2 globulin/Protein.total in Cerebral spinal fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51780,"Amylase, CSF",skos:broadMatch,loinc:14389-1,Amylase [Enzymatic activity/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51781,Beta,skos:broadMatch,loinc:13976-6,Beta globulin/Protein.total in Cerebral spinal fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51782,"Bicarbonate, CSF",skos:broadMatch,loinc:16460-8,Bicarbonate [Moles/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51784,"Chloride, CSF",skos:broadMatch,loinc:2070-1,Chloride [Moles/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51785,"Cholesterol, CSF",skos:broadMatch,loinc:14439-4,Cholesterol [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51786,Clostrid,skos:broadMatch,loinc:77496-8,Clostridium perfringens [Presence] in Specimen by Organism specific culture,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51787,"Creatinine, CSF",skos:broadMatch,loinc:14398-2,Creatinine [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51788,Cryptococ,skos:broadMatch,loinc:31788-3,Cryptococcus sp Ag [Presence] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51789,Fl Scan,,,,,,,,Ambiguous name
+mimic:51792,"Immunoelectrophoresis, CSF",skos:broadMatch,loinc:40685-0,Immunoelectrophoresis for Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51793,"Immunoglobulin G, CSF",skos:broadMatch,loinc:2464-6,IgG [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51794,"Immunoglobulin G, CSF",skos:broadMatch,loinc:2464-6,IgG [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51793
+mimic:51797,"Osmolality, CSF",skos:broadMatch,loinc:2696-3,Osmolality of Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51799,"PEP, CSF, Gamma Region",skos:broadMatch,loinc:2873-8,Gamma globulin [Mass/volume] in Cerebral spinal fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51800,"Potassium, CSF",skos:broadMatch,loinc:2819-1,Potassium [Moles/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51801,"Sodium, CSF",skos:broadMatch,loinc:2948-8,Sodium [Moles/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51803,"Triglycerides, CSF",skos:broadMatch,loinc:14446-9,Triglyceride [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51804,"Urea Nitrogen, CSF",skos:broadMatch,loinc:14000-4,Urea nitrogen [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51805,"Uric Acid, CSF",skos:broadMatch,loinc:13902-2,Urate [Mass/volume] in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51807,(Albumin),skos:broadMatch,loinc:1752-5,Albumin [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51808,Alpha-1,skos:broadMatch,loinc:15125-8,Alpha 1 globulin/Protein.total in Synovial fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51809,Alpha-2,skos:broadMatch,loinc:15126-6,Alpha 2 globulin/Protein.total in Synovial fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51810,Beta,skos:broadMatch,loinc:15127-4,Beta globulin/Protein.total in Synovial fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51811,"Bicarbonate,Joint Fluid",skos:broadMatch,loinc:22735-5,Bicarbonate [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51812,"Bilirubin, Total, Joint Fluid",skos:broadMatch,loinc:14423-8,Bilirubin.total [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51813,"Chloride, Joint Fluid",skos:broadMatch,loinc:32307-1,Chloride [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51814,"Cholesterol, Joint Fluid",skos:broadMatch,loinc:14443-6,Cholesterol [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51815,Clostrid,skos:broadMatch,loinc:97614-2,Clostridium perfringens [Presence] in Synovial fluid by NAA with non-probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51816,Cryptococ,skos:broadMatch,loinc:29533-7,Cryptococcus sp Ag [Presence] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51817,Fl Scan,,,,,,,,Ambiguous name
+mimic:51818,"IgG, Joint Fluid",skos:broadMatch,loinc:42601-5,Immune complex.IgG [Units/volume] in Synovial fluid by C1q binding assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51819,"Immunoelectrophoresis, Joint Fluid",skos:broadMatch,loinc:13169-8,Immunoelectrophoresis for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51820,"Osmolality, Joint Fluid",skos:broadMatch,loinc:2696-3,Osmolality of Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51821,"PEP, Joint Fluid, Gamma Region",skos:broadMatch,loinc:2875-3,Gamma globulin [Mass/volume] in Synovial fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51822,"Potassium, Joint Fluid",skos:broadMatch,loinc:14172-1,Potassium [Moles/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51823,"Sodium, Joint Fluid",skos:broadMatch,loinc:32340-2,Sodium [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51824,"Triglycerides, Joint Fluid",skos:broadMatch,loinc:14449-3,Triglyceride [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51825,"Urea Nitrogen, Joint Fluid",skos:broadMatch,loinc:14396-6,Urea nitrogen [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51826,"Uric Acid, Joint Fluid",skos:broadMatch,loinc:3085-8,Urate [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51828,Voided Specimen,,,,,,,,Not a lab test
+mimic:51829,72 Hr Fat,skos:broadMatch,loinc:2271-5,Fat [Mass/time] in 72 hour Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51830,Acid BAO,,,,,,,,Not a lab test
+mimic:51831,Acid MAO,,,,,,,,Not a lab test
+mimic:51833,"AFP, Amniotic Fluid",skos:broadMatch,loinc:1832-5,Alpha-1-Fetoprotein [Mass/volume] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51834,"AFP, Body Fluid",skos:broadMatch,loinc:11207-8,Alpha-1-Fetoprotein [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51835,(Albumi,skos:broadMatch,loinc:1747-5,Albumin [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51836,<Albumin>,skos:broadMatch,loinc:1747-5,Albumin [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51835
+mimic:51837,Alpha-1,skos:broadMatch,loinc:17812-9,Alpha 1 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51838,Alpha-2,skos:broadMatch,loinc:17814-5,Alpha 2 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51840,Beta,skos:broadMatch,loinc:17816-0,Beta globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51841,"Blood, Occult",skos:broadMatch,loinc:2335-8,Hemoglobin.gastrointestinal [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51842,Bun,skos:broadMatch,loinc:3093-2,Urea nitrogen [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51843,C. diff PCR,skos:broadMatch,loinc:61367-9,Clostridioides difficile DNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51844,C diff Toxin Antigen Assay,skos:broadMatch,loinc:6364-4,Clostridioides difficile toxin A+B [Units/volume] in Specimen by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51847,Clostrid,skos:broadMatch,loinc:20799-3,Clostridium perfringens enterotoxin [Presence] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51854,Cryptococ,skos:broadMatch,loinc:16692-6,Cryptococcus sp Ag [Presence] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51855,"DSPC, Amniotic Fluid",skos:broadMatch,loinc:30165-5,Phosphatidylcholine/Albumin [Mass Ratio] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51856,Epr,,,,,,,,Ambiguous name
+mimic:51857,Fl Scan,,,,,,,,Ambiguous name
+mimic:51858,HIV 1 Viral Load,skos:broadMatch,loinc:25836-8,HIV 1 RNA [#/volume] (viral load) in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51861,"Immunoelectrophoresis, Fluid",skos:broadMatch,loinc:13169-8,Immunoelectrophoresis for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51862,"Immunoglobulin G, Body Fluid",skos:broadMatch,loinc:15183-7,IgG [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51876,"L/S Ratio, Amniotic Fluid",skos:broadMatch,loinc:14976-5,Lecithin/Sphingomyelin [Ratio] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51880,Norovirus Genogroup I,skos:broadMatch,loinc:97525-0,Norovirus genogroup I RNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51881,Norovirus Genogroup II,skos:broadMatch,loinc:97532-6,Norovirus genogroup II RNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51882,O & P,skos:broadMatch,loinc:673-4,Ova and parasites identified in Specimen by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51887,"PEP, Body Fluid",skos:broadMatch,loinc:88698-6,Protein electrophoresis panel - Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51888,"PEP, Body Fluid, Gamma Region",skos:broadMatch,loinc:17818-6,Gamma globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51889,Phosphatidylglycerol,skos:broadMatch,loinc:2785-4,Phosphatidylglycerol [Presence] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51896,Sudan Stain,skos:broadMatch,loinc:10763-1,Microscopic observation [Identifier] in Body fluid by Sudan black stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51898,Surf/Alb,skos:broadMatch,loinc:30562-3,Surfactant/Albumin [Mass Ratio] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51897
+mimic:51900,"Uric Acid, Body Fluid",skos:broadMatch,loinc:53612-8,Urate [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51902,Vpf,,,,,,,,Ambiguous name
+mimic:51905,,,,,,,,,Not a lab test
+mimic:51906,reuse,,,,,,,,Not a lab test
+mimic:51907,reuse1,,,,,,,,Not a lab test
+mimic:51910,(Albumin),skos:broadMatch,loinc:1748-3,Albumin [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51911,Alpha-1,skos:broadMatch,loinc:17812-9,Alpha 1 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51912,Alpha-2,skos:broadMatch,loinc:17814-5,Alpha 2 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51913,Beta,skos:broadMatch,loinc:17816-0,Beta globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51914,Clostrid,skos:broadMatch,loinc:77496-8,Clostridium perfringens [Presence] in Specimen by Organism specific culture,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51915,Cryptococ,skos:broadMatch,loinc:29533-7,Cryptococcus sp Ag [Presence] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51916,Fl Scan,,,,,,,,Ambiguous name
+mimic:51917,"Immunoelectrophoresis, Pleural",skos:broadMatch,loinc:13169-8,Immunoelectrophoresis for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51918,"Immunoglobulin G, Pleural",skos:broadMatch,loinc:15183-7,IgG [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51919,"Osmolality, Pleural",skos:broadMatch,loinc:2690-6,Osmolality of Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51920,"PEP, Pleural, Gamma Region",skos:broadMatch,loinc:17818-6,Gamma globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51922,"Urea Nitrogen, Pleural",skos:broadMatch,loinc:14394-1,Urea nitrogen [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51923,"Uric Acid, Pleural",skos:broadMatch,loinc:60469-4,Urate [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51925,72 Hr Fat,skos:broadMatch,loinc:2271-5,Fat [Mass/time] in 72 hour Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51926,(Albumin),skos:broadMatch,loinc:54346-2,Albumin [Mass/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51927
+mimic:51927,"Albumin, Stool",skos:broadMatch,loinc:54346-2,Albumin [Mass/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51928,Alpha-1,skos:broadMatch,loinc:17812-9,Alpha 1 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51929,Alpha-2,skos:broadMatch,loinc:17814-5,Alpha 2 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51930,"Amylase, Stool",skos:broadMatch,loinc:32298-2,Amylase [Enzymatic activity/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51931,Beta,skos:broadMatch,loinc:17816-0,Beta globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51932,"Bilirubin, Total, Stool",skos:broadMatch,loinc:1976-0,Bilirubin.total [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51935,"Cholesterol, Stool",skos:broadMatch,loinc:32308-9,Cholesterol [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51936,Clostrid,skos:broadMatch,loinc:34712-0,Clostridioides difficile [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51937,"Creatinine, Stool",skos:broadMatch,loinc:47610-1,Creatinine [Moles/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51938,Cryptococ,skos:broadMatch,loinc:29533-7,Cryptococcus sp Ag [Presence] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51939,Fl Scan,,,,,,,,Ambiguous name
+mimic:51940,Gamma,skos:broadMatch,loinc:17818-6,Gamma globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51941,"Glucose, Stool",skos:broadMatch,loinc:51595-7,Glucose [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51942,"IgG, Stool",skos:broadMatch,loinc:15183-7,IgG [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51943,"Immunoelectrophoresis, Stool",skos:broadMatch,loinc:13169-8,Immunoelectrophoresis for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51944,"Lactate Dehydrogenase, Stool",skos:broadMatch,loinc:32324-6,Lactate dehydrogenase [Enzymatic activity/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51947,O & P,skos:broadMatch,loinc:10701-1,Ova and parasites identified in Stool by Concentration,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51948,Sudan Stain,skos:broadMatch,loinc:10753-2,Fat.microscopic observation [Identifier] in Stool by Sudan IV stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51949,"Total Protein, Stool",skos:broadMatch,loinc:47739-8,Protein [Mass/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51950,"Triglycerides, Stool",skos:broadMatch,loinc:77360-6,Triglyceride [Mass/mass] in 24 hour Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51951,"Urea Nitrogen, Stool",skos:broadMatch,loinc:3093-2,Urea nitrogen [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51952,"Uric Acid, Stool",skos:broadMatch,loinc:32343-6,Urate [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51955,,,,,,,,,Not a lab test
+mimic:51957,17-Hydroxycorticosteroids,skos:broadMatch,loinc:1666-7,17-Hydroxycorticosteroids [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51958,"17-Ketosteroids, Urine",skos:broadMatch,loinc:6766-0,17-Ketosteroids [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51959,"5-HIAA, Urine",skos:broadMatch,loinc:1695-6,5-Hydroxyindoleacetate [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51960,Aldolase,skos:broadMatch,loinc:49724-8,Aldolase [Enzymatic activity/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51961,Alpha-1,skos:broadMatch,loinc:13990-7,Alpha 1 globulin/Protein.total in Urine by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51962,Alpha-2,skos:broadMatch,loinc:13993-1,Alpha 2 globulin/Protein.total in Urine by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51963,Amylase/Creatinine Clearance,skos:broadMatch,loinc:30077-2,Amylase/Creatinine renal clearance [Ratio] in Urine and Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51964,"Amylase, Serum",skos:broadMatch,loinc:1799-6,Amylase [Enzymatic activity/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,"Conflict. Label is ""Serum"", Fluid is ""Urine"""
+mimic:51965,Beta,skos:broadMatch,loinc:13994-9,Beta globulin/Protein.total in Urine by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51968,Camp,skos:broadMatch,loinc:22712-4,Adenosine monophosphate.cyclic [Moles/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51969,"Catecholamines, Urine",skos:broadMatch,loinc:2057-8,Catecholamines [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51970,Cben,,,,,,,,Ambiguous name
+mimic:51971,Ccoc,,,,,,,,Ambiguous name
+mimic:51973,Copi,,,,,,,,Ambiguous name
+mimic:51974,"Copper, Urine",skos:broadMatch,loinc:5632-5,Copper [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51975,Coproporphyrins,skos:broadMatch,loinc:2136-0,Coproporphyrin [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51976,"Cortisol, Urine",skos:broadMatch,loinc:28550-2,Cortisol [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51977,"Creatinine, Blood",skos:broadMatch,loinc:2161-8,Creatinine [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,"Conflict. Label is ""Blood"", Fluid is ""Urine"""
+mimic:51978,DirList,,,,,,,,Not a lab test
+mimic:51979,"Estriol, Urine",skos:broadMatch,loinc:2253-3,Estriol (E3) [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51982,"Immunoelectrophoresis, Urine",skos:broadMatch,loinc:29585-7,Immunoelectrophoresis panel - Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51983,"Iron, Urine",skos:broadMatch,loinc:2499-2,Iron [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51988,O & P,skos:broadMatch,loinc:75665-0,Ova and parasites identified in Urine by Trichrome stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51990,"Phenothiazine Screen, Urine",skos:broadMatch,loinc:19670-9,Phenothiazines [Presence] in Urine by Screen method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51991,"Propoxyphene, Urine",skos:broadMatch,loinc:19141-1,Propoxyphene [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51993,Referred,,,,,,,,Not a lab test
+mimic:51995,Study Urine,,,,,,,,Not a lab test
+mimic:51997,UIFEgel,,,,,,,,Not a lab test
+mimic:51998,UPEPgel,,,,,,,,Not a lab test
+mimic:51999,Urine Amylase,skos:broadMatch,loinc:1799-6,Amylase [Enzymatic activity/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52000,Urine  Creatinine,skos:broadMatch,loinc:2161-8,Creatinine [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate ot itemid 51082
+mimic:52001,"Urine PEP, Gamma region",skos:broadMatch,loinc:13995-6,Gamma globulin/Protein.total in Urine by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52003,Uroporphyrins,skos:broadMatch,loinc:3112-0,Uroporphyrin [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52011,UTX8,,,,,,,,Ambiguous name
+mimic:52013,Vanillylmandelic Acid,skos:broadMatch,loinc:3122-9,Vanillylmandelate [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52015,Xylose,skos:broadMatch,loinc:47806-5,Xylose [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52016,Z,,,,,,,,Not a lab test
+mimic:52017,"Zinc, Urine",skos:broadMatch,loinc:40957-3,Zinc [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52021,Abz,,,,,,,,Ambiguous name
+mimic:52022,"Albumin, Blood",skos:broadMatch,loinc:1751-7,Albumin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52025,Delete,,,,,,,,Not a lab test
+mimic:52027,"Glucose, Whole Blood",skos:broadMatch,loinc:2339-0,Glucose [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52028,Hematocrit,skos:broadMatch,loinc:32354-3,Hematocrit [Volume Fraction] of Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:52029,% Ionized Calcium,skos:broadMatch,loinc:49936-8,Calcium.ionized/Calcium.total corrected for albumin in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52030,Lithium,skos:broadMatch,loinc:25461-5,Lithium [Moles/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52031,Osmolality,skos:broadMatch,loinc:2692-2,Osmolality of Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52032,P50 of Hemoglobin,skos:broadMatch,loinc:19214-6,Oxygen [Partial pressure] saturation adjusted to 0.5 in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52034,Total Calcium,skos:broadMatch,loinc:49765-1,Calcium [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52035,Total Calcium,skos:broadMatch,loinc:49765-1,Calcium [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,Duplicate of itemid 52034
+mimic:52037,WB tCO2,skos:broadMatch,loinc:20565-8,"Carbon dioxide, total [Moles/volume] in Blood",HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52038,Base Excess,skos:broadMatch,loinc:1925-7,Base excess in Arterial blood by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,No Fluid info
+mimic:52039,Calculated Bicarbonate,skos:broadMatch,loinc:1960-4,Bicarbonate [Moles/volume] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,No Fluid info
+mimic:52040,pCO2,skos:broadMatch,loinc:2019-8,Carbon dioxide [Partial pressure] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,No Fluid info
+mimic:52041,pH,skos:broadMatch,loinc:2744-1,pH of Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,No Fluid info
+mimic:52042,pO2,skos:broadMatch,loinc:2703-7,Oxygen [Partial pressure] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,No Fluid info
+mimic:52044,"Osmolality, Urine",skos:broadMatch,loinc:2695-5,Osmolality of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52045,"pH, Urine",skos:broadMatch,loinc:2756-5,pH of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52046,"Potassium, Urine",skos:broadMatch,loinc:2828-2,Potassium [Moles/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,"Duplicate of itemid 51097. Conflict. Fluid is ""Urine"" while Category is ""Blood Gas"""
+mimic:52047,"Sodium, Urine",skos:broadMatch,loinc:2955-3,Sodium [Moles/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,"Duplicate of itemid 51100. Conflict. Fluid is ""Urine"" while Category is ""Blood Gas"""
+mimic:52048,Atyps#,skos:broadMatch,loinc:35041-3,Variant lymphocytes [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52049,Bands#,skos:broadMatch,loinc:35014-0,Band form neutrophils [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52050,Basos#,skos:broadMatch,loinc:35073-6,Basophils [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52051,Blasts#,skos:broadMatch,loinc:35065-2,Blasts [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52052,Eos#,skos:broadMatch,loinc:35061-1,Eosinophils [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52053,Histio#,skos:broadMatch,loinc:35057-9,Histiocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52054,Histiocyte,skos:broadMatch,loinc:40516-7,Histiocytes/100 cells in Peritoneal fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52055,Hyperseg,skos:broadMatch,loinc:33384-9,Segmented neutrophils/100 leukocytes in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52056,Hyperseg#,skos:broadMatch,loinc:35010-8,Segmented neutrophils [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52057,Lymphs#,skos:broadMatch,loinc:35097-5,Lymphocytes [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52058,Metas#,skos:broadMatch,loinc:26476-2,Lymphocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52059,Monos#,skos:broadMatch,loinc:35027-2,Monocytes [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52060,Myelos#,skos:broadMatch,loinc:35016-5,Myelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52061,Nuc Rbcs#,skos:broadMatch,loinc:26460-6,Nucleated erythrocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52062,Plasma#,skos:broadMatch,loinc:35006-6,Plasma cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52063,Polys#,skos:broadMatch,loinc:35005-8,Polymorphonuclear cells [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52064,Promyelo#,skos:broadMatch,loinc:34996-9,Promyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52066,Voided Specimen,,,,,,,,Not a lab test
+mimic:52067,Young#,,,,,,,,Ambiguous name
+mimic:52068,24 Hr,,,,,,,,Not a lab test
+mimic:52070,Absolute CD19 Count,skos:broadMatch,loinc:8116-6,CD19 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52071,Absolute CD20 Count,skos:broadMatch,loinc:9558-8,CD20 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52072,Absolute CD56 Count,skos:broadMatch,loinc:14113-5,CD56 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52076,Acid Phosphatase Stain,skos:broadMatch,loinc:11020-5,Microscopic observation [Identifier] in Blood or Marrow by Tartrate-resistant acid phosphatase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52077,Acidserum,skos:broadMatch,loinc:3084-1,Urate [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52078,Antithrombin III,skos:broadMatch,loinc:27811-9,Antithrombin actual/normal in Platelet poor plasma by Chromogenic method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52079,ASA Tol,skos:broadMatch,loinc:3306-8,Acetylsalicylate [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52080,Asd,,,,,,,,Ambiguous name
+mimic:52081,ASD & NA-F,,,,,,,,Ambiguous name
+mimic:52082,Aspirin Reactivity,skos:broadMatch,loinc:53814-0,Platelet aggregation arachidonate induced [Units/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52083,Autohem+g,,,,,,,,Ambiguous name
+mimic:52084,Autohem-g,,,,,,,,Ambiguous name
+mimic:52085,Bleed Tm,skos:broadMatch,loinc:11067-6,Bleeding time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52086,Bleed Tm,skos:broadMatch,loinc:11067-6,Bleeding time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52089,CD30,skos:broadMatch,loinc:17137-1,CD30 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52090,CD42,skos:broadMatch,loinc:19122-1,CD42 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52091,CD52,skos:broadMatch,loinc:17172-8,CD52 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52094,CD61,skos:broadMatch,loinc:20478-4,CD61 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52095,CD62,skos:broadMatch,loinc:32855-9,CD62 cells/100 cells in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52096,Chloroacetate,skos:broadMatch,loinc:10780-5,Microscopic observation [Identifier] in Tissue by Chloracetate esterase stain,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52097,Circ Ab,skos:broadMatch,loinc:34550-4,Immunoglobulin panel [Mass/volume] - Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",0,
+mimic:52098,Clot Lysis,skos:broadMatch,loinc:3244-1,Clot Lysis [Time] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52099,Clot Retraction,skos:broadMatch,loinc:3245-8,Clot Retraction [Time] in Blood by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52100,Clot Time,skos:broadMatch,loinc:52768-9,Clot formation [Time] in Blood by Thromboelastography,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52101,Cr,skos:broadMatch,loinc:38483-4,Creatinine [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52102,Crenated Cells,skos:broadMatch,loinc:7790-9,Burr cells [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52103,Cross Imm,skos:broadMatch,loinc:34550-4,Immunoglobulin panel [Mass/volume] - Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52104,Cryoglob,skos:broadMatch,loinc:5117-7,Cryoglobulin [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52105,Direct Antiplatelet Antibodies,skos:broadMatch,loinc:24374-1,Platelet associated Ab [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52106,Donath-l,skos:broadMatch,loinc:18286-5,Donath Landsteiner Ab [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52110,DSmear,,,,,,,,Ambiguous name
+mimic:52112,Euglobulin Lysis,skos:broadMatch,loinc:3244-1,Clot Lysis [Time] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52113,Factor IX Inhibitor,skos:broadMatch,loinc:3185-6,Coagulation factor IX inhibitor [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52114,Factor VIII Antigen,skos:broadMatch,loinc:10521-3,Coagulation factor VIII Ag [Presence] in Tissue by Immune stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52115,Fibrinoge,skos:broadMatch,loinc:3255-7,Fibrinogen [Mass/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52116,Fibrinogen,skos:broadMatch,loinc:3255-7,Fibrinogen [Mass/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 52115
+mimic:52117,"Fibrinogen, Immunologic",skos:broadMatch,loinc:3256-5,Fibrinogen Ag [Mass/volume] in Platelet poor plasma by Immunoassay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52119,Fitzgerld,skos:broadMatch,loinc:3276-3,Kininogen HMW [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52120,Fitzgerld,skos:broadMatch,loinc:3276-3,Kininogen HMW [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,Duplicate of itemid 52119
+mimic:52121,Fletcher,skos:broadMatch,loinc:6005-3,Prekallikrein (Fletcher Factor) [Units/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52122,Fsp,skos:broadMatch,loinc:30226-5,Fibrin+Fibrinogen fragments [Mass/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52124,G6pd Spec,skos:broadMatch,loinc:32546-4,Glucose-6-Phosphate dehydrogenase [Enzymatic activity/mass] in Red Blood Cells,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52125,Glutathione,skos:broadMatch,loinc:2383-8,Glutathione [Mass/volume] in Red Blood Cells,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52126,Heinz Aph,skos:broadMatch,loinc:716-1,Heinz bodies [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52127,Helmet Cells,skos:broadMatch,loinc:10374-7,Helmet cells [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52128,Hemoglobin H Inclusion,skos:broadMatch,loinc:59185-9,Hemoglobin H inclusion bodies [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52130,Histiocytes,skos:broadMatch,loinc:44721-9,Histiocytes [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52133,Hmwk,skos:broadMatch,loinc:3276-3,Kininogen HMW [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52134,IG,skos:broadMatch,loinc:34550-4,Immunoglobulin panel [Mass/volume] - Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52136,Inhibitor,,,,,,,,Ambiguous name
+mimic:52137,Inh Scr,,,,,,,,Ambiguous name
+mimic:52138,Kct,skos:broadMatch,loinc:13053-4,Kaolin activated time [Units/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52139,LE Prep,skos:broadMatch,loinc:13507-9,Lupus erythematosus cells [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52140,LS,skos:broadMatch,loinc:34571-0,aPTT.lupus sensitive (LA screen),HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",0,
+mimic:52141,Malaria Smear,skos:broadMatch,loinc:32700-7,Microscopic observation [Identifier] in Blood by Malaria smear,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52142,Mean Platelet Volume,skos:broadMatch,loinc:32623-1,Platelet mean volume [Entitic volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52143,Methemalb,skos:broadMatch,loinc:17263-5,Methemalbumin [Presence] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52144,Methemoglobin,skos:broadMatch,loinc:2613-8,Methemoglobin [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52145,Mono Spot Test,skos:broadMatch,loinc:31418-7,Heterophile Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52146,Naphtol Acetate Stain,skos:broadMatch,loinc:10765-6,Microscopic observation [Identifier] in Tissue by Acetate esterase stain,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52147,NEUTX,,,,,,,,Ambiguous name
+mimic:52148,NEUTY,,,,,,,,Ambiguous name
+mimic:52149,NFletcher,skos:broadMatch,loinc:6005-3,Prekallikrein (Fletcher Factor) [Units/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52150,Non-Specific Esterase,skos:broadMatch,loinc:11016-3,Microscopic observation [Identifier] in Blood or Marrow by Esterase stain.non-specific,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52151,NRBC,skos:broadMatch,loinc:34188-3,Nucleated erythrocytes [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52152,"Osmotic Fragility, Incubated",skos:broadMatch,loinc:32862-5,Osmotic fragility [Interpretation] of Red Blood Cells--Incubated,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52153,Other Inhibitor,,,,,,,,Ambiguous name
+mimic:52154,P2Y12 Reaction Units,skos:broadMatch,loinc:49010-2,Platelet aggregation ADP induced [Units/volume] in Platelet rich plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52155,Periodic Acid Schiff Stain,skos:broadMatch,loinc:9786-5,Microscopic observation [Identifier] in Blood or Marrow by Periodic acid-Schiff stain,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52156,Peroxidase Staining,skos:broadMatch,loinc:11018-9,Microscopic observation [Identifier] in Blood or Marrow by Peroxidase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52157,Plasma Hemoglobin,skos:broadMatch,loinc:721-1,Free Hemoglobin [Mass/volume] in Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52158,Plasminogen,skos:broadMatch,loinc:5970-9,Plasminogen [Units/volume] in Platelet poor plasma by Chromogenic method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52159,Platelet Aggregation,skos:broadMatch,loinc:21027-8,Platelet aggregation [Interpretation] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52160,Prekallekrein,skos:broadMatch,loinc:13594-7,Prekallikrein (Fletcher Factor) [Presence] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52161,Problem Specimen,,,,,,,,Not a lab test
+mimic:52162,Protein S,skos:broadMatch,loinc:5892-5,Protein S [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52163,PT Control,skos:broadMatch,loinc:5901-4,Prothrombin time (PT) in Control Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52164,PT Mean,skos:broadMatch,loinc:5902-2,Prothrombin time (PT),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52165,PTT Control,skos:broadMatch,loinc:13488-2,aPTT in Control Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52166,PTT-LA,skos:broadMatch,loinc:34571-0,aPTT.lupus sensitive (LA screen),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52167,PTT mea,skos:broadMatch,loinc:5899-0,aPTT normal/actual in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52168,Pyruvate Kinase,skos:broadMatch,loinc:11227-6,Pyruvate kinase [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52169,QFib,,,,,,,,Ambiguous name
+mimic:52170,Rbc,skos:broadMatch,loinc:789-8,Erythrocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51279
+mimic:52173,Red Blood Cell Enzyme,skos:broadMatch,loinc:72695-0,Erythrocyte enzyme panel - Red Blood Cells,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52174,"Reptilase Time, Control",skos:broadMatch,loinc:5942-8,Reptilase time in Control Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52175,Ristocetin Response,skos:broadMatch,loinc:6014-5,von Willebrand factor (vWf) ristocetin cofactor actual/normal in Platelet poor plasma by Platelet aggregation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52180,STA-CLOT,skos:broadMatch,loinc:75883-9,dRVVT W excess hexagonal phospholipid (STA-StaClot confirm),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52182,Sudan Black Staining,skos:broadMatch,loinc:11019-7,Microscopic observation [Identifier] in Blood or Marrow by Sudan black B stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52183,Sulf Hgb,skos:broadMatch,loinc:4684-7,Sulfhemoglobin [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52186,Test,,,,,,,,Not a lab test
+mimic:52187,Thrombin Time,skos:broadMatch,loinc:3243-3,Thrombin time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52188,Thrombin Time Control,skos:broadMatch,loinc:5955-0,Thrombin time in Control Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52189,Thrombin Time Control,skos:broadMatch,loinc:5955-0,Thrombin time in Control Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52190,Tissue Thromboplastin Inhibitor,skos:broadMatch,loinc:50376-3,Lupus anticoagulant neutralization dilute phospholipid actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Discouraged LOINC code
+mimic:52191,Tr- Acid,,,,,,,,Ambiguous name
+mimic:52192,Trap Stain,skos:broadMatch,loinc:11020-5,Microscopic observation [Identifier] in Blood or Marrow by Tartrate-resistant acid phosphatase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52193,Viii Ag,skos:broadMatch,loinc:38521-1,Coagulation factor VIII Ag actual/normal in Platelet poor plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52194,VIII-CIE,,,,,,,,Ambiguous name
+mimic:52196,WAM Manual Diff,skos:broadMatch,loinc:57782-5,CBC W Ordered Manual Differential panel - Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52197,WAM MANUAL DIFF 2,skos:broadMatch,loinc:57782-5,CBC W Ordered Manual Differential panel - Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,Duplicate of itemid 52196
+mimic:52198,ErytFlg,skos:broadMatch,loinc:789-8,Erythrocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52199,FragFlg,skos:broadMatch,loinc:800-3,Schistocytes [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52200,PltDist,skos:broadMatch,loinc:32207-3,Platelet distribution width [Entitic volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52201,PltScat,skos:broadMatch,loinc:777-3,Platelets [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52202,PltClmp,skos:broadMatch,loinc:7796-6,Platelet clump [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52203,RBCAgg,skos:broadMatch,loinc:51638-5,Erythrocyte aggregates [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52204,RBCDist,skos:broadMatch,loinc:788-0,Erythrocyte distribution width [Ratio] by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52205,RetScat,skos:broadMatch,loinc:14196-0,Reticulocytes [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52206,RetFlg,skos:broadMatch,loinc:4679-7,Reticulocytes/100 erythrocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52207,TurbHbI,skos:broadMatch,loinc:718-7,Hemoglobin [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52208,BasoFlg,skos:broadMatch,loinc:704-7,Basophils [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52209,EosFlg,skos:broadMatch,loinc:711-2,Eosinophils [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52210,LeftShf,skos:broadMatch,loinc:30411-3,Leukocytes Left Shift [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52211,LymFlg,skos:broadMatch,loinc:731-0,Lymphocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52212,MonoFlg,skos:broadMatch,loinc:5905-5,Monocytes/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52213,NRBCFlg,skos:broadMatch,loinc:771-6,Nucleated erythrocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52214,AbnLymp,skos:broadMatch,loinc:30412-1,Abnormal lymphocytes [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52215,ATLFlg,,,,,,,,Ambiguous name
+mimic:52216,BlasFlg,skos:broadMatch,loinc:30376-8,Blasts [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52217,Bl/AbLy,,,,,,,,Ambiguous name
+mimic:52218,IG Flg,skos:broadMatch,loinc:34550-4,Immunoglobulin panel [Mass/volume] - Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52219,WBCScat,skos:broadMatch,loinc:6690-2,Leukocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52222,Atyps#,skos:broadMatch,loinc:35043-9,Variant lymphocytes [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52224,Bands#,skos:broadMatch,loinc:35015-7,Band form neutrophils [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52226,Basos#,skos:broadMatch,loinc:35072-8,Basophils [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52228,Blasts#,skos:broadMatch,loinc:35068-6,Blasts [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52229,Delete,,,,,,,,Not a lab test
+mimic:52230,Delete,,,,,,,,Not a lab test
+mimic:52231,Delete,,,,,,,,Not a lab test
+mimic:52232,Delete,,,,,,,,Not a lab test
+mimic:52233,Delete,,,,,,,,Not a lab test
+mimic:52234,Delete,,,,,,,,Not a lab test
+mimic:52235,Delete,,,,,,,,Not a lab test
+mimic:52236,Delete,,,,,,,,Not a lab test
+mimic:52237,Delete,,,,,,,,Not a lab test
+mimic:52238,Delete,,,,,,,,Not a lab test
+mimic:52239,Delete,,,,,,,,Not a lab test
+mimic:52240,Delete,,,,,,,,Not a lab test
+mimic:52241,Delete,,,,,,,,Not a lab test
+mimic:52242,Delete,,,,,,,,Not a lab test
+mimic:52243,Delete,,,,,,,,Not a lab test
+mimic:52244,Delete,,,,,,,,Not a lab test
+mimic:52245,Delete,,,,,,,,Not a lab test
+mimic:52246,Delete,,,,,,,,Not a lab test
+mimic:52247,Delete,,,,,,,,Not a lab test
+mimic:52248,Delete,,,,,,,,Not a lab test
+mimic:52249,Delete,,,,,,,,Not a lab test
+mimic:52250,Delete,,,,,,,,Not a lab test
+mimic:52251,Delete,,,,,,,,Not a lab test
+mimic:52252,Delete,,,,,,,,Not a lab test
+mimic:52253,Delete,,,,,,,,Not a lab test
+mimic:52254,Delete,,,,,,,,Not a lab test
+mimic:52255,Eos#,skos:broadMatch,loinc:34958-9,Eosinophils [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52258,Histiocyte,skos:broadMatch,loinc:20504-7,Histiocytes/100 cells in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52260,Hypersegmented Neutrophils,skos:broadMatch,loinc:26506-6,Segmented neutrophils/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52261,Hypersegmented Neutrophils #,skos:broadMatch,loinc:35011-6,Segmented neutrophils [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52265,Lymphs#,skos:broadMatch,loinc:26475-4,Lymphocytes [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52267,Macrophage#,skos:broadMatch,loinc:35038-9,Macrophages [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52269,Mesothelial cells #,skos:broadMatch,loinc:35034-8,Mesothelial cells [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52271,Metas#,skos:broadMatch,loinc:35030-6,Metamyelocytes [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52273,Monos#,skos:broadMatch,loinc:35026-4,Monocytes [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52277,NRBC#,skos:broadMatch,loinc:26459-8,Nucleated erythrocytes [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52280,Plasma#,skos:broadMatch,loinc:35006-6,Plasma cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52282,Polys#,skos:broadMatch,loinc:35001-7,Polymorphonuclear cells [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52284,Promyelocytes#,skos:broadMatch,loinc:34995-1,Promyelocytes [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52289,Young#,,,,,,,,Ambiguous name
+mimic:52290,Dna,,,,,,,,Not a lab test
+mimic:52291,Atyps#,skos:broadMatch,loinc:35044-7,Variant lymphocytes [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52292,Bands#,skos:broadMatch,loinc:35013-2,Band form neutrophils [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52293,Basos#,skos:broadMatch,loinc:35074-4,Basophils [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52294,Blasts,skos:broadMatch,loinc:33374-0,Blasts/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52295,Blasts#,skos:broadMatch,loinc:35064-5,Blasts [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52296,Eos#,skos:broadMatch,loinc:35060-3,Eosinophils [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52297,Histio#,skos:broadMatch,loinc:35057-9,Histiocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52298,Histiocyte,skos:broadMatch,loinc:40489-7,Histiocytes/100 cells in Synovial fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52299,Hypersegmented Neutrophils,skos:broadMatch,loinc:33386-4,Segmented neutrophils/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52300,Hypersegmented Neutrophils #,skos:broadMatch,loinc:35009-0,Segmented neutrophils [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52302,Lymphs#,skos:broadMatch,loinc:35049-6,Lymphocytes [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52303,Metas#,skos:broadMatch,loinc:35031-4,Metamyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52304,Monos#,skos:broadMatch,loinc:30435-2,Monocytes [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52306,Myelos#,skos:broadMatch,loinc:35016-5,Myelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52308,Plasma#,skos:broadMatch,loinc:35006-6,Plasma cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52309,Polys#,skos:broadMatch,loinc:35004-1,Polymorphonuclear cells [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52310,Promyelo#,skos:broadMatch,loinc:34996-9,Promyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52314,Young,,,,,,,,Ambiguous name
+mimic:52315,Young#,,,,,,,,Ambiguous name
+mimic:52316,Acid Phosphatase Stain,skos:broadMatch,loinc:21391-8,Microscopic observation [Identifier] in Bone by Acid phosphatase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52317,Asd,,,,,,,,Ambiguous name
+mimic:52318,Asd&na-f,,,,,,,,Ambiguous name
+mimic:52320,CD30,skos:broadMatch,loinc:51289-7,CD30 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52321,CD42,skos:broadMatch,loinc:51323-4,CD42 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52322,CD52,skos:broadMatch,loinc:42886-2,CD52 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52323,CD61,skos:broadMatch,loinc:51361-4,CD61 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52324,CD62,skos:broadMatch,loinc:32855-9,CD62 cells/100 cells in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52325,Chloroacetate Esterase,skos:broadMatch,loinc:11017-1,Microscopic observation [Identifier] in Blood or Marrow by Chloracetate esterase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52326,Naphthol Acetate Stain,skos:broadMatch,loinc:81423-6,Microscopic observation [Identifier] in Bone marrow by Acetate esterase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52327,Naphthol Butryrate,skos:broadMatch,loinc:13512-9,Microscopic observation [Identifier] in Bone marrow by Butyrate esterase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52328,Periodic Schiff Stain,skos:broadMatch,loinc:9786-5,Microscopic observation [Identifier] in Blood or Marrow by Periodic acid-Schiff stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52329,Peroxidase Stain,skos:broadMatch,loinc:11018-9,Microscopic observation [Identifier] in Blood or Marrow by Peroxidase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52330,Sudan Black Stain,skos:broadMatch,loinc:11019-7,Microscopic observation [Identifier] in Blood or Marrow by Sudan black B stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52333,Tr-acid,,,,,,,,Ambiguous name
+mimic:52334,Voided Specimen,,,,,,,,Not a lab test
+mimic:52336,Atyps#,skos:broadMatch,loinc:35045-4,Variant lymphocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52337,Bands#,skos:broadMatch,loinc:35014-0,Band form neutrophils [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52338,Basos#,skos:broadMatch,loinc:35071-0,Basophils [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52340,Blasts#,skos:broadMatch,loinc:35067-8,Blasts [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52342,CD30,skos:broadMatch,loinc:51290-5,CD30 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52343,CD42,skos:broadMatch,loinc:51324-2,CD42 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52344,CD52,skos:broadMatch,loinc:42885-4,CD52 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52345,CD55,skos:broadMatch,loinc:43935-6,CD55 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52346,CD59,skos:broadMatch,loinc:43938-0,CD59 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52347,CD61,skos:broadMatch,loinc:51362-2,CD61 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52348,CD62,skos:broadMatch,loinc:32855-9,CD62 cells/100 cells in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52349,Chloroac,skos:broadMatch,loinc:32814-6,Microscopic observation [Identifier] in Specimen by Chloracetate esterase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52350,Eos#,skos:broadMatch,loinc:35063-7,Eosinophils [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52351,Fetal Hgb,skos:broadMatch,loinc:28067-7,Hemoglobin F [Presence] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52352,FETAL LUNG MATURITY - LBC,skos:broadMatch,loinc:19114-8,Lamellar bodies [#/volume] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52353,Histiocyte#,skos:broadMatch,loinc:35057-9,Histiocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52354,Histiocytes,skos:broadMatch,loinc:35055-3,Histiocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52356,Hypersegmented Neutrophils#,skos:broadMatch,loinc:30452-7,Segmented neutrophils [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52357,Iron,skos:broadMatch,loinc:44327-5,Iron [Presence] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52359,Lymphs#,skos:broadMatch,loinc:26476-2,Lymphocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52360,Metamyelocytes#,skos:broadMatch,loinc:35031-4,Metamyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52361,Monos#,skos:broadMatch,loinc:35076-9,Monocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52362,Myelos#,skos:broadMatch,loinc:35016-5,Myelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52363,NRBC#,skos:broadMatch,loinc:26460-6,Nucleated erythrocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52364,Plasma#,skos:broadMatch,loinc:35006-6,Plasma cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52365,Polys#,skos:broadMatch,loinc:35002-5,Polymorphonuclear cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52366,Promyelocyte#,skos:broadMatch,loinc:34996-9,Promyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52367,TCR Alpha-Beta,skos:broadMatch,loinc:57409-5,CD3+TCR alpha beta+ cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52368,TCR Gamma-Delta,skos:broadMatch,loinc:57429-3,CD3+TCR gamma delta+ cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52371,Young,,,,,,,,Ambiguous name
+mimic:52372,Young#,,,,,,,,Ambiguous name
+mimic:52374,,,,,,,,,Not a lab test
+mimic:52375,Atyps#,skos:broadMatch,loinc:35042-1,Variant lymphocytes [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52376,Bands#,skos:broadMatch,loinc:35014-0,Band form neutrophils [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52377,Basos#,skos:broadMatch,loinc:35075-1,Basophils [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52378,Blasts#,skos:broadMatch,loinc:35066-0,Blasts [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52379,Eos#,skos:broadMatch,loinc:35062-9,Eosinophils [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52380,Histiocyte#,skos:broadMatch,loinc:35057-9,Histiocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52381,Histiocytes,skos:broadMatch,loinc:40519-1,Histiocytes/100 cells in Pleural fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52382,Hypersegmented  Neutrophils#,skos:broadMatch,loinc:35012-4,Segmented neutrophils [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52383,Hypersegmented Neutrophils,skos:broadMatch,loinc:33385-6,Segmented neutrophils/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52384,Lymphs#,skos:broadMatch,loinc:35098-3,Lymphocytes [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52385,Metas#,skos:broadMatch,loinc:35031-4,Metamyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52386,Monos#,skos:broadMatch,loinc:35028-0,Monocytes [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52387,Myelos#,skos:broadMatch,loinc:35016-5,Myelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52388,Plasma#,skos:broadMatch,loinc:35006-6,Plasma cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52389,Polys#,skos:broadMatch,loinc:35000-9,Polymorphonuclear cells [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52390,Promyelocytes#,skos:broadMatch,loinc:34996-9,Promyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52392,Voided Specimen,,,,,,,,Not a lab test
+mimic:52393,Young#,,,,,,,,Ambiguous name
+mimic:52394,FL1-D,,,,,,,,Ambiguous name
+mimic:52395,FL1-%FL2,,,,,,,,Ambiguous name
+mimic:52396,FL1-S,,,,,,,,Ambiguous name
+mimic:52397,FL2-D,,,,,,,,Ambiguous name
+mimic:52398,FL2-%FL1,,,,,,,,Ambiguous name
+mimic:52399,FL2-S,,,,,,,,Ambiguous name
+mimic:52400,FSC-S,,,,,,,,Ambiguous name
+mimic:52401,SSC-D,,,,,,,,Ambiguous name
+mimic:52402,SSC-S,,,,,,,,Ambiguous name
+mimic:52403,Bile,skos:broadMatch,loinc:1965-3,Bile [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52404,Fat,skos:broadMatch,loinc:2270-7,Fat [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52405,Prblm,,,,,,,,Not a lab test
+mimic:52407,WBC,skos:broadMatch,loinc:13655-6,Leukocytes [Presence] in Stool by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52408,Bacturia,skos:broadMatch,loinc:630-4,Bacteria identified in Urine by Culture,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52409,Budding Yeast,skos:broadMatch,loinc:21033-6,Yeast.budding [Presence] in Urine sediment,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52411,Hgb,skos:broadMatch,loinc:5794-3,Hemoglobin [Presence] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52412,HPF,,,,,,,,Not a lab test
+mimic:52413,Leuks,skos:broadMatch,loinc:5821-4,Leukocytes [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52414,LEUKS,skos:broadMatch,loinc:5821-4,Leukocytes [#/area] in Urine sediment by Microscopy high power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 52413
+mimic:52415,LPF,,,,,,,,Not a lab test
+mimic:52416,Myoglobin,skos:broadMatch,loinc:2640-1,Myoglobin [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52417,Pku,skos:broadMatch,loinc:29571-7,Phenylalanine [Presence] in DBS,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52418,Problem Specimen,,,,,,,,Not a lab test
+mimic:52420,ZZDUMMY,,,,,,,,Not a lab test
+mimic:52421,GATE,,,,,,,,Not a lab test
+mimic:52422,RUN,,,,,,,,Not a lab test
+mimic:52423,SKIP,,,,,,,,Not a lab test
+mimic:52434,"Chloride, Whole Blood",skos:broadMatch,loinc:41650-3,Chloride [Moles/volume] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:52442,Lactate,skos:broadMatch,loinc:2518-9,Lactate [Moles/volume] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:52452,"Potassium, Whole Blood",skos:broadMatch,loinc:32713-0,Potassium [Moles/volume] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:52455,"Sodium, Whole Blood",skos:broadMatch,loinc:32717-1,Sodium [Moles/volume] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:52548,Cryoglobulin,skos:broadMatch,loinc:5117-7,Cryoglobulin [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52562,Folate,skos:broadMatch,loinc:2284-8,Folate [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52703,"Albumin, Urine",skos:broadMatch,loinc:1753-3,Albumin [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52786,Bleeding Time,skos:broadMatch,loinc:11067-6,Bleeding time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52838,Factor II,skos:broadMatch,loinc:3289-6,Prothrombin activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52840,Factor IX,skos:broadMatch,loinc:3188-0,Coagulation factor IX activity [Units/volume] in Platelet poor plasma by Chromogenic method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52842,Factor V,skos:broadMatch,loinc:3193-0,Coagulation factor V activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52844,Factor VII,skos:broadMatch,loinc:3198-9,Coagulation factor VII activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52846,Factor VIII,skos:broadMatch,loinc:3209-4,Coagulation factor VIII activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52849,Factor X,skos:broadMatch,loinc:3218-5,Coagulation factor X activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52851,Factor XI,skos:broadMatch,loinc:3226-8,Coagulation factor XI activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52853,Factor XII,skos:broadMatch,loinc:3232-6,Coagulation factor XII activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52855,Factor XIII,skos:broadMatch,loinc:3240-9,Coagulation factor XIII coagulum dissolution [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52858,Fibrin Degradation Products,skos:broadMatch,loinc:30226-5,Fibrin+Fibrinogen fragments [Mass/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52889,Lupus Anticoagulant,skos:broadMatch,loinc:3281-3,Lupus anticoagulant [Interpretation] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52921,PT,skos:broadMatch,loinc:5902-2,Prothrombin time (PT),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52923,PTT,skos:broadMatch,loinc:3173-2,aPTT in Blood by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52929,Reptilase Time,skos:broadMatch,loinc:6683-7,Reptilase time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52934,"Reticulocyte Count, Manual",skos:broadMatch,loinc:40665-2,Reticulocytes [#/volume] in Blood by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52948,Thrombin,skos:broadMatch,loinc:3243-3,Thrombin time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53012,NRBC,skos:broadMatch,loinc:68545-3,Nucleated erythrocytes/100 leukocytes [Ratio] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53083,NRBC,skos:broadMatch,loinc:70170-6,Nucleated erythrocytes/100 cells in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53084,Alanine Aminotransferase,skos:broadMatch,loinc:1742-6,Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 50861
+mimic:53085,Albumin,skos:broadMatch,loinc:2862-1,Albumin [Mass/volume] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 50862
+mimic:53086,Alkaline Phosphatase,skos:broadMatch,loinc:6768-6,Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53087,Amylase,skos:broadMatch,loinc:1798-8,Amylase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53088,Asparate Aminotransferase,skos:broadMatch,loinc:1920-8,Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53089,"Bilirubin, Total",skos:broadMatch,loinc:1975-2,Bilirubin.total [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 50885
+mimic:53093,Gamma Glutamyltranferase,skos:broadMatch,loinc:2324-2,Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53094,HBV VL CT,skos:broadMatch,loinc:29615-2,Hepatitis B virus DNA [#/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53095,Lyme VsIE/PepC10 Antibody,skos:broadMatch,loinc:11006-4,Borrelia burgdorferi Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53096,"Protein, Total",skos:broadMatch,loinc:2885-2,Protein [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53097,COV10,,,,,,,,Ambiguous name
+mimic:53098,COV11,,,,,,,,Ambiguous name
+mimic:53099,COV12,,,,,,,,Ambiguous name
+mimic:53100,COV13,,,,,,,,Ambiguous name
+mimic:53104,"COVID-19, RAPID ANTIGEN",skos:broadMatch,loinc:94558-4,SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53105,E GENE CT,skos:broadMatch,loinc:96764-6,SARS-CoV-2 (COVID-19) E gene [Cycle Threshold #] in Respiratory specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53106,E GENE ENDPT,,,,,,,,Ambiguous name
+mimic:53107,FLUA1,,,,,,,,Ambiguous name
+mimic:53108,FLUA2,,,,,,,,Ambiguous name
+mimic:53109,FLUB1,,,,,,,,Ambiguous name
+mimic:53110,FLUB2,,,,,,,,Ambiguous name
+mimic:53111,N2 GENE CT,skos:broadMatch,loinc:94312-6,SARS-CoV-2 (COVID-19) N gene [Cycle Threshold #] in Specimen by Nucleic acid amplification using CDC primer-probe set N2,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53112,N2 GENE ENDPT,,,,,,,,Ambiguous name
+mimic:53113,Rapid Respiratory Syncytial Virus,skos:broadMatch,loinc:72885-7,Respiratory syncytial virus Ag [Presence] in Nasopharynx by Rapid immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53114,RSV1,,,,,,,,Ambiguous name
+mimic:53115,RSV2,,,,,,,,Ambiguous name
+mimic:53116,(Albumin),skos:broadMatch,loinc:1749-1,Albumin [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53117,Alpha-1,skos:broadMatch,loinc:17812-9,Alpha 1 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53118,Alpha-2,skos:broadMatch,loinc:17814-5,Alpha 2 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53119,Beta,skos:broadMatch,loinc:17816-0,Beta globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53120,Clostrid,skos:broadMatch,loinc:77496-8,Clostridium perfringens [Presence] in Specimen by Organism specific culture,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53121,Cryptococ,skos:broadMatch,loinc:29533-7,Cryptococcus sp Ag [Presence] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53122,Fl Scan,,,,,,,,Ambiguous name
+mimic:53123,"Immunoelectrophoresis, Ascites",skos:broadMatch,loinc:13169-8,Immunoelectrophoresis for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53124,"Immunoglobulin G, Ascites",skos:broadMatch,loinc:54901-4,IgG [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53125,"PEP, Ascites, Gamma Region",skos:broadMatch,loinc:17818-6,Gamma globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53126,"Uric Acid, Ascites",skos:broadMatch,loinc:32343-6,Urate [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53128,11-Deoxycorticosterone,skos:broadMatch,loinc:1656-8,11-Deoxycorticosterone [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53129,3t,skos:broadMatch,loinc:3053-6,Triiodothyronine (T3) [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:53130,4t,skos:broadMatch,loinc:3026-2,Thyroxine (T4) [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:53131,5' Nucleotidase,skos:broadMatch,loinc:1690-7,5'-Nucleotidase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53132,Absolute Lymphocyte Count,skos:broadMatch,loinc:731-0,Lymphocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51133
+mimic:53133,Absolute Neutrophil,skos:broadMatch,loinc:751-8,Neutrophils [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 52075
+mimic:53134,Absolute Other WBC,skos:broadMatch,loinc:30406-3,Leukocytes other [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53135,"Acid Phosphatase, Prostatic Fraction",skos:broadMatch,loinc:1714-5,Prostatic acid phosphatase [Enzymatic activity/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53136,Adrenocorticotrophic Hormone,skos:broadMatch,loinc:6016-0,Corticotropin IgE Ab [Units/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53137,Afp Mom,skos:broadMatch,loinc:20450-3,Alpha-1-Fetoprotein [Multiple of the median] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53138,(Albumin),skos:broadMatch,loinc:2862-1,Albumin [Mass/volume] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53139,Aldosterone,skos:broadMatch,loinc:1763-2,Aldosterone [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53140,Aldosterone,skos:broadMatch,loinc:1763-2,Aldosterone [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 53139
+mimic:53141,Alpha-1,skos:broadMatch,loinc:2865-4,Alpha 1 globulin [Mass/volume] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53142,Alpha-1-antitrypsin,skos:broadMatch,loinc:1825-9,Alpha 1 antitrypsin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53143,Alpha-2,skos:broadMatch,loinc:2868-8,Alpha 2 globulin [Mass/volume] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53145,Anti-GBM Antibody,skos:broadMatch,loinc:49774-3,Glomerular basement membrane Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53146,Anti Hav,skos:broadMatch,loinc:13951-9,Hepatitis A virus Ab [Presence] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53147,Anti Hbc,skos:broadMatch,loinc:13952-7,Hepatitis B virus core Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53148,Anti Hbe,skos:broadMatch,loinc:13953-5,Hepatitis B virus e Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53149,Anti-hbs,skos:broadMatch,loinc:5193-8,Hepatitis B virus surface Ab [Units/volume] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53150,Anti Hbs,skos:broadMatch,loinc:10900-9,Hepatitis B virus surface Ab [Presence] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53151,Anti-la,skos:broadMatch,loinc:8094-5,Sjogrens syndrome-B extractable nuclear Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53152,HIV FINAL,skos:broadMatch,loinc:22356-0,HIV 1 Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,

--- a/mimic-iv/concepts/concept_map/d_labitems_to_omop.csv
+++ b/mimic-iv/concepts/concept_map/d_labitems_to_omop.csv
@@ -1,0 +1,1624 @@
+subject_id,subject_label,predicate_id,object_id,object_label,mapping_justification,author_id,reviewer_id,confidence,comment
+mimic:51221,Hematocrit,skos:exactMatch,omop:3023314,Hematocrit [Volume Fraction] of Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:50912,Creatinine,skos:exactMatch,omop:3016723,Creatinine [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51265,Platelet Count,skos:exactMatch,omop:3024929,Platelets [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:51006,Urea Nitrogen,skos:exactMatch,omop:3013682,Urea nitrogen [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51222,Hemoglobin,skos:exactMatch,omop:3000963,Hemoglobin [Mass/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:51301,White Blood Cells,skos:exactMatch,omop:3000905,Leukocytes [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 51300
+mimic:51249,MCHC,skos:exactMatch,omop:3009744,MCHC [Mass/volume] by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:51279,Red Blood Cells,skos:exactMatch,omop:3020416,Erythrocytes [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:51250,MCV,skos:exactMatch,omop:3023599,MCV [Entitic volume] by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:51248,MCH,skos:exactMatch,omop:3012030,MCH [Entitic mass] by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:51277,RDW,skos:exactMatch,omop:3019897,Erythrocyte distribution width [Ratio] by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:50971,Potassium,skos:exactMatch,omop:3023103,Potassium [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50983,Sodium,skos:exactMatch,omop:3019550,Sodium [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50902,Chloride,skos:exactMatch,omop:3014576,Chloride [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50882,Bicarbonate,skos:exactMatch,omop:3016293,Bicarbonate [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50868,Anion Gap,skos:exactMatch,omop:3037278,Anion gap 4 in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50931,Glucose,skos:exactMatch,omop:3004501,Glucose [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50893,"Calcium, Total",skos:exactMatch,omop:3006906,Calcium [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50960,Magnesium,skos:exactMatch,omop:3001420,Magnesium [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50970,Phosphate,skos:exactMatch,omop:3011904,Phosphate [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50934,H,,,,,,,,Not a lab test
+mimic:51678,L,,,,,,,,Not a lab test
+mimic:50947,I,,,,,,,,Not a lab test
+mimic:51237,INR(PT),skos:exactMatch,omop:3022217,INR in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51274,PT,skos:exactMatch,omop:3034426,Prothrombin time (PT),HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50920,Estimated GFR (MDRD equation),skos:exactMatch,omop:46236952,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52172,RDW-SD,skos:exactMatch,omop:3015182,Erythrocyte distribution width [Entitic volume] by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50861,Alanine Aminotransferase (ALT),skos:exactMatch,omop:3006923,Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50878,Asparate Aminotransferase (AST),skos:exactMatch,omop:3013721,Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51275,PTT,skos:exactMatch,omop:3018677,aPTT in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51244,Lymphocytes,skos:exactMatch,omop:3037511,Lymphocytes/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,1,
+mimic:51256,Neutrophils,skos:exactMatch,omop:3008342,Neutrophils/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,1,
+mimic:51254,Monocytes,skos:exactMatch,omop:3011948,Monocytes/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,1,
+mimic:51146,Basophils,skos:exactMatch,omop:3013869,Basophils/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,1,
+mimic:51200,Eosinophils,skos:exactMatch,omop:3010457,Eosinophils/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,1,
+mimic:50885,"Bilirubin, Total",skos:exactMatch,omop:3024128,Bilirubin.total [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50863,Alkaline Phosphatase,skos:exactMatch,omop:3035995,Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50862,Albumin,skos:exactMatch,omop:3024561,Albumin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51486,Leukocytes,skos:exactMatch,omop:3022547,Leukocytes [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51491,pH,skos:exactMatch,omop:3022621,pH of Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 51094
+mimic:51498,Specific Gravity,skos:exactMatch,omop:3000330,Specific gravity of Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51506,Urine Appearance,skos:exactMatch,omop:3007876,Appearance of Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51508,Urine Color,skos:exactMatch,omop:3027162,Color of Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51466,Blood,skos:exactMatch,omop:3051227,Blood [Presence] in Urine by Visual,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51478,Glucose,skos:exactMatch,omop:3024629,Glucose [Mass/volume] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51492,Protein,skos:exactMatch,omop:3005897,Protein [Mass/volume] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51464,Bilirubin,skos:exactMatch,omop:3018834,Bilirubin.total [Presence] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51484,Ketone,skos:exactMatch,omop:3023539,Ketones [Mass/volume] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51487,Nitrite,skos:exactMatch,omop:3021601,Nitrite [Presence] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51514,Urobilinogen,skos:exactMatch,omop:3037072,Urobilinogen [Mass/volume] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51087,Length of Urine Collection,skos:exactMatch,omop:3016750,Collection duration of Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52033,Specimen Type,skos:exactMatch,omop:40769406,Specimen type,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50820,pH,skos:exactMatch,omop:3010421,pH of Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52075,Absolute Neutrophil Count,skos:exactMatch,omop:3013650,Neutrophils [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:52073,Absolute Eosinophil Count,skos:exactMatch,omop:3028615,Eosinophils [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,Duplicate of itemid 51199
+mimic:52074,Absolute Monocyte Count,skos:exactMatch,omop:3033575,Monocytes [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,Duplicate of itemid 51253
+mimic:51133,Absolute Lymphocyte Count,skos:exactMatch,omop:3004327,Lymphocytes [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:52069,Absolute Basophil Count,skos:exactMatch,omop:3013429,Basophils [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:50821,pO2,skos:exactMatch,omop:3027315,Oxygen [Partial pressure] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50802,Base Excess,skos:exactMatch,omop:3012501,Base excess in Blood by calculation,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50804,Calculated Total CO2,skos:exactMatch,omop:3031147,"Carbon dioxide, total [Moles/volume] in Blood by calculation",HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50818,pCO2,skos:exactMatch,omop:3013290,Carbon dioxide [Partial pressure] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50813,Lactate,skos:exactMatch,omop:3047181,Lactate [Moles/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51493,RBC,skos:exactMatch,omop:3035124,Erythrocytes [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51516,WBC,skos:exactMatch,omop:3035583,Leukocytes [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51463,Bacteria,skos:exactMatch,omop:3025255,Bacteria [#/area] in Urine sediment by Microscopy high power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51476,Epithelial Cells,skos:exactMatch,omop:3010189,Epithelial cells [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51519,Yeast,skos:exactMatch,omop:3037244,Yeast [#/area] in Urine sediment by Microscopy high power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50954,Lactate Dehydrogenase (LD),skos:closeMatch,omop:3016436,Lactate dehydrogenase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Discouraged LOINC code
+mimic:52135,Immature Granulocytes,skos:exactMatch,omop:3050479,Immature granulocytes/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51003,Troponin T,skos:exactMatch,omop:3019800,Troponin T.cardiac [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51512,Urine Mucous,skos:exactMatch,omop:3006175,Mucus [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50993,Thyroid Stimulating Hormone,skos:exactMatch,omop:3009201,Thyrotropin [Units/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50933,Green Top Hold (plasma),,,,,,,,Not a lab test
+mimic:50910,Creatine Kinase (CK),skos:exactMatch,omop:3007220,Creatine kinase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50808,Free Calcium,skos:exactMatch,omop:3021119,Calcium.ionized [Moles/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50887,Blue Top Hold,,,,,,,,Not a lab test
+mimic:51266,Platelet Smear,skos:exactMatch,omop:3033641,Platelet adequacy [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50907,"Cholesterol, Total",skos:exactMatch,omop:3027114,Cholesterol [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51000,Triglycerides,skos:exactMatch,omop:3022192,Triglyceride [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50822,"Potassium, Whole Blood",skos:exactMatch,omop:3005456,Potassium [Moles/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50904,"Cholesterol, HDL",skos:exactMatch,omop:3007070,Cholesterol in HDL [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50903,Cholesterol Ratio (Total/HDL),skos:exactMatch,omop:3011163,Cholesterol.total/Cholesterol in HDL [Mass Ratio] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51137,Anisocytosis,skos:exactMatch,omop:3038691,Anisocytosis [Presence] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51267,Poikilocytosis,skos:exactMatch,omop:3011368,Poikilocytosis [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50956,Lipase,skos:exactMatch,omop:3004905,Lipase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50955,Light Green Top Hold,,,,,,,,Not a lab test
+mimic:51246,Macrocytes,skos:exactMatch,omop:3005707,Macrocytes [Presence] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51268,Polychromasia,skos:exactMatch,omop:3011987,Polychromasia [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51252,Microcytes,skos:exactMatch,omop:3025639,Microcytes [Presence] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50911,"Creatine Kinase, MB Isoenzyme",skos:exactMatch,omop:3005785,Creatine kinase.MB [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51233,Hypochromia,skos:exactMatch,omop:3021303,Hypochromia [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50852,% Hemoglobin A1c,skos:exactMatch,omop:3004410,Hemoglobin A1c/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50905,"Cholesterol, LDL, Calculated",skos:exactMatch,omop:3028288,Cholesterol in LDL [Mass/volume] in Serum or Plasma by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51144,Bands,skos:exactMatch,omop:3004809,Band form neutrophils/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50809,Glucose,skos:exactMatch,omop:3000483,Glucose [Mass/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51251,Metamyelocytes,skos:exactMatch,omop:3002179,Metamyelocytes/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51255,Myelocytes,skos:exactMatch,omop:3017181,Myelocytes/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51143,Atypical Lymphocytes,skos:exactMatch,omop:3013498,Variant lymphocytes/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51613,eAG,skos:exactMatch,omop:3005131,Glucose mean value [Mass/volume] in Blood Estimated from glycated hemoglobin,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51082,"Creatinine, Urine",skos:exactMatch,omop:3017250,Creatinine [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50817,Oxygen Saturation,skos:exactMatch,omop:3013502,Oxygen saturation in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50979,Red Top Hold,,,,,,,,Not a lab test
+mimic:50976,"Protein, Total",skos:exactMatch,omop:3020630,Protein [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51103,Uhold,,,,,,,,Not a lab test
+mimic:50812,Intubated,,,,,,,,Not a lab test
+mimic:50924,Ferritin,skos:exactMatch,omop:3001122,Ferritin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51007,Uric Acid,skos:exactMatch,omop:3037556,Urate [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51107,"Urine tube, held",,,,,,,,Not a lab test
+mimic:50930,Globulin,skos:exactMatch,omop:3021886,Globulin [Mass/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50889,C-Reactive Protein,skos:exactMatch,omop:3020460,C reactive protein [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50952,Iron,skos:exactMatch,omop:3002400,Iron [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51260,Ovalocytes,skos:exactMatch,omop:3027920,Ovalocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50824,"Sodium, Whole Blood",skos:exactMatch,omop:3000285,Sodium [Moles/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50810,"Hematocrit, Calculated",skos:exactMatch,omop:3050746,Hematocrit [Volume Fraction] of Blood by Estimated,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50811,Hemoglobin,skos:exactMatch,omop:3000963,Hemoglobin [Mass/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51214,"Fibrinogen, Functional",skos:exactMatch,omop:3016407,Fibrinogen [Mass/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51482,Hyaline Casts,skos:exactMatch,omop:3022509,Hyaline casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50998,Transferrin,skos:exactMatch,omop:3004789,Transferrin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50953,"Iron Binding Capacity, Total",skos:exactMatch,omop:3021044,Iron binding capacity [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51010,Vitamin B12,skos:exactMatch,omop:3000593,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50825,Temperature,skos:exactMatch,omop:3020891,Body temperature,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50995,"Thyroxine (T4), Free",skos:exactMatch,omop:3008598,Thyroxine (T4) free [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51009,Vancomycin,skos:exactMatch,omop:3005715,Vancomycin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50986,tacroFK,skos:exactMatch,omop:3026250,Tacrolimus [Mass/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51218,Granulocyte Count,skos:exactMatch,omop:3035715,Granulocytes [#/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50883,"Bilirubin, Direct",skos:exactMatch,omop:3027597,Bilirubin.direct [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51102,"Total Protein, Urine",skos:exactMatch,omop:3037121,Protein [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50922,Ethanol,skos:exactMatch,omop:3025643,Ethanol [Mass/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50884,"Bilirubin, Indirect",skos:exactMatch,omop:3007359,Bilirubin.indirect [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50856,Acetaminophen,skos:exactMatch,omop:3002617,Acetaminophen [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50981,Salicylate,skos:exactMatch,omop:3000787,Salicylates [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50806,"Chloride, Whole Blood",skos:exactMatch,omop:3018572,Chloride [Moles/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50999,Tricyclic Antidepressant Screen,skos:exactMatch,omop:21494637,Tricyclic antidepressants [Presence] in Blood by Screen method,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50867,Amylase,skos:exactMatch,omop:3016771,Amylase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51085,"HCG, Urine, Qualitative",skos:exactMatch,omop:3018954,Choriogonadotropin (pregnancy test) [Presence] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50919,EDTA Hold,,,,,,,,Not a lab test
+mimic:51092,"Opiate Screen, Urine",skos:exactMatch,omop:3015208,Opiates [Presence] in Urine by Screen method,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51079,"Cocaine, Urine",skos:exactMatch,omop:3016879,Cocaine [Presence] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51075,"Benzodiazepine Screen, Urine",skos:exactMatch,omop:3007682,Benzodiazepines [Presence] in Urine by Screen method,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51071,"Amphetamine Screen, Urine",skos:exactMatch,omop:3000144,Amphetamine [Presence] in Urine by Screen method,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51090,"Methadone, Urine",skos:exactMatch,omop:3036180,Methadone [Presence] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51074,"Barbiturate Screen, Urine",skos:exactMatch,omop:3005058,Barbiturates [Presence] in Urine by Screen method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50853,25-OH Vitamin D,skos:exactMatch,omop:3020149,25-hydroxyvitamin D3 [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51099,Protein/Creatinine Ratio,skos:exactMatch,omop:3001582,Protein/Creatinine [Mass Ratio] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51296,Teardrop Cells,skos:exactMatch,omop:3000456,Dacrocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50880,Benzodiazepine Screen,skos:exactMatch,omop:3031951,Benzodiazepines [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50879,Barbiturate Screen,skos:exactMatch,omop:3003132,"Barbiturates [Presence] in Serum, Plasma or Blood",HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50816,Oxygen,skos:exactMatch,omop:3020716,Inhaled oxygen concentration,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51257,Nucleated Red Cells,skos:exactMatch,omop:40761514,Nucleated erythrocytes/100 leukocytes [Ratio] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",1,
+mimic:50963,NTproBNP,skos:exactMatch,omop:3029187,Natriuretic peptide.B prohormone N-Terminal [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51100,"Sodium, Urine",skos:exactMatch,omop:3003181,Sodium [Moles/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51501,Transitional Epithelial Cells,skos:exactMatch,omop:3035851,Transitional cells [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50941,Hepatitis B Surface Antigen,skos:exactMatch,omop:3019510,Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50943,Hepatitis C Virus Antibody,skos:exactMatch,omop:3013801,Hepatitis C virus Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51288,Sedimentation Rate,skos:exactMatch,omop:3013707,Erythrocyte sedimentation rate by Westergren method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50944,HIV Antibody,skos:exactMatch,omop:3037274,HIV 1 Ab [Units/volume] in Serum or Plasma by Immunoassay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50974,Prostate Specific Antigen,skos:exactMatch,omop:3013603,Prostate specific Ag [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51287,Schistocytes,skos:exactMatch,omop:3019880,Schistocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51069,"Albumin, Urine",skos:exactMatch,omop:3000034,Microalbumin [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50819,PEEP,skos:exactMatch,omop:3022875,Positive end expiratory pressure setting Ventilator,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50828,Ventilator,skos:exactMatch,omop:3004921,Ventilation mode Ventilator,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51070,"Albumin/Creatinine, Urine",skos:exactMatch,omop:3002827,Microalbumin/Creatinine [Mass Ratio] in 24 hour Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50827,Ventilation Rate,skos:exactMatch,omop:21492234,Ventilation rate by Carbon dioxide measurement,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:50940,Hepatitis B Surface Antibody,skos:exactMatch,omop:3017797,Hepatitis B virus surface Ab [Presence] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50925,Folate,skos:exactMatch,omop:3036987,Folate [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51093,"Osmolality, Urine",skos:exactMatch,omop:3026782,Osmolality of Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50965,Parathyroid Hormone,skos:exactMatch,omop:3000067,Parathyrin.intact [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50826,Tidal Volume,skos:exactMatch,omop:3012410,Tidal volume setting Ventilator,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51283,"Reticulocyte Count, Automated",skos:exactMatch,omop:40763528,Reticulocytes [#/volume] in Blood by Automated count,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,"Conflict. Label is ""Count"", Unit is ""%"""
+mimic:50950,Immunoglobulin G,skos:exactMatch,omop:3005719,IgG [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50935,Haptoglobin,skos:exactMatch,omop:3012336,Haptoglobin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50975,Protein Electrophoresis,skos:exactMatch,omop:3035956,Protein Fractions [Interpretation] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50949,Immunoglobulin A,skos:exactMatch,omop:3007164,IgA [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50964,"Osmolality, Measured",skos:exactMatch,omop:3008295,Osmolality of Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51097,"Potassium, Urine",skos:exactMatch,omop:3016038,Potassium [Moles/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50900,Carcinoembyronic Antigen (CEA),skos:exactMatch,omop:3003785,Carcinoembryonic Ag [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50906,"Cholesterol, LDL, Measured",skos:exactMatch,omop:3009966,Cholesterol in LDL [Mass/volume] in Serum or Plasma by Direct assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51078,"Chloride, Urine",skos:exactMatch,omop:3007733,Chloride [Moles/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50942,Hepatitis B Virus Core Antibody,skos:exactMatch,omop:3036282,Hepatitis B virus core Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50951,Immunoglobulin M,skos:exactMatch,omop:3028026,IgM [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50946,Human Chorionic Gonadotropin,skos:exactMatch,omop:3018171,Choriogonadotropin [Units/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51104,"Urea Nitrogen, Urine",skos:exactMatch,omop:3011965,Urea nitrogen [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52111,Echinocytes,skos:exactMatch,omop:3005854,Burr cells [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51462,Amorphous Crystals,skos:exactMatch,omop:40763395,Crystals.amorphous [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51989,Oxycodone,skos:exactMatch,omop:3000068,oxyCODONE [Presence] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50864,Alpha-Fetoprotein,skos:exactMatch,omop:3009306,Alpha-1-Fetoprotein [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51733,STX2,,,,,,,,Ambiguous name
+mimic:51176,"CD3 Cells, Percent",skos:exactMatch,omop:3022533,CD3 cells/100 cells in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 51174
+mimic:51734,STX3,,,,,,,,Ambiguous name
+mimic:52007,UTX4,,,,,,,,Ambiguous name
+mimic:51180,"CD4 Cells, Percent",skos:exactMatch,omop:3014037,CD3+CD4+ (T4 helper) cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51194,"CD8 Cells, Percent",skos:exactMatch,omop:3007449,CD3+CD8+ (T8 suppressor cells) cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52004,UTX1,,,,,,,,Ambiguous name
+mimic:52006,UTX3,,,,,,,,Ambiguous name
+mimic:52008,UTX5,,,,,,,,Ambiguous name
+mimic:52010,UTX7,,,,,,,,Ambiguous name
+mimic:51732,STX1,,,,,,,,Ambiguous name
+mimic:51737,STX6,,,,,,,,Ambiguous name
+mimic:52005,UTX2,,,,,,,,Ambiguous name
+mimic:50873,Anti-Nuclear Antibody,skos:exactMatch,omop:3004616,Nuclear Ab [Presence] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51131,Absolute CD4 Count,skos:exactMatch,omop:3028167,CD3+CD4+ (T4 helper) cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51130,Absolute CD3 Count,skos:exactMatch,omop:3011412,CD3 cells [#/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51132,Absolute CD8 Count,skos:exactMatch,omop:3001405,CD3+CD8+ (T8 suppressor cells) cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51181,CD4/CD8 Ratio,skos:exactMatch,omop:40757349,CD3+CD4+ (T4 helper) cells/CD3+CD8+ (T8 suppressor cells) cells [# Ratio] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51245,"Lymphocytes, Percent",skos:exactMatch,omop:3037511,Lymphocytes/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51244
+mimic:51300,WBC Count,skos:exactMatch,omop:3000905,Leukocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,1,
+mimic:52769,Absolute Lymphocyte Count,skos:exactMatch,omop:3004327,Lymphocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51133
+mimic:52009,UTX6,,,,,,,,Ambiguous name
+mimic:50909,Cortisol,skos:exactMatch,omop:3009682,Cortisol [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51564,ARCH-1,,,,,,,,Ambiguous name
+mimic:50908,CK-MB Index,skos:exactMatch,omop:3048863,Creatine kinase.MB/Creatine kinase.total [Ratio] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51706,Problem Specimen,,,,,,,,Not a lab test
+mimic:51148,Blasts,skos:exactMatch,omop:3025159,Blasts/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51282,"Reticulocyte Count, Absolute",skos:exactMatch,omop:3023520,Reticulocytes [#/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50803,"Calculated Bicarbonate, Whole Blood",skos:exactMatch,omop:3006576,Bicarbonate [Moles/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50967,Phenytoin,skos:exactMatch,omop:3022616,Phenytoin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50915,D-Dimer,skos:exactMatch,omop:3051714,Fibrin D-dimer FEU [Mass/volume] in Platelet poor plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51657,HPE1,,,,,,,,Ambiguous name
+mimic:52171,RBC Morphology,skos:exactMatch,omop:3012764,Erythrocyte morphology finding [Identifier] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51663,HPE7,,,,,,,,Ambiguous name
+mimic:50994,Thyroxine (T4),skos:exactMatch,omop:3016991,Thyroxine (T4) [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52023,Assist/Control,,,,,,,,Not a lab test
+mimic:51294,Target Cells,skos:exactMatch,omop:3025616,Target cells [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50914,Cyclosporin,skos:exactMatch,omop:3010375,cycloSPORINE [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51098,"Prot. Electrophoresis, Urine",skos:exactMatch,omop:3007822,Protein Fractions [Interpretation] in Urine by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51001,Triiodothyronine (T3),skos:exactMatch,omop:3010340,Triiodothyronine (T3) [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51658,HPE2,,,,,,,,Ambiguous name
+mimic:51518,WBC Clumps,skos:exactMatch,omop:40770446,Leukocyte clumps [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51865,Influenza A by PCR,skos:exactMatch,omop:3044938,Influenza virus A RNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51864
+mimic:51873,Influenza B by PCR,skos:exactMatch,omop:3038288,Influenza virus B RNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51872
+mimic:50937,Hepatitis A Virus Antibody,skos:exactMatch,omop:3035456,Hepatitis A virus Ab [Presence] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50988,Testosterone,skos:exactMatch,omop:3008893,Testosterone [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52264,Lymphs,skos:exactMatch,omop:3020951,Lymphocytes/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52272,Monocytes,skos:exactMatch,omop:3037577,Monocytes/100 leukocytes in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52281,Polys,skos:exactMatch,omop:3022356,Polymorphonuclear cells/100 leukocytes in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52286,"Total Nucleated Cells, CSF",skos:exactMatch,omop:40761570,Nucleated cells [#/volume] in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52285,"RBC, CSF",skos:exactMatch,omop:3027475,Erythrocytes [#/volume] in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51292,Spherocytes,skos:exactMatch,omop:3005481,Spherocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51752,Voided Specimen,,,,,,,,Not a lab test
+mimic:50927,Gamma Glutamyltransferase,skos:exactMatch,omop:3026910,Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51659,HPE3,,,,,,,,Ambiguous name
+mimic:50996,"Tissue Transglutaminase Ab, IgA",skos:exactMatch,omop:3019050,Tissue transglutaminase IgA Ab [Units/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51469,Calcium Oxalate Crystals,skos:exactMatch,omop:3006490,Calcium oxalate crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51479,Granular Casts,skos:exactMatch,omop:3011483,Granular casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51625,Free Kappa,skos:exactMatch,omop:3034860,Kappa light chains.free [Mass/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51627,Free Lambda,skos:exactMatch,omop:3047169,Lambda light chains.free [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51626,Free Kappa/Free Lambda Ratio,skos:exactMatch,omop:3053209,Kappa light chains.free/Lambda light chains.free [Mass Ratio] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51219,H/O Smear,skos:broadMatch,omop:3018760,Blood smear finding [Identifier] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51197,Elliptocytes,skos:exactMatch,omop:3000493,Elliptocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50892,CA-125,skos:exactMatch,omop:3037551,Cancer Ag 125 [Units/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51145,Basophilic Stippling,skos:exactMatch,omop:3026904,Basophilic stippling [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51802,"Total Protein, CSF",skos:exactMatch,omop:3019473,Protein [Mass/volume] in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50823,Required O2,skos:exactMatch,omop:3020716,Inhaled oxygen concentration,HumanCurated,orcid:0000-0002-9348-9284,orcid:0000-0001-8822-1884,,
+mimic:50801,Alveolar-arterial Gradient,skos:exactMatch,omop:3007913,Alveolar-arterial oxygen Partial pressure difference,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51790,"Glucose, CSF",skos:exactMatch,omop:3022548,Glucose [Mass/volume] in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51736,STX5,,,,,,,,Ambiguous name
+mimic:51735,STX4,,,,,,,,Ambiguous name
+mimic:50891,C4,skos:exactMatch,omop:3017766,Complement C4 [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51134,Acanthocytes,skos:exactMatch,omop:3019416,Acanthocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50917,Digoxin,skos:exactMatch,omop:3011335,Digoxin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51008,Valproic Acid,skos:exactMatch,omop:3016201,Valproate [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51116,Lymphocytes,skos:exactMatch,omop:3004437,Lymphocytes/100 leukocytes in Peritoneal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51120,Monocytes,skos:exactMatch,omop:3033483,Monocytes/100 leukocytes in Peritoneal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51125,Polys,skos:exactMatch,omop:3008838,Polymorphonuclear cells/100 leukocytes in Peritoneal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52065,"Total Nucleated Cells, Ascites",skos:exactMatch,omop:3040145,Nucleated cells [#/volume] in Peritoneal fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51127,"RBC, Ascites",skos:exactMatch,omop:3009613,Erythrocytes [#/volume] in Peritoneal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50890,C3,skos:exactMatch,omop:3000620,Complement C3 [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50978,Rapamycin,skos:exactMatch,omop:3021374,Sirolimus [Mass/volume] in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51089,Marijuana,skos:exactMatch,omop:3028064,Tetrahydrocannabinol [Presence] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50980,Rheumatoid Factor,skos:exactMatch,omop:3021614,Rheumatoid factor [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51108,Urine Volume,skos:exactMatch,omop:3036603,Volume of Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51094,pH,skos:exactMatch,omop:3015736,pH of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50898,Cancer Antigen 27.29,skos:exactMatch,omop:3013520,Cancer Ag 27-29 [Units/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50973,Prolactin,skos:exactMatch,omop:3004722,Prolactin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51117,Macrophage,skos:exactMatch,omop:3041635,Macrophages/100 leukocytes in Peritoneal fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Manual count only
+mimic:51259,Other Cells,skos:exactMatch,omop:3013727,Leukocytes other/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51269,Promyelocytes,skos:exactMatch,omop:3011587,Promyelocytes/100 leukocytes in Blood by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50815,O2 Flow,skos:exactMatch,omop:3005629,Inhaled oxygen flow rate,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50948,Immunofixation,skos:exactMatch,omop:3037756,Immunofixation for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51196,D-Dimer,skos:exactMatch,omop:3051714,Fibrin D-dimer FEU [Mass/volume] in Platelet poor plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 50915
+mimic:50926,Follicle Stimulating Hormone,skos:exactMatch,omop:3023323,Follitropin [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51846,Chlamydia trachomatis,skos:exactMatch,omop:3043310,Chlamydia trachomatis rRNA [Presence] in Specimen by NAA with probe detection,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51879,Neisseria gonorrhoeae,skos:exactMatch,omop:3045028,Neisseria gonorrhoeae rRNA [Presence] in Specimen by NAA with probe detection,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51903,PAN1,,,,,,,,Ambiguous name
+mimic:51067,24 hr Creatinine,skos:exactMatch,omop:3004239,Creatinine [Mass/time] in 24 hour Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50881,Beta-2 Microglobulin,skos:exactMatch,omop:3013201,Beta-2-Microglobulin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51118,Mesothelial Cell,skos:exactMatch,omop:3024271,Mesothelial cells/100 leukocytes in Peritoneal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50895,Calculated TBG,skos:exactMatch,omop:3017523,Thyroxine (T4)/Thyroxine binding globulin [Mass Ratio] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51005,Uptake Ratio,skos:exactMatch,omop:3021717,Triiodothyronine resin uptake (T3RU) in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50896,Calculated Thyroxine (T4) Index,skos:exactMatch,omop:3000551,Thyroxine (T4) free index in Serum or Plasma by calculation,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52391,"Total Nucleated Cells, Pleural",skos:narrowMatch,omop:3041079,Nucleated cells [#/volume] in Pleural fluid by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51446,Lymphocytes,skos:exactMatch,omop:3005532,Lymphocytes/100 leukocytes in Pleural fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51450,Monos,skos:exactMatch,omop:3043387,Monocytes/100 leukocytes in Pleural fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51455,Polys,skos:exactMatch,omop:3026051,Polymorphonuclear cells/100 leukocytes in Pleural fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50874,"Anti-Nuclear Antibody, Titer",skos:exactMatch,omop:3002971,Nuclear Ab [Titer] in Serum by Immunofluorescence,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51054,"Lactate Dehydrogenase, Pleural",skos:closeMatch,omop:3015054,Lactate dehydrogenase [Enzymatic activity/volume] in Pleural fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Discouraged LOINC code
+mimic:51059,"Total Protein, Pleural",skos:exactMatch,omop:3003434,Protein [Mass/volume] in Pleural fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50957,Lithium,skos:exactMatch,omop:3024666,Lithium [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50918,Double Stranded DNA,skos:exactMatch,omop:3012718,DNA double strand Ab [Presence] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,5718 labevents have U/mL as unit of measurement (wrong)
+mimic:50849,"Total Protein, Ascites",skos:exactMatch,omop:3002331,Protein [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52018,PAN1,,,,,,,,Ambiguous name
+mimic:51972,Chlamydia trachomatis,skos:exactMatch,omop:3007813,Chlamydia trachomatis [Presence] in Urine sediment by Organism specific culture,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51986,Neisseria gonorrhoeae,skos:exactMatch,omop:40763311,Neisseria gonorrhoeae rRNA [Presence] in Urine by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50932,Gray Top Hold (plasma),,,,,,,,Not a lab test
+mimic:50982,Sex Hormone Binding Globulin,skos:exactMatch,omop:3004248,Sex hormone binding globulin [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51497,Renal Epithelial Cells,skos:exactMatch,omop:3015023,Epithelial cells.renal [#/area] in Urine sediment by Microscopy high power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51147,Bite Cells,skos:exactMatch,omop:3005686,Bite cells [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51457,"RBC, Pleural",skos:exactMatch,omop:3028308,Erythrocytes [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50866,Ammonia,skos:exactMatch,omop:3011958,Ammonia [Moles/volume] in Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51053,"Glucose, Pleural",skos:exactMatch,omop:3003403,Glucose [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51474,Eosinophils,skos:exactMatch,omop:3037579,Eosinophils [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50894,Calculated Free Testosterone,skos:exactMatch,omop:36032269,Testosterone Free [Moles/volume] in Serum or Plasma by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50877,Anti-Thyroglobulin Antibodies,skos:exactMatch,omop:3025547,Thyroglobulin Ab [Units/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51598,Cytomegalovirus Viral Load,skos:exactMatch,omop:40757337,Cytomegalovirus DNA [Log #/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50872,Anti-Neutrophil Cytoplasmic Antibody,skos:exactMatch,omop:3009628,Neutrophil cytoplasmic Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50876,Anti-Smooth Muscle Antibody,skos:exactMatch,omop:3005932,Smooth muscle Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51086,"Immunofixation, Urine",skos:exactMatch,omop:3017704,Immunofixation for Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51660,HPE4,,,,,,,,Ambiguous name
+mimic:52312,"Total Nucleated Cells, Joint",skos:exactMatch,omop:3039497,Nucleated cells [#/volume] in Synovial fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51375,Lymphocytes,skos:exactMatch,omop:3003329,Lymphocytes/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51379,Monocytes,skos:exactMatch,omop:3009361,Monocytes/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51382,Polys,skos:exactMatch,omop:3006571,Polymorphonuclear cells/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50835,"Albumin, Ascites",skos:exactMatch,omop:3026692,Albumin [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50871,Anti-Mitochondrial Antibody,skos:exactMatch,omop:3005277,Mitochondria Ab [Presence] in Serum by Immunofluorescence,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51240,Large Platelets,skos:exactMatch,omop:3034118,Platelets Large [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50961,Methotrexate,skos:exactMatch,omop:3017115,Methotrexate [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52036,Voided Specimen,,,,,,,,Not a lab test
+mimic:50805,Carboxyhemoglobin,skos:exactMatch,omop:3023081,Carboxyhemoglobin/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50958,Luteinizing Hormone,skos:exactMatch,omop:3009214,Lutropin [Units/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51447,Macrophages,skos:exactMatch,omop:3039528,Macrophages/100 leukocytes in Pleural fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Manual count only
+mimic:51373,"Joint Crystals, Number",skos:broadMatch,omop:3050238,Crystals [Presence] in Synovial fluid by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51383,"RBC, Joint Fluid",skos:exactMatch,omop:3010144,Erythrocytes [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51216,Fragmented Cells,skos:exactMatch,omop:3028468,Fragments [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51224,Hemoglobin C,skos:exactMatch,omop:3001258,Hemoglobin C/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51226,Hemogloblin A,skos:exactMatch,omop:3020428,Hemoglobin A/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51227,Hemogloblin S,skos:exactMatch,omop:3005081,Hemoglobin S/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50831,pH,skos:closeMatch,omop:3018672,pH of Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas"""
+mimic:51424,Immunophenotyping,skos:broadMatch,omop:40758359,Immunophenotyping study,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:50938,Hepatitis A Virus IgM Antibody,skos:exactMatch,omop:3013327,Hepatitis A virus IgM Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51513,Urine Specimen Type,skos:exactMatch,omop:3025954,Urinalysis specimen collection method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50992,Thyroid Peroxidase Antibodies,skos:exactMatch,omop:3027238,Thyroperoxidase Ab [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50814,Methemoglobin,skos:exactMatch,omop:3007930,Methemoglobin/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50842,"Glucose, Ascites",skos:exactMatch,omop:3002240,Glucose [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51427,Lymphocytes,skos:exactMatch,omop:3028079,Lymphocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51431,Monos,skos:exactMatch,omop:3038104,Monocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51436,Polys,skos:exactMatch,omop:3025450,Polymorphonuclear cells/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50991,Thyroglobulin,skos:exactMatch,omop:3036535,Thyroglobulin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51338,Immunophenotyping,skos:broadMatch,omop:40758359,Immunophenotyping study,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52220,wbcp,skos:broadMatch,omop:3013727,Leukocytes other/100 leukocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51046,"Albumin, Pleural",skos:exactMatch,omop:3011544,Albumin [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51236,Inpatient Hematology/Oncology Smear,skos:broadMatch,omop:3018760,Blood smear finding [Identifier] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51077,"Calcium, Urine",skos:exactMatch,omop:3006661,Calcium [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52425,XUCU,,,,,,,,Ambiguous name
+mimic:51243,Lupus Anticoagulant,skos:broadMatch,omop:3027184,Lupus anticoagulant [Interpretation] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51051,"Cholesterol, Pleural",skos:exactMatch,omop:3033364,Cholesterol [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51150,Blood Parasite Smear,skos:exactMatch,omop:37019529,Parasite [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52024,"Creatinine, Whole Blood",skos:exactMatch,omop:3051825,Creatinine [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51213,Fibrin Degradation Products,skos:exactMatch,omop:3000401,Fibrin+Fibrinogen fragments [Mass/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51651,Hepatitis C Viral Load,skos:exactMatch,omop:3034868,Hepatitis C virus RNA [log units/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51448,Mesothelial Cells,skos:exactMatch,omop:3028029,Mesothelial cells/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51231,Howell-Jolly Bodies,skos:exactMatch,omop:3002620,Howell-Jolly bodies [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51068,24 hr Protein,skos:exactMatch,omop:3020876,Protein [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51654,HIV 1 Viral Load,skos:exactMatch,omop:3026532,HIV 1 RNA [Log #/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52026,Estimated GFR (MDRD equation),skos:exactMatch,omop:46235172,Glomerular filtration rate/1.73 sq M.predicted by Creatinine-based formula (MDRD) in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51228,Heparin,skos:exactMatch,omop:40769146,Heparin unfractionated [Units/volume] in Platelet poor plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50939,"Hepatitis B Core Antibody, IgM",skos:exactMatch,omop:3013527,Hepatitis B virus core IgM Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52014,Voided Specimen,,,,,,,,Not a lab test
+mimic:50843,"Lactate Dehydrogenase, Ascites",skos:closeMatch,omop:3008581,Lactate dehydrogenase [Enzymatic activity/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Discouraged LOINC code
+mimic:50966,Phenobarbital,skos:exactMatch,omop:3025411,PHENobarbital [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51748,Treponema pallidum (Syphilis) Ab,skos:exactMatch,omop:3019832,Treponema pallidum Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52266,Macrophage,skos:exactMatch,omop:3028502,Macrophages/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51749,Treponema pallidum (syphilis) value,skos:exactMatch,omop:3015378,Treponema pallidum Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51225,Hemoglobin F,skos:exactMatch,omop:3018738,Hemoglobin F/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 51212
+mimic:51428,Macrophage,skos:exactMatch,omop:3024126,Macrophages/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50836,"Amylase, Ascites",skos:exactMatch,omop:3008691,Amylase [Enzymatic activity/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51284,"Reticulocyte Count, Manual",skos:exactMatch,omop:3041154,Reticulocytes [#/volume] in Blood by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,"Conflict. Label is ""Count"", Unit is ""%"""
+mimic:51648,Hepatitis B Viral Load,skos:exactMatch,omop:3048505,Hepatitis B virus DNA [log units/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50921,Estradiol,skos:exactMatch,omop:3025285,Estradiol (E2) [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51223,Hemoglobin A2,skos:exactMatch,omop:3020784,Hemoglobin A2/Hemoglobin.total in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50899,Carbamazepine,skos:exactMatch,omop:3028639,carBAMazepine [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50929,Gentamicin,skos:exactMatch,omop:3035510,Gentamicin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51261,Pappenheimer Bodies,skos:exactMatch,omop:3019761,Pappenheimer bodies [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51411,CD45,skos:exactMatch,omop:3001845,CD45 (Lymphs) cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52195,Voided Specimen,,,,,,,,Not a lab test
+mimic:51095,"Phosphate, Urine",skos:exactMatch,omop:3026729,Phosphate [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51453,Other,skos:exactMatch,omop:3015094,Leukocytes other/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51342,Wright Giemsa,skos:exactMatch,omop:3014837,Microscopic observation [Identifier] in Bone marrow by Wright Giemsa stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51398,CD19,skos:exactMatch,omop:3013368,CD19 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51376,Macrophage,skos:exactMatch,omop:3029170,Macrophages/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52012,UTX9,,,,,,,,Ambiguous name
+mimic:51933,C. diff PCR,skos:exactMatch,omop:3051552,Clostridioides difficile toxin genes [Presence] in Stool by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51460,"Blood, Occult",skos:broadMatch,omop:3016251,Hemoglobin.gastrointestinal [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51234,Immunophenotyping,skos:exactMatch,omop:40758359,Immunophenotyping study,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51123,Other,skos:exactMatch,omop:3008855,Leukocytes other/100 leukocytes in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51956,CDT027,,,,,,,,Ambiguous name
+mimic:51425,Kappa,skos:exactMatch,omop:3051901,Kappa lymphocytes/100 lymphocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51426,Lambda,skos:broadMatch,omop:3000611,Lambda lymphocytes/100 lymphocytes in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51076,"Bicarbonate, Urine",skos:exactMatch,omop:3008251,Bicarbonate [Moles/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51276,Quantitative G6PD,skos:exactMatch,omop:3003994,Glucose-6-Phosphate dehydrogenase [Enzymatic activity/mass] in Red Blood Cells,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51839,Anat Path Hold,,,,,,,,Not a lab test
+mimic:51138,Anticardiolipin Antibody IgG,skos:exactMatch,omop:3009041,Cardiolipin IgG Ab [Units/volume] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51139,Anticardiolipin Antibody IgM,skos:exactMatch,omop:3015813,Cardiolipin IgM Ab [Units/volume] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51229,"Heparin, LMW",skos:exactMatch,omop:3045452,LMW Heparin [Units/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51444,Eosinophils,skos:exactMatch,omop:3001893,Eosinophils/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51505,Uric Acid Crystals,skos:exactMatch,omop:3036882,Urate crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50945,Homocysteine,skos:exactMatch,omop:3016724,Homocysteine [Moles/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51899,Trichomonas vaginalis,skos:exactMatch,omop:3047204,Trichomonas vaginalis [Presence] in Specimen by Wet preparation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51206,Factor VIII,skos:exactMatch,omop:3019250,Coagulation factor VIII activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51904,PAN2,,,,,,,,Ambiguous name
+mimic:51262,Pencil Cells,skos:exactMatch,omop:3011151,Pencil cells [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51795,"Lactate Dehydrogenase, CSF",skos:exactMatch,omop:3016920,Lactate dehydrogenase [Enzymatic activity/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52427,UCU2,,,,,,,,Ambiguous name
+mimic:50913,Cryoglobulin,skos:exactMatch,omop:3021322,Cryoglobulin [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52369,"Total Nucleated Cells, Other",skos:exactMatch,omop:40758914,Nucleated cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50989,"Testosterone, Free",skos:exactMatch,omop:3016049,Testosterone Free [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51198,Envelope Cells,skos:exactMatch,omop:3017196,Microscopic observation [Identifier] in Specimen by Wright stain,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51140,Antithrombin,skos:exactMatch,omop:3000515,Antithrombin actual/normal in Platelet poor plasma by Chromogenic method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50838,"Bilirubin, Total, Ascites",skos:exactMatch,omop:3011004,Bilirubin.total [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51325,CD45,skos:exactMatch,omop:3029857,CD45 (Lymphs) cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51066,24 hr Calcium,skos:exactMatch,omop:3007687,Calcium [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50841,"Creatinine, Ascites",skos:exactMatch,omop:3016647,Creatinine [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51662,HPE6,,,,,,,,Ambiguous name
+mimic:51297,Thrombin,skos:exactMatch,omop:3036489,Thrombin time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50997,Tobramycin,skos:exactMatch,omop:3035509,Tobramycin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50916,DHEA-Sulfate,skos:exactMatch,omop:3015884,Dehydroepiandrosterone sulfate (DHEA-S) [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51412,CD5,skos:exactMatch,omop:40760535,CD5 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51047,"Amylase, Pleural",skos:exactMatch,omop:3015401,Amylase [Enzymatic activity/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51404,CD3,skos:exactMatch,omop:3033894,CD3 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51438,"RBC, Other Fluid",skos:exactMatch,omop:3010910,Erythrocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51388,CD10,skos:exactMatch,omop:3030724,CD10 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51400,CD20,skos:exactMatch,omop:40760530,CD20 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51263,Plasma Cells,skos:exactMatch,omop:3018718,Plasma cells/100 leukocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52278,Other,skos:exactMatch,omop:46234850,Other cells/100 leukocytes in Cerebral spinal fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52424,RFXUCU,,,,,,,,Ambiguous name
+mimic:51114,Eosinophils,skos:exactMatch,omop:3019298,Eosinophils/100 leukocytes in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51434,Other Cell,skos:exactMatch,omop:46235833,Other cells/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51105,"Uric Acid, Urine",skos:exactMatch,omop:3033526,Urate [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51271,"Protein C, Functional",skos:exactMatch,omop:3020287,Protein C actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51060,"Triglycerides, Pleural",skos:exactMatch,omop:3034207,Triglyceride [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51313,CD19,skos:exactMatch,omop:3035081,CD19 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50857,Acetone,skos:exactMatch,omop:3022859,Acetone [Presence] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51419,Eosinophils,skos:exactMatch,omop:3021453,Eosinophils/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51056,"Miscellaneous, Pleural",,,,,,,,Not a lab test
+mimic:51722,RFXLDLM,skos:broadMatch,omop:3028437,Cholesterol in LDL [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52256,Eosinophils,skos:exactMatch,omop:3022640,Eosinophils/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51319,CD3,skos:exactMatch,omop:3018064,CD3 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51088,"Magnesium, Urine",skos:exactMatch,omop:3019738,Magnesium [Mass/volume] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51337,HLA-DR,skos:broadMatch,omop:3029669,HLA-DR+ cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51945,Norovirus Genogroup I,skos:exactMatch,omop:40758035,Norovirus genogroup I RNA [Presence] in Stool by NAA with probe detection,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51946,Norovirus Genogroup II,skos:exactMatch,omop:40758036,Norovirus genogroup II RNA [Presence] in Stool by NAA with probe detection,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51273,"Protein S, Functional",skos:exactMatch,omop:3036669,Protein S actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52955,CD10,skos:exactMatch,omop:3030454,CD10 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51423,HLA-DR,skos:exactMatch,omop:3030297,HLA-DR+ cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51315,CD20,skos:closeMatch,omop:3029955,CD20 blasts/100 blasts in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51289,Serum Viscosity,skos:exactMatch,omop:3010493,Viscosity of Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51420,FMC-7,skos:exactMatch,omop:40760540,FMC7 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51402,CD23,skos:exactMatch,omop:3033041,CD23 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51340,Kappa,skos:broadMatch,omop:3051293,Kappa lymphocytes/100 lymphocytes in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51341,Lambda,skos:broadMatch,omop:3000611,Lambda lymphocytes/100 lymphocytes in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51326,CD5,skos:exactMatch,omop:3035527,CD5 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50869,Anti-DGP (IgA/IgG),skos:exactMatch,omop:40766151,Gliadin peptide+tissue transglutaminase IgA+IgG Ab [Presence] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51980,Fentanyl,skos:exactMatch,omop:3004176,fentaNYL [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52020,UTX10,,,,,,,,Ambiguous name
+mimic:51183,CD45,skos:closeMatch,omop:3023116,CD45 (Lymphs) cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51164,CD19,skos:closeMatch,omop:3016228,CD19 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,Duplicate of itemid 51165
+mimic:51026,"Amylase, Body Fluid",skos:exactMatch,omop:3012133,Amylase [Enzymatic activity/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51174,CD3 %,skos:exactMatch,omop:3022533,CD3 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51175,CD3 Absolute Count,skos:exactMatch,omop:3011412,CD3 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51052,"Creatinine, Pleural",skos:exactMatch,omop:3025065,Creatinine [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51370,"Joint Crystals, Birefringence",skos:broadMatch,omop:3022683,Crystals [type] in Synovial fluid by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51371,"Joint Crystals, Comment",skos:exactMatch,omop:3012027,Character of Synovial fluid,HumanCurated,orcid:0000-0002-9348-9284,orcid:0000-0001-8822-1884,,
+mimic:51372,"Joint Crystals, Location",skos:broadMatch,omop:3050238,Crystals [Presence] in Synovial fluid by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51374,"Joint Crystals, Shape",skos:broadMatch,omop:3022683,Crystals [type] in Synovial fluid by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51033,FetalFN,skos:exactMatch,omop:3036848,Fibronectin.fetal [Presence] in Vaginal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52992,Iron Stain,skos:exactMatch,omop:3018543,Iron.microscopic observation [Identifier] in Bone marrow by Potassium ferrocyanide stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51168,CD20,skos:closeMatch,omop:3022878,CD20 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,Duplicate of itemid 51169
+mimic:51152,CD10,skos:closeMatch,omop:3010287,CD10 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51894,"Strep A, Rapid Antigen",skos:broadMatch,omop:21491660,Streptococcus pyogenes Ag [Presence] in Throat by Rapid immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51184,CD5,skos:closeMatch,omop:3020383,CD5 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,Duplicate of itemid 51185
+mimic:51238,Kappa,skos:broadMatch,omop:3007672,Kappa lymphocytes/100 lymphocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51239,Lambda,skos:broadMatch,omop:3034226,Lambda lymphocytes/100 lymphocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51772,PAN3,,,,,,,,Ambiguous name
+mimic:51230,HLA-DR,skos:closeMatch,omop:3047187,HLA-DR [Presence],HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51664,HPE8,,,,,,,,Ambiguous name
+mimic:51503,Triple Phosphate Crystals,skos:exactMatch,omop:3001137,Triple phosphate crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51921,"proBNP, Pleural",skos:exactMatch,omop:46236287,Natriuretic peptide.B prohormone N-Terminal [Mass/volume] in Pleural fluid by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52123,"G6PD, Qualitative",skos:exactMatch,omop:3037292,Glucose-6-Phosphate dehydrogenase [Presence] in Red Blood Cells,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51165,CD19 %,skos:exactMatch,omop:3016228,CD19 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51166,CD19 Absolute Count,skos:exactMatch,omop:3010503,CD19 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51169,CD20 %,skos:exactMatch,omop:3022878,CD20 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51170,CD20 Absolute Count,skos:exactMatch,omop:3018071,CD20 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51162,CD16/56 Absolute Count,skos:exactMatch,omop:3020358,CD16+CD56+ cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51163,CD16/56%,skos:exactMatch,omop:3015455,CD16+CD56+ cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51429,Mesothelial cells,skos:exactMatch,omop:3036353,Mesothelial cells/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51299,Von Willebrand Factor Antigen,skos:exactMatch,omop:3036035,von Willebrand factor (vWf) Ag actual/normal in Platelet poor plasma by Immunoassay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51298,Von Willebrand Factor Activity,skos:exactMatch,omop:3037533,von Willebrand factor (vWf) ristocetin cofactor actual/normal in Platelet poor plasma by Platelet aggregation,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51688,Lyme C6 Ab,skos:exactMatch,omop:3033987,Borrelia burgdorferi C6 Ab [Units/volume] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51689,Lyme G and M Value,skos:exactMatch,omop:3044883,Borrelia burgdorferi IgG+IgM Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51317,CD23,skos:exactMatch,omop:3032694,CD23 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51335,FMC-7,skos:broadMatch,omop:3043498,CD20+FMC7+ cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51368,Eosinophils,skos:exactMatch,omop:3035611,Eosinophils/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51215,FMC-7,skos:exactMatch,omop:3003047,FMC7 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51754,VZV IgG Ab Value,skos:exactMatch,omop:3022575,Varicella zoster virus IgG Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51753,VZV IgG Ab,skos:exactMatch,omop:3022386,Varicella zoster virus IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51416,CD7,skos:exactMatch,omop:40760537,CD7 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51172,CD23,skos:closeMatch,omop:3025559,CD23 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51399,CD2,skos:exactMatch,omop:3034427,CD2 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51406,CD34,skos:exactMatch,omop:40762032,CD34 cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51769,RUBIgGV,skos:exactMatch,omop:3011564,Rubella virus IgG Ab [Units/volume] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51724,Rubella IgG Ab,skos:exactMatch,omop:3013750,Rubella virus IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51471,Cellular Cast,skos:exactMatch,omop:3042588,Mixed cellular casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52019,PAN2,,,,,,,,Ambiguous name
+mimic:51996,Trichomonas vaginalis,skos:exactMatch,omop:3002253,Trichomonas vaginalis [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51321,CD34,skos:exactMatch,omop:40760512,CD34 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51445,"Hematocrit, Pleural",skos:exactMatch,omop:42868643,Hematocrit [Volume Fraction] of Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51192,CD7,skos:closeMatch,omop:3003255,CD7 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51877,MRSA PCR,skos:exactMatch,omop:3033966,Methicillin resistant Staphylococcus aureus (MRSA) DNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51893,Staph aureus PCR,skos:exactMatch,omop:40764165,Staphylococcus aureus DNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51167,CD2,skos:closeMatch,omop:3021562,CD2 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51661,HPE5,,,,,,,,Ambiguous name
+mimic:51235,Inhibitor Screen,skos:broadMatch,omop:3041789,Factor inhibitor XXX [Presence] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51381,Other,skos:exactMatch,omop:3013794,Leukocytes other/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51587,CMV IgG Ab Value,skos:exactMatch,omop:3005356,Cytomegalovirus IgG Ab [Units/volume] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51586,CMV IgG Ab,skos:exactMatch,omop:3016816,Cytomegalovirus IgG Ab [Presence] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51332,CD7,skos:exactMatch,omop:3035186,CD7 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51579,CA 19-9,skos:exactMatch,omop:3022914,Cancer Ag 19-9 [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51314,CD2,skos:exactMatch,omop:3009357,CD2 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51307,CD13,skos:exactMatch,omop:3029960,CD13 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52221,Atypical Lymphocytes,skos:broadMatch,omop:3008266,Variant lymphocytes/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52426,UCU1,,,,,,,,Ambiguous name
+mimic:51768,EE6,,,,,,,,Ambiguous name
+mimic:51762,EE1,,,,,,,,Ambiguous name
+mimic:51499,Sperm,skos:exactMatch,omop:3026796,Spermatozoa [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51798,"PEP, CSF",skos:broadMatch,omop:3006670,Protein Fractions [Interpretation] in Cerebral spinal fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51291,Sickle Cells,skos:exactMatch,omop:3020412,Sickle cells [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 51290
+mimic:51369,"Hematocrit, Joint Fluid",skos:exactMatch,omop:42868642,Hematocrit [Volume Fraction] of Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51588,CMV IgM Ab,skos:exactMatch,omop:3013332,Cytomegalovirus IgM Ab [Presence] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51590,CMV Interpretation,skos:exactMatch,omop:3038184,Cytomegalovirus IgG Ab [Interpretation] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50968,"Phenytoin, Free",skos:exactMatch,omop:3005893,Phenytoin Free [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51305,CD117,skos:exactMatch,omop:3037631,CD117 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51489,NonSquamous Epithelial Cell,skos:exactMatch,omop:3042062,Epithelial cells.non-squamous [#/area] in Urine sediment by Microscopy high power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51488
+mimic:50969,"Phenytoin, Percent Free",skos:exactMatch,omop:3002551,Phenytoin Free/Phenytoin.total in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51034,"Glucose, Body Fluid",skos:exactMatch,omop:3019210,Glucose [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51763,EE2,,,,,,,,Ambiguous name
+mimic:51247,MacroOvalocytes,skos:exactMatch,omop:3010950,Oval macrocytes [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51290,Sickle Cell Preparation,skos:exactMatch,omop:3020412,Sickle cells [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51043,"Total Protein, Body Fluid",skos:exactMatch,omop:3005029,Protein [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51038,"Miscellaneous, Body Fluid",,,,,,,,Not a lab test
+mimic:51310,CD15,skos:exactMatch,omop:3029648,CD15 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51614,Epstein-Barr Virus  EBNA IgG Ab,skos:exactMatch,omop:3021849,Epstein Barr virus nuclear IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51618,Epstein-Barr Virus Interpretation,skos:broadMatch,omop:3031599,Epstein Barr virus band pattern [Interpretation] in Specimen by Immunoblot Narrative,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51619,Epstein-Barr Virus VCA IgG Ab,skos:exactMatch,omop:3015681,Epstein Barr virus capsid IgG Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51620,Epstein-Barr Virus VCA IgM Ab,skos:exactMatch,omop:3008360,Epstein Barr virus capsid IgM Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52419,Voided Specimen,,,,,,,,Not a lab test
+mimic:51615,Epstein-Barr Virus EBNA IgG Ab,skos:exactMatch,omop:3021849,Epstein Barr virus nuclear IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51614
+mimic:51481,Hemosiderin,skos:exactMatch,omop:3036265,Hemosiderin [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51616,Epstein-Barr Virus IgG Ab Value,skos:exactMatch,omop:3007080,Epstein Barr virus nuclear IgG Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51617,Epstein-Barr Virus IgM Ab Value,skos:exactMatch,omop:3006033,Epstein Barr virus nuclear IgM Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51124,Plasma,skos:exactMatch,omop:3041137,Plasma cells/100 leukocytes in Peritoneal fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52262,Immunophenotyping,skos:broadMatch,omop:40758359,Immunophenotyping study,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51320,CD33,skos:exactMatch,omop:3029723,CD33 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51080,Creatinine Clearance,skos:exactMatch,omop:3005770,Creatinine renal clearance in 24 hour Urine and Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51081,"Creatinine, Serum",skos:exactMatch,omop:3016723,Creatinine [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,"Conflict. Label is ""Creatinine, Serum"", fluid is ""Urine"""
+mimic:51101,Total Collection Time,skos:exactMatch,omop:3016750,Collection duration of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51106,Urine Creatinine,skos:exactMatch,omop:3017250,Creatinine [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate ot itemid 51082
+mimic:51109,"Urine Volume, Total",skos:exactMatch,omop:3036603,Volume of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51726,Rubeola IgG Ab Value,skos:exactMatch,omop:3006573,Measles virus IgG Ab [Units/volume] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51725,Rubeola IgG Ab,skos:exactMatch,omop:3013339,Measles virus IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51025,"Albumin, Body Fluid",skos:exactMatch,omop:3025313,Albumin [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51035,"LD, Body Fluid",skos:closeMatch,omop:3008338,Lactate dehydrogenase [Enzymatic activity/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Discouraged LOINC code
+mimic:51517,WBC Casts,skos:exactMatch,omop:3002052,WBC casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51232,Hypersegmented Neutrophils,skos:exactMatch,omop:3009864,Neutrophils.hypersegmented/100 leukocytes in Blood,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51309,CD14,skos:exactMatch,omop:3004400,CD14 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51966,Bilirubin,skos:exactMatch,omop:3011258,Bilirubin.total [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51967,Blood,skos:exactMatch,omop:3051227,Blood [Presence] in Urine by Visual,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51981,Glucose,skos:exactMatch,omop:3020399,Glucose [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51984,Ketone,skos:exactMatch,omop:3032459,Ketones [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51985,Leukocytes,skos:exactMatch,omop:3022547,Leukocytes [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51987,Nitrite,skos:exactMatch,omop:3042812,Nitrite [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51992,Protein,skos:exactMatch,omop:3014051,Protein [Presence] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51994,Specific Gravity,skos:exactMatch,omop:3033543,Specific gravity of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52002,Urobilinogen,skos:exactMatch,omop:3007950,Urobilinogen [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52730,pH,skos:exactMatch,omop:3015736,pH of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51694,Mumps IgG Ab Value,skos:exactMatch,omop:3018867,Mumps virus IgG Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51693,Mumps IgG Ab,skos:exactMatch,omop:3028498,Mumps virus IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51741,Toxoplasma IgG Ab,skos:exactMatch,omop:3024995,Toxoplasma gondii IgG Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51745,Toxoplasma Interpretation,skos:exactMatch,omop:3005475,Toxoplasma gondii Ab [Interpretation] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51764,EE7,,,,,,,,Ambiguous name
+mimic:51742,Toxoplasma IgG Ab Value,skos:exactMatch,omop:3006957,Toxoplasma gondii IgG Ab [Units/volume] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50901,Centromere,skos:exactMatch,omop:3014825,Centromere Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50854,Absolute A1c,skos:exactMatch,omop:3034639,Hemoglobin A1c [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50855,Absolute Hemoglobin,skos:exactMatch,omop:3000963,Hemoglobin [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52223,Bands,skos:exactMatch,omop:3007905,Band form neutrophils/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50865,Amikacin,skos:exactMatch,omop:3036152,Amikacin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51454,Plasma Cells,skos:exactMatch,omop:3040900,Plasma cells/100 leukocytes in Pleural fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Manual count only
+mimic:51199,Eosinophil Count,skos:exactMatch,omop:3028615,Eosinophils [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51323,CD4,skos:exactMatch,omop:3023029,CD3+CD4+ (T4 helper) cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51796,"Miscellaneous, CSF",,,,,,,,Not a lab test
+mimic:51934,C Diff Toxin Antigen Assay,skos:exactMatch,omop:3032068,Clostridioides difficile toxin A+B [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52087,CD15/56,skos:broadMatch,omop:3020358,CD16+CD56+ cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51567,Beta Hydroxybutyrate,skos:exactMatch,omop:3003985,Beta hydroxybutyrate [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51096,Porphobilinogen Screen,skos:exactMatch,omop:3034719,Porphobilinogen [Presence] in Urine,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51334,CD8,skos:exactMatch,omop:3018724,CD3+CD8+ (T8 suppressor) cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51442,Basophils,skos:exactMatch,omop:3030571,Basophils/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52109,dRVVT - Screen,skos:broadMatch,omop:3019174,dRVVT (LA screen),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51422,"Hematocrit, Other Fluid",skos:exactMatch,omop:3008108,Hematocrit [Volume Fraction] of Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51205,Factor VII,skos:exactMatch,omop:3011547,Coagulation factor VII activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51677,K (GREEN),skos:exactMatch,omop:3023103,Potassium [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 50971
+mimic:51110,Atypical Lymphocytes,skos:exactMatch,omop:3043989,Variant lymphocytes/100 leukocytes in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51142,Arachadonic Acid,skos:exactMatch,omop:3031450,Arachidonate (C20:4w6) [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51328,CD56,skos:broadMatch,omop:3030751,CD3+CD56+ cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51331,CD64,skos:exactMatch,omop:3030234,CD64 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50850,"Triglycerides, Ascites",skos:exactMatch,omop:3023386,Triglyceride [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51135,ADP,skos:broadMatch,omop:3018442,Adenosine diphosphate [Mass/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51091,"Myoglobin, Urine",skos:exactMatch,omop:3011470,Myoglobin [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51032,"Creatinine, Body Fluid",skos:exactMatch,omop:3016662,Creatinine [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51195,Collagen,skos:broadMatch,omop:21491241,Platelet aggregation collagen induced [Units/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51306,CD11c,skos:exactMatch,omop:3046866,CD11c cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51638,Hematocrit,skos:exactMatch,omop:3023314,Hematocrit [Volume Fraction] of Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51221
+mimic:51645,"Hemoglobin, Calculated",skos:exactMatch,omop:3027484,Hemoglobin [Mass/volume] in Blood by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52569,Glucose,skos:exactMatch,omop:3004501,Glucose [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52610,Potassium,skos:exactMatch,omop:3023103,Potassium [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 50971
+mimic:52623,Sodium,skos:exactMatch,omop:3019550,Sodium [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51507,"Urine Casts, Other",skos:exactMatch,omop:3005658,Casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51028,"Bilirubin, Total, Body Fluid",skos:exactMatch,omop:3028193,Bilirubin.total [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52546,Creatinine,skos:exactMatch,omop:3016723,Creatinine [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51212,Fetal Hemoglobin,skos:exactMatch,omop:3018738,Hemoglobin F/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51510,"Urine Crystals, Other",skos:exactMatch,omop:3026978,Unidentified crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51440,Atypical Lymphocytes,skos:exactMatch,omop:3046289,Variant lymphocytes/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52535,Chloride,skos:exactMatch,omop:3014576,Chloride [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52647,Urea Nitrogen,skos:exactMatch,omop:3013682,Urea nitrogen [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51624,Free Calcium,skos:exactMatch,omop:3021119,Calcium.ionized [Moles/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51739,Total CO2,skos:exactMatch,omop:3015632,"Carbon dioxide, total [Moles/volume] in Serum or Plasma",HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52500,Anion Gap,skos:exactMatch,omop:3045716,Anion gap in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51901,Voided Specimen,,,,,,,,Not a lab test
+mimic:51953,Voided Specimen,,,,,,,,Not a lab test
+mimic:51666,H. pylori IgG Ab,skos:exactMatch,omop:3023871,Helicobacter pylori IgG Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51324,CD41,skos:exactMatch,omop:3029369,CD41 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51112,Basophils,skos:exactMatch,omop:3032363,Basophils/100 leukocytes in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52179,SCT - Screen,skos:broadMatch,omop:40769396,Normalized silica clotting time of Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51509,Urine Comments,skos:exactMatch,omop:3036005,Urine sediment comments by Light microscopy Narrative,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51188,CD56,skos:closeMatch,omop:3005460,CD56 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51115,"Hematocrit, Ascites",skos:broadMatch,omop:3008108,Hematocrit [Volume Fraction] of Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51667,H. pylori IgG Ab Value,skos:exactMatch,omop:3027491,Helicobacter pylori IgG Ab [Units/volume] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51333,CD71,skos:broadMatch,omop:3009872,CD71 cells/100 cells in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51242,LUC,skos:exactMatch,omop:3010224,Large unstained cells/100 leukocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51377,Mesothelial Cells,skos:exactMatch,omop:3043694,Mesothelial cells/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51264,Platelet Clumps,skos:exactMatch,omop:3035460,Platelet clump [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50888,Blue Top Hold Frozen,,,,,,,,Not a lab test
+mimic:51336,Glyco A,skos:broadMatch,omop:40758985,Glycolate [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51954,CDT027,,,,,,,,Ambiguous name
+mimic:52225,Basophils,skos:exactMatch,omop:3020829,Basophils/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51203,Factor IX,skos:exactMatch,omop:3006109,Coagulation factor IX activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51209,Factor XI,skos:exactMatch,omop:3001850,Coagulation factor XI activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51178,CD34,skos:exactMatch,omop:3023256,CD34 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51515,Waxy Casts,skos:exactMatch,omop:3020851,Waxy casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51204,Factor V,skos:exactMatch,omop:3005757,Coagulation factor V activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51111,Bands,skos:exactMatch,omop:1988747,Band form neutrophils/100 leukocytes in Peritoneal fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Manual count only
+mimic:51156,CD13,skos:closeMatch,omop:3025842,CD13 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51869,"Influenza A, Rapid Antigen",skos:exactMatch,omop:3002523,Influenza virus A Ag [Presence] in Specimen,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51874,"Influenza B, Rapid Antigen",skos:exactMatch,omop:3003740,Influenza virus B Ag [Presence] in Specimen,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51895,"Strep A, Rapid Antigen",skos:broadMatch,omop:21491660,Streptococcus pyogenes Ag [Presence] in Throat by Rapid immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,Duplicate of itemid 51894
+mimic:52720,"HCG, Urine, Qualitative",skos:exactMatch,omop:3018954,Choriogonadotropin (pregnancy test) [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51155,CD11c,skos:closeMatch,omop:3009295,CD11c cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51653,HIV 1 Ab Confirmation,skos:exactMatch,omop:3017675,HIV 1 Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51655,HIV 2 Ab Confirmation,skos:exactMatch,omop:3024449,HIV 2 Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52131,HIT-Ab Interpreted Result,skos:exactMatch,omop:43533839,Heparin induced platelet IgG Ab [Interpretation] in Serum Narrative,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52132,HIT-Ab Numerical Result,skos:exactMatch,omop:3043870,Heparin induced platelet Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51065,"Sodium, Stool",skos:exactMatch,omop:3011846,Sodium [Moles/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51202,Factor II,skos:exactMatch,omop:3005353,Prothrombin activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51064,"Potassium, Stool",skos:exactMatch,omop:3005819,Potassium [Moles/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51154,CD117,skos:closeMatch,omop:3026595,CD117 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51208,Factor X,skos:exactMatch,omop:3004409,Coagulation factor X activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51063,"Osmolality, Stool",skos:exactMatch,omop:3007256,Osmolality of Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51765,EE3,,,,,,,,Ambiguous name
+mimic:51652,High-Sensitivity CRP,skos:exactMatch,omop:3010156,C reactive protein [Mass/volume] in Serum or Plasma by High sensitivity method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51755,White Blood Cells,skos:exactMatch,omop:3000905,Leukocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51300
+mimic:51159,CD15,skos:closeMatch,omop:3010143,CD15 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51408,CD4,skos:exactMatch,omop:3002870,CD3+CD4+ (T4 helper) cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51158,CD14,skos:closeMatch,omop:3026992,CD14 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51177,CD33,skos:closeMatch,omop:3006501,CD33 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51418,CD8,skos:exactMatch,omop:3000683,CD3+CD8+ (T8 suppressor) cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51366,Bands,skos:exactMatch,omop:3042845,Band form neutrophils/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51864,Influenza A by PCR,skos:exactMatch,omop:3044938,Influenza virus A RNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51872,Influenza B by PCR,skos:exactMatch,omop:3038288,Influenza virus B RNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51187,CD55,skos:closeMatch,omop:3007166,CD55 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51190,CD59,skos:closeMatch,omop:3026461,CD59 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51185,CD5 %,skos:exactMatch,omop:3020383,CD5 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51186,CD5 Absolute Count,skos:exactMatch,omop:3018627,CD5 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51191,CD64,skos:closeMatch,omop:3027120,CD64 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51220,Heinz Body Prep,skos:exactMatch,omop:3022613,Heinz bodies [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52279,Plasma,skos:exactMatch,omop:3053157,Plasma cells/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51387,Basophils,skos:exactMatch,omop:3021302,Basophils/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51027,"Bicarbonate, Other Fluid",skos:exactMatch,omop:3024655,Bicarbonate [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51193,CD71,skos:closeMatch,omop:3002153,CD71 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:52276,NRBC,skos:exactMatch,omop:3053315,Nucleated erythrocytes/100 cells in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51207,Factor VIII Inhibitor,skos:exactMatch,omop:3024942,Coagulation factor VIII inhibitor [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51488,Non-squamous Epithelial Cells,skos:exactMatch,omop:3042062,Epithelial cells.non-squamous [#/area] in Urine sediment by Microscopy high power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51217,Glyco A,skos:exactMatch,omop:3037918,Glycolate [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51182,CD41,skos:closeMatch,omop:3021854,CD41 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51386,Bands,skos:exactMatch,omop:3017161,Band form neutrophils/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51441,Bands,skos:exactMatch,omop:1988450,Band form neutrophils/100 leukocytes in Pleural fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Manual count only
+mimic:51272,"Protein S, Antigen",skos:exactMatch,omop:3037201,Protein S Ag actual/normal in Platelet poor plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51367,Basophils,skos:exactMatch,omop:3035319,Basophils/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51049,"Bilirubin, Total, Pleural",skos:exactMatch,omop:3013272,Bilirubin.total [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52642,Troponin I,skos:exactMatch,omop:3021337,Troponin I.cardiac [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51022,"Glucose, Joint Fluid",skos:exactMatch,omop:3001978,Glucose [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51621,Ethylene Glycol,skos:exactMatch,omop:3020475,"Ethylene glycol [Mass/volume] in Serum, Plasma or Blood",HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52358,Lining Cell,skos:exactMatch,omop:3035196,Ciliated columnar lining cells/100 leukocytes [# Ratio] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51122,Nucleated RBC,skos:exactMatch,omop:42868645,Nucleated erythrocytes/100 cells in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51189,CD57,skos:closeMatch,omop:3004291,CD57 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51201,Epinepherine,skos:exactMatch,omop:3008625,EPINEPHrine [Mass/volume] in Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51502,Trichomonas,skos:exactMatch,omop:3029154,Trichomonas sp [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52301,Lining Cell,skos:exactMatch,omop:3034891,Synovial lining cells/100 cells in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50875,Anti-Parietal Cell Antibody,skos:exactMatch,omop:3018885,Parietal cell Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51312,CD16/56,skos:exactMatch,omop:3029712,CD16+CD56+ cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51302,Young Cells,skos:broadMatch,omop:40758562,Immature cells/100 leukocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51385,Atypical Lymphocytes,skos:exactMatch,omop:3007169,Variant lymphocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51044,Triglycer,skos:exactMatch,omop:3000637,Triglyceride [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51365,Atypical Lymphocytes,skos:exactMatch,omop:3046317,Variant lymphocytes/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51743,Toxoplasma IgM Ab,skos:exactMatch,omop:3038943,Toxoplasma gondii IgM Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51452,NRBC,skos:exactMatch,omop:42868644,Nucleated erythrocytes/100 cells in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51084,"Glucose, Urine",skos:exactMatch,omop:3020399,Glucose [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51286,Ristocetin,skos:exactMatch,omop:3027990,Ristocetin [Susceptibility],HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51270,"Protein C, Antigen",skos:exactMatch,omop:3002022,Protein C Ag actual/normal in Platelet poor plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51024,"Total Protein, Joint Fluid",skos:exactMatch,omop:3036670,Protein [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51744,Toxoplasma IgM Ab Value,skos:exactMatch,omop:3017382,Toxoplasma gondii IgM Ab [Units/volume] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52107,dRVVT - Confirmation,skos:broadMatch,omop:3032493,dRVVT/dRVVT W excess phospholipid (screen to confirm ratio),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52108,dRVVT - Normalized Ratio,skos:broadMatch,omop:1616395,dRVVT/dRVVT.excess phospholipid [Ratio] normalized in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52270,Metamyelocytes,skos:exactMatch,omop:3009788,Metamyelocytes/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51870,"Influenza A, Rapid Antigen",skos:exactMatch,omop:3002523,Influenza virus A Ag [Presence] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51869
+mimic:51875,"Influenza B, Rapid Antigen",skos:broadMatch,omop:21492989,Influenza virus B Ag [Presence] in Upper respiratory specimen by Rapid immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,Duplicate of itemid 51874
+mimic:50870,"Anti-Gliadin Antibody, IgA",skos:exactMatch,omop:40761803,Gliadin peptide IgA Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52181,Stomatocyte,skos:exactMatch,omop:3024783,Stomatocytes [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51072,"Amylase, Urine",skos:exactMatch,omop:3017315,Amylase [Enzymatic activity/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51073,"Amylase/Creatinine Ratio, Urine",skos:exactMatch,omop:3044902,Amylase/Creatinine [Ratio] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52257,"Hematocrit, CSF",skos:exactMatch,omop:3013811,Hematocrit [Volume Fraction] of Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50990,Theophylline,skos:exactMatch,omop:3016072,Theophylline [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51083,"Ethanol, Urine",skos:exactMatch,omop:3010109,Ethanol [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51161,CD16,skos:closeMatch,omop:3010201,CD16 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51392,CD13,skos:exactMatch,omop:3030772,CD13 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51467,Broad Casts,skos:exactMatch,omop:3017179,Broad casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51767,EE5,,,,,,,,Ambiguous name
+mimic:50844,"Lipase, Ascites",skos:exactMatch,omop:3045996,Lipase [Enzymatic activity/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51062,"Chloride, Stool",skos:exactMatch,omop:3001260,Chloride [Moles/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51179,CD38,skos:closeMatch,omop:3019183,CD38 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51494,RBC Casts,skos:exactMatch,omop:3002587,RBC casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52227,Blasts,skos:exactMatch,omop:3025698,Blasts/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51465,Bilirubin Crystals,skos:exactMatch,omop:3014537,Bilirubin crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51697,Neutrophils,skos:exactMatch,omop:3013650,Neutrophils [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Incorrect Unit (mmol/l)
+mimic:51433,NRBC,skos:exactMatch,omop:3053291,Nucleated erythrocytes/100 leukocytes [Ratio] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51397,CD16/56,skos:exactMatch,omop:3008741,CD16+CD56+ cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51713,Reflex Confirmatory Hepatitis C Viral Load,skos:broadMatch,omop:3018447,Hepatitis C virus RNA [Units/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51211,Factor XIII,skos:exactMatch,omop:3020066,Coagulation factor XIII activity actual/normal in Platelet poor plasma by Chromogenic method,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52268,Mesothelial cells,skos:exactMatch,omop:3011271,Mesothelial cells/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51173,CD25,skos:closeMatch,omop:3011497,CD25 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51511,Urine Fat Bodies,skos:exactMatch,omop:3033486,Oval fat bodies (globules) [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51380,NRBC,skos:exactMatch,omop:40771130,Nucleated erythrocytes/100 leukocytes [Ratio] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51149,Bleeding Time,skos:exactMatch,omop:3011625,Bleeding time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51171,CD22,skos:closeMatch,omop:3022703,CD22 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:53127,Voided Specimen,,,,,,,,Not a lab test
+mimic:51413,CD56,skos:exactMatch,omop:40760536,CD56 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51210,Factor XII,skos:exactMatch,omop:3002348,Coagulation factor XII activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51153,CD103,skos:exactMatch,omop:3018791,CD103 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52335,TdT,skos:exactMatch,omop:3032522,Terminal deoxyribonucleotidyl transferase cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51318,CD25,skos:exactMatch,omop:3012205,CD25 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51390,CD117,skos:exactMatch,omop:3031818,CD117 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52176,Rouleaux,skos:exactMatch,omop:3036273,Rouleaux [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51435,Plasma,skos:exactMatch,omop:3011681,Plasma cells/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51395,CD15,skos:exactMatch,omop:3029717,CD15 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52274,Myelocytes,skos:exactMatch,omop:3021345,Myelocytes/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51470,Calcium Phosphate Crystals,skos:exactMatch,omop:3022327,Calcium phosphate crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51045,"Urea Nitrogen, Body Fluid",skos:exactMatch,omop:3019930,Urea nitrogen [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51692,"Monospot, Rapid Antigen",skos:exactMatch,omop:3033533,Heterophile Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52283,Promyelocytes,skos:exactMatch,omop:3036234,Promyelocytes/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53144,ANCA Titer,skos:exactMatch,omop:3026712,Neutrophil cytoplasmic Ab [Titer] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51036,"Lipase, Body Fluid",skos:exactMatch,omop:3026286,Lipase [Enzymatic activity/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50848,"Sodium, Ascites",skos:exactMatch,omop:3033042,Sodium [Moles/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51241,Leukocyte Alkaline Phosphatase,skos:exactMatch,omop:3004218,Leukocyte phosphatase [Enzymatic activity/volume] in Leukocytes,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51407,CD38,skos:exactMatch,omop:3030804,CD38 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52043,Voided Specimen,,,,,,,,Not a lab test
+mimic:51405,CD33,skos:exactMatch,omop:3029576,CD33 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51409,CD4/CD8 Ratio,skos:exactMatch,omop:3014859,CD3+CD4+ (T4 helper) cells/CD3+CD8+ (T8 suppressor cells) cells [# Ratio] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50840,"Cholesterol, Ascites",skos:exactMatch,omop:3002651,Cholesterol [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51061,"Bicarbonate, Stool",skos:broadMatch,omop:3014637,Bicarbonate [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52177,SCT - Confirmation,skos:broadMatch,omop:40769396,Normalized silica clotting time of Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52178,SCT - Normalized Ratio,skos:exactMatch,omop:40769396,Normalized silica clotting time of Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52263,Lining Cell,skos:exactMatch,omop:3016512,Cerebroventricular lining cells [Presence] in Cerebral spinal fluid by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51322,CD38,skos:exactMatch,omop:3030000,CD38 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51295,TdT,skos:broadMatch,omop:3008488,Terminal deoxyribonucleotidyl transferase [Enzymatic activity/volume] in Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52551,D-Dimer,skos:exactMatch,omop:3048530,Fibrin D-dimer DDU [Mass/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51316,CD22,skos:broadMatch,omop:3029412,CD22 blasts/100 blasts in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51393,CD138,skos:exactMatch,omop:3033713,CD138 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51042,"Sodium, Body Fluid",skos:exactMatch,omop:3022810,Sodium [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52129,Hemoglobin Other,skos:exactMatch,omop:3051396,Hemoglobin.other/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51023,"LD, Joint Fluid",skos:closeMatch,omop:3016675,Lactate dehydrogenase [Enzymatic activity/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Discouraged LOINC code
+mimic:51394,CD14,skos:exactMatch,omop:3029714,CD14 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51675,INR(PT),skos:exactMatch,omop:3022217,INR in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51897,Surfactant/Albumin,skos:exactMatch,omop:3017439,Surfactant/Albumin [Mass Ratio] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50847,"Potassium, Ascites",skos:exactMatch,omop:3029821,Potassium [Moles/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51041,"Potassium, Body Fluid",skos:exactMatch,omop:3036243,Potassium [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51304,CD103,skos:exactMatch,omop:3029695,CD103 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51776,<Albumin>,skos:exactMatch,omop:3024474,Albumin [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51775
+mimic:51329,CD57,skos:exactMatch,omop:3014360,CD57 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50845,"Miscellaneous, Ascites",,,,,,,,Not a lab test
+mimic:51253,Monocyte Count,skos:exactMatch,omop:3033575,Monocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50839,"Chloride, Ascites",skos:exactMatch,omop:3043156,Chloride [Moles/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51806,Voided Specimen,,,,,,,,Not a lab test
+mimic:51495,RBC Clumps,skos:exactMatch,omop:40761550,Erythrocyte clumps [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50837,"Bicarbonate, Ascites",skos:exactMatch,omop:40757491,Bicarbonate [Moles/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51030,"Chloride, Body Fluid",skos:exactMatch,omop:3013194,Chloride [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51415,CD64,skos:exactMatch,omop:3029062,CD64 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51490,Oval Fat Body,skos:exactMatch,omop:3010491,Oval fat bodies (globules) [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50959,Macro Prolactin,skos:exactMatch,omop:43055514,Macroprolactin [Presence] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51456,Promyelocytes,skos:broadMatch,omop:3023316,Promyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51475,Epithelial Casts,skos:exactMatch,omop:3024290,Epithelial casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51391,CD11c,skos:exactMatch,omop:3030790,CD11c cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51311,CD16,skos:broadMatch,omop:3029325,CD16 blasts/100 blasts in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51714,Reflex HIV Confirmation,skos:broadMatch,omop:40760007,HIV 1+2 Ab+HIV1 p24 Ag [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51449,Metamyelocytes,skos:broadMatch,omop:3024936,Metamyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51461,Ammonium Biurate,skos:exactMatch,omop:3019200,Ammonium urate crystals [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50962,N-Acetylprocainamide (NAPA),skos:exactMatch,omop:3001706,N-acetylprocainamide [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50972,Procainamide,skos:exactMatch,omop:3004653,Procainamide [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51403,CD25,skos:exactMatch,omop:3031912,CD25 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50851,"Urea Nitrogen, Ascites",skos:exactMatch,omop:3006866,Urea nitrogen [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51430,Metamyelocytes,skos:exactMatch,omop:3024936,Metamyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51119,Metamyelocytes,skos:broadMatch,omop:3024936,Metamyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51401,CD22,skos:exactMatch,omop:3031560,CD22 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51472,Cholesterol Crystals,skos:exactMatch,omop:3026327,Cholesterol crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51126,Promyelocytes,skos:broadMatch,omop:3023316,Promyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51308,CD138,skos:exactMatch,omop:3031244,CD138 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51924,Voided Specimen,,,,,,,,Not a lab test
+mimic:51378,Metamyelocytes,skos:broadMatch,omop:3024936,Metamyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51396,CD16,skos:exactMatch,omop:3022430,CD16 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51410,CD41,skos:exactMatch,omop:3030262,CD41 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51414,CD57,skos:exactMatch,omop:3029617,CD57 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51417,CD71,skos:exactMatch,omop:40760538,CD71 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51451,Myelocytes,skos:broadMatch,omop:3024394,Myelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51468,Calcium Carbonate Crystals,skos:exactMatch,omop:3007501,Calcium carbonate crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51473,Cysteine Crystals,skos:exactMatch,omop:3027820,Cystine crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51480,Hematocrit,skos:exactMatch,omop:3003427,Hematocrit [Volume Fraction] of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51791,HIV 1 Viral Load,skos:exactMatch,omop:3026532,HIV 1 RNA [Log #/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52307,Plasma,skos:exactMatch,omop:3044515,Plasma cells/100 leukocytes in Synovial fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51031,"Cholesterol, Body Fluid",skos:exactMatch,omop:3015232,Cholesterol [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51121,Myelocytes,skos:broadMatch,omop:3024394,Myelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51421,Glyco A,skos:exactMatch,omop:40758985,Glycolate [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52373,TdT,skos:exactMatch,omop:3041975,Terminal deoxyribonucleotidyl transferase cells/100 cells in Body fluid by Flow cytometry (FC),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51157,CD138,skos:closeMatch,omop:3031831,CD138 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51029,"Calcium, Body Fluid",skos:exactMatch,omop:3000822,Calcium [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51040,"Phosphate, Body Fluid",skos:exactMatch,omop:3034814,Phosphate [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51389,CD103,skos:exactMatch,omop:3034064,CD103 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51432,Myelocytes,skos:exactMatch,omop:3024394,Myelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51437,Promyelocytes,skos:exactMatch,omop:3023316,Promyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51665,HPE9,,,,,,,,Ambiguous name
+mimic:51827,Voided Specimen,,,,,,,,Not a lab test
+mimic:51039,"Osmolality, Body Fluid",skos:exactMatch,omop:3004663,Osmolality of Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51443,Blasts,skos:exactMatch,omop:3028880,Blasts/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51477,Free Fat,skos:exactMatch,omop:3023744,Fat [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52311,Promyelocytes,skos:broadMatch,omop:3023316,Promyelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51019,"Albumin, Joint Fluid",skos:exactMatch,omop:3025380,Albumin [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51037,"Magnesium, Body Fluid",skos:exactMatch,omop:3014175,Magnesium [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51055,"Lipase, Pleural",skos:exactMatch,omop:3048752,Lipase [Enzymatic activity/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52092,CD56 %,skos:exactMatch,omop:3005460,CD56 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52093,CD56 Absolute Count,skos:exactMatch,omop:3026757,CD56 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52305,Myelocytes,skos:broadMatch,omop:3024394,Myelocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51500,Sulfonamides,skos:exactMatch,omop:3003356,Sulfonamide crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51504,Tyrosine Crystals,skos:exactMatch,omop:3021314,Tyrosine crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50846,"Osmolality, Ascites",skos:exactMatch,omop:3016937,Osmolality of Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51058,"Sodium, Pleural",skos:broadMatch,omop:3026681,Sodium [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51020,"Amylase, Joint Fluid",skos:exactMatch,omop:3004142,Amylase [Enzymatic activity/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51258,Osmotic Fragility,skos:closeMatch,omop:3032605,Osmotic fragility [Interpretation] of Red Blood Cells,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51280,Reptilase Time,skos:exactMatch,omop:3005308,Reptilase time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51327,CD55,skos:exactMatch,omop:3033246,CD55 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52184,TCR Alpha-Beta,skos:exactMatch,omop:21493682,TCR alpha beta cells/100 CD3 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52185,TCR Gamma-Delta,skos:exactMatch,omop:21493683,TCR gamma delta cells/100 CD3 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52319,CD 1a,skos:exactMatch,omop:3039636,CD1a cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51057,"Potassium, Pleural",skos:broadMatch,omop:3013098,Potassium [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51278,Red Blood Cell Fragments,skos:exactMatch,omop:3019880,Schistocytes [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51287
+mimic:51281,Reptilase Time Control,skos:exactMatch,omop:3011893,Reptilase time in Control Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51330,CD59,skos:exactMatch,omop:3031007,CD59 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51483,Hyphenated Yeast,skos:exactMatch,omop:3033741,Yeast.hyphae [Presence] in Urine sediment by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51485,Leucine Crystals,skos:exactMatch,omop:3019169,Leucine crystals [Presence] in Urine sediment by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51496,"Reducing Substances, Urine",skos:exactMatch,omop:3020029,Reducing substances [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52370,Voided Specimen,,,,,,,,Not a lab test
+mimic:51783,"Bilirubin, Total, CSF",skos:exactMatch,omop:3027110,Bilirubin.total [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52288,Young,,,,,,,,Ambiguous name
+mimic:52331,TCR Alpha-Beta,skos:exactMatch,omop:3046019,TCR alpha beta cells/100 cells in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52332,TCR Gamma-Delta,skos:exactMatch,omop:3046045,TCR gamma delta cells/100 cells in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51021,"Creatinine, Joint Fluid",skos:exactMatch,omop:3007367,Creatinine [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51048,"Bicarbonate, Pleural",skos:exactMatch,omop:40757492,Bicarbonate [Moles/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51113,Blasts,skos:exactMatch,omop:3046003,Blasts/100 leukocytes in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51129,Young,,,,,,,,Ambiguous name
+mimic:52088,CD 1a,skos:exactMatch,omop:3033563,CD1a cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52287,Voided Specimen,,,,,,,,Not a lab test
+mimic:52313,Voided Specimen,,,,,,,,Not a lab test
+mimic:52339,Blasts,skos:exactMatch,omop:3026596,Blasts/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52406,Voided Specimen,,,,,,,,Not a lab test
+mimic:50830,"pCO2, Body Fluid",skos:exactMatch,omop:3027480,Carbon dioxide [Partial pressure] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas"""
+mimic:50832,"pO2, Body Fluid",skos:exactMatch,omop:3010251,Oxygen [Partial pressure] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas"""
+mimic:51050,"Chloride, Pleural",skos:exactMatch,omop:3038308,Chloride [Moles/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52341,CD 1a,skos:exactMatch,omop:3039924,CD1a cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52355,Hypersegmented Neutrophils,skos:exactMatch,omop:3022005,Segmented neutrophils/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52410,Fatty Casts,skos:exactMatch,omop:3015913,Fatty casts [#/area] in Urine sediment by Microscopy low power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50829,Fluid Type,,,,,,,,Not a lab test
+mimic:50833,Potassium,skos:broadMatch,omop:3036243,Potassium [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas"""
+mimic:50834,"Sodium, Body Fluid",skos:broadMatch,omop:3022810,Sodium [Moles/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,"Conflict. Fluid is ""Other Body Fluid"", Category is ""Blood Gas"""
+mimic:50858,Acid Phosphatase,skos:broadMatch,omop:3020233,Acid phosphatase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50859,"Acid Phosphatase, Non-Prostatic",skos:broadMatch,omop:3009383,Non prostatic acid phosphatase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50860,"AFP, Maternal Screen",skos:broadMatch,omop:3009306,Alpha-1-Fetoprotein [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50886,Blood Culture Hold,,,,,,,,Not a lab test
+mimic:50897,Call,,,,,,,,Not a lab test
+mimic:50923,Fax,,,,,,,,Not a lab test
+mimic:50928,Gastrin,skos:broadMatch,omop:3009927,Gastrin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50936,"HCG, Maternal Screen",skos:broadMatch,omop:3018171,Choriogonadotropin [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:50977,Quinidine,skos:broadMatch,omop:3019736,quiNIDine [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:50984,Stat,,,,,,,,Not a lab test
+mimic:50985,Study Tubes,,,,,,,,Not a lab test
+mimic:51002,Troponin I,skos:broadMatch,omop:3021337,Troponin I.cardiac [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51004,"UE3, Maternal Screen",skos:broadMatch,omop:3025455,Estriol (E3).unconjugated [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51136,Alpha Antiplasmin,skos:broadMatch,omop:3023479,Plasmin inhibitor actual/normal in Platelet poor plasma by Chromogenic method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51141,APT Test,skos:broadMatch,omop:3000873,Hemoglobin F [Presence] in Blood by Alkali denaturation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51285,"Reticulocyte, Cellular Hemoglobin",skos:broadMatch,omop:46234968,Reticulocyte cellular hemoglobin distribution width [Entitic mass] in Blood by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51293,Sugar Water Test,skos:broadMatch,omop:3028647,Sucrose hemolysis [Presence] of Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:51303,CD10,skos:broadMatch,omop:3030454,CD10 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51339,Iron Stain,skos:broadMatch,omop:3018543,Iron.microscopic observation [Identifier] in Bone marrow by Potassium ferrocyanide stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51459,Young Cells,,,,,,,,Ambiguous name
+mimic:51556,Anti-Microsomal Antibodies,skos:broadMatch,omop:3015352,Thyroperoxidase Ab [Units/volume] in Serum or Plasma by Radioimmunoassay (RIA),HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51557,Anti-Microsomal Antibody,skos:broadMatch,omop:3011617,Mitochondria Ab [Units/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51558,Antirnp,skos:broadMatch,omop:3008025,Ribonucleoprotein extractable nuclear Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51559,Anti-ro,skos:broadMatch,omop:3015154,Sjogrens syndrome-A extractable nuclear Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51560,Anti-SARS-CoV-2 IgA,skos:broadMatch,omop:723473,SARS-CoV-2 (COVID-19) IgA Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51562,Anti-Skin Antibody,skos:broadMatch,omop:40769532,Skin Ab [Titer] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51563,Anti-sm,skos:broadMatch,omop:3005932,Smooth muscle Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51565,Argon,skos:broadMatch,omop:21490915,Argon [VFr/PPres] Gas delivery system,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51566,Beta,skos:broadMatch,omop:3016520,Beta globulin [Mass/volume] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51568,"Bilirubin, Neonatal",skos:broadMatch,omop:3043744,Bilirubin.conjugated+indirect [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51569,"Bilirubin, Neonatal, Direct",skos:broadMatch,omop:3019676,Bilirubin.conjugated [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51570,"Bilirubin, Neonatal, Indirect",skos:broadMatch,omop:3007359,Bilirubin.indirect [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51571,Billed,,,,,,,,Not a lab test
+mimic:51572,Bioavailable Testosterone,skos:broadMatch,omop:3023837,Testosterone.free+weakly bound/Testosterone.total in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51573,Bromide,skos:broadMatch,omop:3026383,Bromide [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51574,C1 Inhibitor,skos:broadMatch,omop:3003245,Complement C1 esterase inhibitor [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51575,C1q,skos:broadMatch,omop:3002140,Complement C1q [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51576,C2,skos:broadMatch,omop:3001793,Complement C2 [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51577,C5,skos:broadMatch,omop:3017692,Complement C5 [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51578,C6,skos:broadMatch,omop:3018772,Complement C6 [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51580,Calculated CK-MB,skos:broadMatch,omop:3025909,Creatine kinase.MB/Creatine kinase.total in Serum or Plasma by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51581,Carotene,skos:broadMatch,omop:3001599,Carotene [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51582,CH50,skos:broadMatch,omop:3028461,Complement total hemolytic CH50 [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51583,Chol Estr,skos:broadMatch,omop:3016297,Cholesterol esterase [Enzymatic activity/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51584,Chylomicrons,skos:broadMatch,omop:3020132,Chylomicrons [Presence] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51585,Clostrid,skos:broadMatch,omop:3035407,Clostridium tetani toxoid Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51589,CMV IgM Ab Value,skos:broadMatch,omop:3003526,Cytomegalovirus IgM Ab [Units/volume] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51591,Confirmation,,,,,,,,Not a lab test
+mimic:51592,Conj Bili,skos:broadMatch,omop:3027597,Bilirubin.direct [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51593,Copper,skos:broadMatch,omop:3027126,Copper [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51594,"Creatine Kinase, Isoenzyme BB",skos:broadMatch,omop:3015040,Creatine kinase.BB/Creatine kinase.total in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51595,"Creatine Kinase, Isoenzyme MB",skos:broadMatch,omop:3016311,Creatine kinase.MB/Creatine kinase.total in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51596,"Creatine Kinase, Isoenzyme MM",skos:broadMatch,omop:3008558,Creatine kinase.MM/Creatine kinase.total in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51597,Cvhlc,,,,,,,,Ambiguous name
+mimic:51599,D,,,,,,,,Not a lab test
+mimic:51600,Delete,,,,,,,,Not a lab test
+mimic:51601,Delete,,,,,,,,Not a lab test
+mimic:51602,Delete,,,,,,,,Not a lab test
+mimic:51603,Delete,,,,,,,,Not a lab test
+mimic:51604,Delete,,,,,,,,Not a lab test
+mimic:51605,Delta/Dlt,,,,,,,,Ambiguous name
+mimic:51606,Digitoxin,skos:broadMatch,omop:3007288,Digitoxin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51607,"Dimeric Inhibin A, Maternal Screen",skos:broadMatch,omop:3018595,Inhibin A [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51608,DirLst,,,,,,,,Not a lab test
+mimic:51609,Disopyramide,skos:broadMatch,omop:3026235,Disopyramide [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51610,Dlta Bili,skos:broadMatch,omop:3004173,Bilirubin.delta [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51611,Down Syndrome Risk,skos:broadMatch,omop:3043238,Trisomy 21 risk [Likelihood] in Fetus,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51612,Dr. X,,,,,,,,Not a lab test
+mimic:51623,Fibrinogen,skos:broadMatch,omop:3016407,Fibrinogen [Mass/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51628,Fructosamine,skos:broadMatch,omop:3019839,Fructosamine [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51629,Fructosamine Plus,skos:broadMatch,omop:3019839,Fructosamine [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51630,Gamma,skos:broadMatch,omop:3023465,Gamma globulin [Mass/volume] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51631,Glycated Hemoglobin,skos:broadMatch,omop:3004410,Hemoglobin A1c/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51632,Growth Hormone,skos:broadMatch,omop:3023709,Somatotropin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51633,Hbeag,skos:broadMatch,omop:3023378,Hepatitis B virus e Ag [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51634,Hbsag,skos:broadMatch,omop:3019510,Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51635,Hbsag,skos:broadMatch,omop:3019510,Hepatitis B virus surface Ag [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51634
+mimic:51636,"HCG, Multiples of Median",skos:broadMatch,omop:3004376,Choriogonadotropin [Multiple of the median] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51637,"HCG, Qualitative",skos:broadMatch,omop:3011149,Choriogonadotropin.beta subunit (pregnancy test) [Presence] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51639,Hematocrit,skos:broadMatch,omop:3023314,Hematocrit [Volume Fraction] of Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51221
+mimic:51640,Hemoglobin,skos:broadMatch,omop:3000963,Hemoglobin [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 50811
+mimic:51641,Hemoglobin  A,skos:broadMatch,omop:3020428,Hemoglobin A/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51642,Hemoglobin  A1,skos:broadMatch,omop:3005446,Hemoglobin A1/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51643,Hemoglobin  A2,skos:broadMatch,omop:3020784,Hemoglobin A2/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51223
+mimic:51644,Hemoglobin  C,skos:broadMatch,omop:3001258,Hemoglobin C/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51646,Hemoglobin  F,skos:broadMatch,omop:3018738,Hemoglobin F/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51212
+mimic:51647,Hemoglobin  S,skos:broadMatch,omop:3005081,Hemoglobin S/Hemoglobin.total in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51227
+mimic:51649,Hepatitis B Virus E Antibody,skos:broadMatch,omop:3023202,Hepatitis B virus e Ab [Units/volume] in Serum by Immunoassay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51650,Hepatitis B Virus E Antigen,skos:broadMatch,omop:3011516,Hepatitis B virus e Ag [Units/volume] in Serum by Immunoassay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51656,Hlap,skos:broadMatch,omop:3011081,Alkaline phosphatase.heat labile [Enzymatic activity/volume] in Serum or Plasma by Heat stability,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51668,Hsap,skos:broadMatch,omop:3016506,Alkaline phosphatase.heat stable [Enzymatic activity/volume] in Serum or Plasma by Heat stability,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51669,Htlv Ab,skos:broadMatch,omop:3014389,HTLV I+II Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51670,Icd9,skos:broadMatch,omop:3038810,"Diagnosis recommendations, ICD9-CM CPHS",HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51671,IFEgel,,,,,,,,Not a lab test
+mimic:51672,Immune Complexes,skos:broadMatch,omop:3017905,Immune complex [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51673,Immunoelectrophoresis,skos:broadMatch,omop:3000265,Immunoelectrophoresis for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51674,Immunoglobulin E,skos:broadMatch,omop:3016604,IgE [Mass/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51676,Insulin,skos:broadMatch,omop:3016244,Insulin [Units/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51679,Lap,skos:broadMatch,omop:3004218,Leukocyte phosphatase [Enzymatic activity/volume] in Leukocytes,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51680,"LD, Isoenzyme 1",skos:broadMatch,omop:3006898,Lactate dehydrogenase 1/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51681,"LD, Isoenzyme 2",skos:broadMatch,omop:3023919,Lactate dehydrogenase 2/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51682,"LD, Isoenzyme 3",skos:broadMatch,omop:3007858,Lactate dehydrogenase 3/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51683,"LD, Isoenzyme 4",skos:broadMatch,omop:3024830,Lactate dehydrogenase 4/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51684,"LD, Isoenzyme 5",skos:broadMatch,omop:3012481,Lactate dehydrogenase 5/Lactate dehydrogenase.total in Serum or Plasma by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51685,Lidocaine,skos:broadMatch,omop:3004944,Lidocaine [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51686,Lip2,,,,,,,,Ambiguous name
+mimic:51687,Lipo Electrophoresis,skos:broadMatch,omop:3008183,Lipoprotein fractions [Interpretation] in Serum or Plasma by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51690,Lymphocytes,skos:broadMatch,omop:3037511,Lymphocytes/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,Duplicate of itemid 51244
+mimic:51691,MCV,skos:broadMatch,omop:3023599,MCV [Entitic volume] by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of Itemid 51250
+mimic:51695,Myoglobin,skos:broadMatch,omop:3005895,Myoglobin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51696,Neural Tube Defect Risk,skos:broadMatch,omop:3048541,Neural tube defect risk [Likelihood] in Fetus,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51698,No MD,,,,,,,,Not a lab test
+mimic:51699,Not Done,,,,,,,,Not a lab test
+mimic:51700,Np-fx,,,,,,,,Not a lab test
+mimic:51701,"Osmolality, Calculated",skos:broadMatch,omop:3034739,Osmolality of Serum or Plasma by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51702,Park,,,,,,,,Not a lab test
+mimic:51703,PEPgel,,,,,,,,Not a lab test
+mimic:51704,Platelet Count,skos:broadMatch,omop:3024929,Platelets [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51265
+mimic:51705,Primidone,skos:broadMatch,omop:3002248,Primidone [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51707,Progesterone,skos:broadMatch,omop:3027144,Progesterone [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51708,Qnthbsab,skos:broadMatch,omop:3023421,Hepatitis B virus surface Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51709,Quantitative RPR Test,skos:broadMatch,omop:3026501,Reagin Ab [Titer] in Serum by RPR,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51710,Rapid Plasma Reagin Test,skos:broadMatch,omop:3021461,Reagin Ab [Presence] in Serum by RPR,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51712,Referred,,,,,,,,Not a lab test
+mimic:51715,Renin,skos:broadMatch,omop:3007808,Renin [Enzymatic activity/volume] in Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51717,Reserved,,,,,,,,Not a lab test
+mimic:51718,Reserved1,,,,,,,,Not a lab test
+mimic:51719,Reserved3,,,,,,,,Not a lab test
+mimic:51720,Reserved4,,,,,,,,Not a lab test
+mimic:51721,Reverse T3,skos:broadMatch,omop:3027514,Triiodothyronine (T3).reverse [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51723,Rubella,skos:broadMatch,omop:3010937,Rubella virus Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51727,Send Out,,,,,,,,Not a lab test
+mimic:51728,Serum B12,skos:broadMatch,omop:3000593,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51010
+mimic:51729,Serum B12,skos:broadMatch,omop:3000593,Cobalamin (Vitamin B12) [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51010
+mimic:51730,Serum Folate,skos:broadMatch,omop:3036987,Folate [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 50925
+mimic:51731,Single Stranded DNA,skos:broadMatch,omop:3003717,DNA single strand Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51738,Thyroid Binding Globulin,skos:broadMatch,omop:3020924,Thyroxine binding globulin [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51740,Toxic Screen,skos:broadMatch,omop:3017324,Toxicology panel - Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51746,Transferrin Saturation,skos:broadMatch,omop:3000185,Iron saturation [Mass Fraction] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51747,Treponemal Antibody Test,skos:broadMatch,omop:3019832,Treponema pallidum Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51750,"UE3, Multiples of Median",skos:broadMatch,omop:3003262,Estriol (E3).unconjugated [Multiple of the median] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51751,Uncon Bil,skos:broadMatch,omop:3007359,Bilirubin.indirect [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 50885
+mimic:51756,White Blood Cells,skos:broadMatch,omop:3000905,Leukocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51300
+mimic:51757,Xxx,,,,,,,,Not a lab test
+mimic:51758,Xylose,skos:broadMatch,omop:3019048,Xylose [Moles/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51759,Z,,,,,,,,Not a lab test
+mimic:51760,Z,,,,,,,,Not a lab test
+mimic:51761,Zinc,skos:broadMatch,omop:3017394,Zinc [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51770,MDRDgfr,skos:broadMatch,omop:46236952,"Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood by Creatinine-based formula (MDRD)",HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51771,,,,,,,,,Not a lab test
+mimic:51773,RFXFRKL,skos:broadMatch,omop:3035795,FMR1 gene targeted mutation analysis in Blood or Tissue by Molecular genetics method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51774,RFXHCV,skos:broadMatch,omop:3052023,Hepatitis C virus Ab Signal/Cutoff in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51775,(Albumin),skos:broadMatch,omop:3024474,Albumin [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51777,"Albumin, CSF",skos:broadMatch,omop:3024474,Albumin [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51775
+mimic:51778,Alpha-1,skos:broadMatch,omop:3018149,Alpha 1 globulin/Protein.total in Cerebral spinal fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51779,Alpha-2,skos:broadMatch,omop:3006757,Alpha 2 globulin/Protein.total in Cerebral spinal fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51780,"Amylase, CSF",skos:broadMatch,omop:3007327,Amylase [Enzymatic activity/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51781,Beta,skos:broadMatch,omop:3025229,Beta globulin/Protein.total in Cerebral spinal fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51782,"Bicarbonate, CSF",skos:broadMatch,omop:3005805,Bicarbonate [Moles/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51784,"Chloride, CSF",skos:broadMatch,omop:3036172,Chloride [Moles/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51785,"Cholesterol, CSF",skos:broadMatch,omop:3035660,Cholesterol [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51786,Clostrid,skos:broadMatch,omop:46236184,Clostridium perfringens [Presence] in Specimen by Organism specific culture,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51787,"Creatinine, CSF",skos:broadMatch,omop:3024535,Creatinine [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51788,Cryptococ,skos:broadMatch,omop:3001363,Cryptococcus sp Ag [Presence] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51789,Fl Scan,,,,,,,,Ambiguous name
+mimic:51792,"Immunoelectrophoresis, CSF",skos:broadMatch,omop:3041917,Immunoelectrophoresis for Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51793,"Immunoglobulin G, CSF",skos:broadMatch,omop:3007368,IgG [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51794,"Immunoglobulin G, CSF",skos:broadMatch,omop:3007368,IgG [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51793
+mimic:51797,"Osmolality, CSF",skos:broadMatch,omop:3028160,Osmolality of Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51799,"PEP, CSF, Gamma Region",skos:broadMatch,omop:3022932,Gamma globulin [Mass/volume] in Cerebral spinal fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51800,"Potassium, CSF",skos:broadMatch,omop:3018062,Potassium [Moles/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51801,"Sodium, CSF",skos:broadMatch,omop:3003834,Sodium [Moles/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51803,"Triglycerides, CSF",skos:broadMatch,omop:3036816,Triglyceride [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51804,"Urea Nitrogen, CSF",skos:broadMatch,omop:3034450,Urea nitrogen [Mass/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51805,"Uric Acid, CSF",skos:broadMatch,omop:3007151,Urate [Mass/volume] in Cerebral spinal fluid,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:51807,(Albumin),skos:broadMatch,omop:3025380,Albumin [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51808,Alpha-1,skos:broadMatch,omop:3026790,Alpha 1 globulin/Protein.total in Synovial fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51809,Alpha-2,skos:broadMatch,omop:3028168,Alpha 2 globulin/Protein.total in Synovial fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51810,Beta,skos:broadMatch,omop:3028778,Beta globulin/Protein.total in Synovial fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51811,"Bicarbonate,Joint Fluid",skos:broadMatch,omop:3014637,Bicarbonate [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51812,"Bilirubin, Total, Joint Fluid",skos:broadMatch,omop:3014687,Bilirubin.total [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51813,"Chloride, Joint Fluid",skos:broadMatch,omop:3009024,Chloride [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51814,"Cholesterol, Joint Fluid",skos:broadMatch,omop:3020324,Cholesterol [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51815,Clostrid,skos:broadMatch,omop:1617096,Clostridium perfringens [Presence] in Synovial fluid by NAA with non-probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51816,Cryptococ,skos:broadMatch,omop:3024255,Cryptococcus sp Ag [Presence] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51817,Fl Scan,,,,,,,,Ambiguous name
+mimic:51818,"IgG, Joint Fluid",skos:broadMatch,omop:3031064,Immune complex.IgG [Units/volume] in Synovial fluid by C1q binding assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51819,"Immunoelectrophoresis, Joint Fluid",skos:broadMatch,omop:3000265,Immunoelectrophoresis for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51820,"Osmolality, Joint Fluid",skos:broadMatch,omop:3028160,Osmolality of Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51821,"PEP, Joint Fluid, Gamma Region",skos:broadMatch,omop:3000516,Gamma globulin [Mass/volume] in Synovial fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51822,"Potassium, Joint Fluid",skos:broadMatch,omop:3007485,Potassium [Moles/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51823,"Sodium, Joint Fluid",skos:broadMatch,omop:3026681,Sodium [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51824,"Triglycerides, Joint Fluid",skos:broadMatch,omop:3014110,Triglyceride [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51825,"Urea Nitrogen, Joint Fluid",skos:broadMatch,omop:3006710,Urea nitrogen [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51826,"Uric Acid, Joint Fluid",skos:broadMatch,omop:3038146,Urate [Mass/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51828,Voided Specimen,,,,,,,,Not a lab test
+mimic:51829,72 Hr Fat,skos:broadMatch,omop:3023505,Fat [Mass/time] in 72 hour Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51830,Acid BAO,,,,,,,,Not a lab test
+mimic:51831,Acid MAO,,,,,,,,Not a lab test
+mimic:51833,"AFP, Amniotic Fluid",skos:broadMatch,omop:3010296,Alpha-1-Fetoprotein [Mass/volume] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51834,"AFP, Body Fluid",skos:broadMatch,omop:3034165,Alpha-1-Fetoprotein [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51835,(Albumi,skos:broadMatch,omop:3025313,Albumin [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51836,<Albumin>,skos:broadMatch,omop:3025313,Albumin [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51835
+mimic:51837,Alpha-1,skos:broadMatch,omop:3019891,Alpha 1 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51838,Alpha-2,skos:broadMatch,omop:3005504,Alpha 2 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51840,Beta,skos:broadMatch,omop:3003304,Beta globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51841,"Blood, Occult",skos:broadMatch,omop:3016251,Hemoglobin.gastrointestinal [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51842,Bun,skos:broadMatch,omop:3019930,Urea nitrogen [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51843,C. diff PCR,skos:broadMatch,omop:40764128,Clostridioides difficile DNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51844,C diff Toxin Antigen Assay,skos:broadMatch,omop:3026688,Clostridioides difficile toxin A+B [Units/volume] in Specimen by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51847,Clostrid,skos:broadMatch,omop:3007592,Clostridium perfringens enterotoxin [Presence] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51854,Cryptococ,skos:broadMatch,omop:3023879,Cryptococcus sp Ag [Presence] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51855,"DSPC, Amniotic Fluid",skos:broadMatch,omop:3036054,Phosphatidylcholine/Albumin [Mass Ratio] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51856,Epr,,,,,,,,Ambiguous name
+mimic:51857,Fl Scan,,,,,,,,Ambiguous name
+mimic:51858,HIV 1 Viral Load,skos:broadMatch,omop:3038207,HIV 1 RNA [#/volume] (viral load) in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51861,"Immunoelectrophoresis, Fluid",skos:broadMatch,omop:3000265,Immunoelectrophoresis for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51862,"Immunoglobulin G, Body Fluid",skos:broadMatch,omop:3015390,IgG [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51876,"L/S Ratio, Amniotic Fluid",skos:broadMatch,omop:3035904,Lecithin/Sphingomyelin [Ratio] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51880,Norovirus Genogroup I,skos:broadMatch,omop:1616677,Norovirus genogroup I RNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51881,Norovirus Genogroup II,skos:broadMatch,omop:1616915,Norovirus genogroup II RNA [Presence] in Specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51882,O & P,skos:broadMatch,omop:3012744,Ova and parasites identified in Specimen by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51887,"PEP, Body Fluid",skos:broadMatch,omop:36305551,Protein electrophoresis panel - Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51888,"PEP, Body Fluid, Gamma Region",skos:broadMatch,omop:3023700,Gamma globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51889,Phosphatidylglycerol,skos:broadMatch,omop:3013297,Phosphatidylglycerol [Presence] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:51896,Sudan Stain,skos:broadMatch,omop:3013569,Microscopic observation [Identifier] in Body fluid by Sudan black stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51898,Surf/Alb,skos:broadMatch,omop:3017439,Surfactant/Albumin [Mass Ratio] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51897
+mimic:51900,"Uric Acid, Body Fluid",skos:broadMatch,omop:3050920,Urate [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51902,Vpf,,,,,,,,Ambiguous name
+mimic:51905,,,,,,,,,Not a lab test
+mimic:51906,reuse,,,,,,,,Not a lab test
+mimic:51907,reuse1,,,,,,,,Not a lab test
+mimic:51910,(Albumin),skos:broadMatch,omop:3011544,Albumin [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51911,Alpha-1,skos:broadMatch,omop:3019891,Alpha 1 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51912,Alpha-2,skos:broadMatch,omop:3005504,Alpha 2 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51913,Beta,skos:broadMatch,omop:3003304,Beta globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51914,Clostrid,skos:broadMatch,omop:46236184,Clostridium perfringens [Presence] in Specimen by Organism specific culture,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51915,Cryptococ,skos:broadMatch,omop:3024255,Cryptococcus sp Ag [Presence] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51916,Fl Scan,,,,,,,,Ambiguous name
+mimic:51917,"Immunoelectrophoresis, Pleural",skos:broadMatch,omop:3000265,Immunoelectrophoresis for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51918,"Immunoglobulin G, Pleural",skos:broadMatch,omop:3015390,IgG [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51919,"Osmolality, Pleural",skos:broadMatch,omop:3016098,Osmolality of Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51920,"PEP, Pleural, Gamma Region",skos:broadMatch,omop:3023700,Gamma globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51922,"Urea Nitrogen, Pleural",skos:broadMatch,omop:3004717,Urea nitrogen [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51923,"Uric Acid, Pleural",skos:broadMatch,omop:40763523,Urate [Mass/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51925,72 Hr Fat,skos:broadMatch,omop:3023505,Fat [Mass/time] in 72 hour Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51926,(Albumin),skos:broadMatch,omop:40757477,Albumin [Mass/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51927
+mimic:51927,"Albumin, Stool",skos:broadMatch,omop:40757477,Albumin [Mass/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51928,Alpha-1,skos:broadMatch,omop:3019891,Alpha 1 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51929,Alpha-2,skos:broadMatch,omop:3005504,Alpha 2 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51930,"Amylase, Stool",skos:broadMatch,omop:3021162,Amylase [Enzymatic activity/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51931,Beta,skos:broadMatch,omop:3003304,Beta globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51932,"Bilirubin, Total, Stool",skos:broadMatch,omop:3024733,Bilirubin.total [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51935,"Cholesterol, Stool",skos:broadMatch,omop:3015548,Cholesterol [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51936,Clostrid,skos:broadMatch,omop:3032057,Clostridioides difficile [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51937,"Creatinine, Stool",skos:broadMatch,omop:3052695,Creatinine [Moles/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51938,Cryptococ,skos:broadMatch,omop:3024255,Cryptococcus sp Ag [Presence] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51939,Fl Scan,,,,,,,,Ambiguous name
+mimic:51940,Gamma,skos:broadMatch,omop:3023700,Gamma globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51941,"Glucose, Stool",skos:broadMatch,omop:3040980,Glucose [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51942,"IgG, Stool",skos:broadMatch,omop:3015390,IgG [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51943,"Immunoelectrophoresis, Stool",skos:broadMatch,omop:3000265,Immunoelectrophoresis for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51944,"Lactate Dehydrogenase, Stool",skos:broadMatch,omop:3007869,Lactate dehydrogenase [Enzymatic activity/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:51947,O & P,skos:broadMatch,omop:3020389,Ova and parasites identified in Stool by Concentration,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51948,Sudan Stain,skos:broadMatch,omop:3024796,Fat.microscopic observation [Identifier] in Stool by Sudan IV stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51949,"Total Protein, Stool",skos:broadMatch,omop:3051707,Protein [Mass/volume] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51950,"Triglycerides, Stool",skos:broadMatch,omop:46236065,Triglyceride [Mass/mass] in 24 hour Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51951,"Urea Nitrogen, Stool",skos:broadMatch,omop:3019930,Urea nitrogen [Mass/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51952,"Uric Acid, Stool",skos:broadMatch,omop:3028566,Urate [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51955,,,,,,,,,Not a lab test
+mimic:51957,17-Hydroxycorticosteroids,skos:broadMatch,omop:3026205,17-Hydroxycorticosteroids [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51958,"17-Ketosteroids, Urine",skos:broadMatch,omop:3020027,17-Ketosteroids [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51959,"5-HIAA, Urine",skos:broadMatch,omop:3005148,5-Hydroxyindoleacetate [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51960,Aldolase,skos:broadMatch,omop:3032449,Aldolase [Enzymatic activity/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:51961,Alpha-1,skos:broadMatch,omop:3026665,Alpha 1 globulin/Protein.total in Urine by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51962,Alpha-2,skos:broadMatch,omop:3028558,Alpha 2 globulin/Protein.total in Urine by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51963,Amylase/Creatinine Clearance,skos:broadMatch,omop:3003046,Amylase/Creatinine renal clearance [Ratio] in Urine and Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51964,"Amylase, Serum",skos:broadMatch,omop:3017315,Amylase [Enzymatic activity/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,"Conflict. Label is ""Serum"", Fluid is ""Urine"""
+mimic:51965,Beta,skos:broadMatch,omop:3009565,Beta globulin/Protein.total in Urine by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51968,Camp,skos:broadMatch,omop:3004131,Adenosine monophosphate.cyclic [Moles/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51969,"Catecholamines, Urine",skos:broadMatch,omop:3033473,Catecholamines [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51970,Cben,,,,,,,,Ambiguous name
+mimic:51971,Ccoc,,,,,,,,Ambiguous name
+mimic:51973,Copi,,,,,,,,Ambiguous name
+mimic:51974,"Copper, Urine",skos:broadMatch,omop:3028506,Copper [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51975,Coproporphyrins,skos:broadMatch,omop:3019954,Coproporphyrin [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51976,"Cortisol, Urine",skos:broadMatch,omop:3037229,Cortisol [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51977,"Creatinine, Blood",skos:broadMatch,omop:3017250,Creatinine [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,"Conflict. Label is ""Blood"", Fluid is ""Urine"""
+mimic:51978,DirList,,,,,,,,Not a lab test
+mimic:51979,"Estriol, Urine",skos:broadMatch,omop:3013426,Estriol (E3) [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51982,"Immunoelectrophoresis, Urine",skos:broadMatch,omop:3008366,Immunoelectrophoresis panel - Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51983,"Iron, Urine",skos:broadMatch,omop:3001312,Iron [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51988,O & P,skos:broadMatch,omop:46235447,Ova and parasites identified in Urine by Trichrome stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51990,"Phenothiazine Screen, Urine",skos:broadMatch,omop:3020282,Phenothiazines [Presence] in Urine by Screen method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51991,"Propoxyphene, Urine",skos:broadMatch,omop:3011802,Propoxyphene [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:51993,Referred,,,,,,,,Not a lab test
+mimic:51995,Study Urine,,,,,,,,Not a lab test
+mimic:51997,UIFEgel,,,,,,,,Not a lab test
+mimic:51998,UPEPgel,,,,,,,,Not a lab test
+mimic:51999,Urine Amylase,skos:broadMatch,omop:3017315,Amylase [Enzymatic activity/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52000,Urine  Creatinine,skos:broadMatch,omop:3017250,Creatinine [Mass/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate ot itemid 51082
+mimic:52001,"Urine PEP, Gamma region",skos:broadMatch,omop:3010157,Gamma globulin/Protein.total in Urine by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52003,Uroporphyrins,skos:broadMatch,omop:3004961,Uroporphyrin [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52011,UTX8,,,,,,,,Ambiguous name
+mimic:52013,Vanillylmandelic Acid,skos:broadMatch,omop:3025591,Vanillylmandelate [Mass/time] in 24 hour Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52015,Xylose,skos:broadMatch,omop:3051069,Xylose [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52016,Z,,,,,,,,Not a lab test
+mimic:52017,"Zinc, Urine",skos:broadMatch,omop:3041478,Zinc [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52021,Abz,,,,,,,,Ambiguous name
+mimic:52022,"Albumin, Blood",skos:broadMatch,omop:3024561,Albumin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52025,Delete,,,,,,,,Not a lab test
+mimic:52027,"Glucose, Whole Blood",skos:broadMatch,omop:3000483,Glucose [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52028,Hematocrit,skos:broadMatch,omop:3023230,Hematocrit [Volume Fraction] of Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:52029,% Ionized Calcium,skos:broadMatch,omop:3032710,Calcium.ionized/Calcium.total corrected for albumin in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52030,Lithium,skos:broadMatch,omop:3001823,Lithium [Moles/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52031,Osmolality,skos:broadMatch,omop:3008295,Osmolality of Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52032,P50 of Hemoglobin,skos:broadMatch,omop:3015968,Oxygen [Partial pressure] saturation adjusted to 0.5 in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52034,Total Calcium,skos:broadMatch,omop:3032503,Calcium [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52035,Total Calcium,skos:broadMatch,omop:3032503,Calcium [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,Duplicate of itemid 52034
+mimic:52037,WB tCO2,skos:broadMatch,omop:3014094,"Carbon dioxide, total [Moles/volume] in Blood",HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52038,Base Excess,skos:broadMatch,omop:3003396,Base excess in Arterial blood by calculation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,No Fluid info
+mimic:52039,Calculated Bicarbonate,skos:broadMatch,omop:3008152,Bicarbonate [Moles/volume] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,No Fluid info
+mimic:52040,pCO2,skos:broadMatch,omop:3027946,Carbon dioxide [Partial pressure] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,No Fluid info
+mimic:52041,pH,skos:broadMatch,omop:3019977,pH of Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,No Fluid info
+mimic:52042,pO2,skos:broadMatch,omop:3027801,Oxygen [Partial pressure] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,No Fluid info
+mimic:52044,"Osmolality, Urine",skos:broadMatch,omop:3026782,Osmolality of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52045,"pH, Urine",skos:broadMatch,omop:3015736,pH of Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52046,"Potassium, Urine",skos:broadMatch,omop:3016038,Potassium [Moles/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,"Duplicate of itemid 51097. Conflict. Fluid is ""Urine"" while Category is ""Blood Gas"""
+mimic:52047,"Sodium, Urine",skos:broadMatch,omop:3003181,Sodium [Moles/volume] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,"Duplicate of itemid 51100. Conflict. Fluid is ""Urine"" while Category is ""Blood Gas"""
+mimic:52048,Atyps#,skos:broadMatch,omop:3031744,Variant lymphocytes [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52049,Bands#,skos:broadMatch,omop:3032632,Band form neutrophils [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52050,Basos#,skos:broadMatch,omop:3030877,Basophils [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52051,Blasts#,skos:broadMatch,omop:3031471,Blasts [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52052,Eos#,skos:broadMatch,omop:3032059,Eosinophils [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52053,Histio#,skos:broadMatch,omop:3030564,Histiocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52054,Histiocyte,skos:broadMatch,omop:3041062,Histiocytes/100 cells in Peritoneal fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52055,Hyperseg,skos:broadMatch,omop:3030345,Segmented neutrophils/100 leukocytes in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52056,Hyperseg#,skos:broadMatch,omop:3032375,Segmented neutrophils [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52057,Lymphs#,skos:broadMatch,omop:3030833,Lymphocytes [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52058,Metas#,skos:broadMatch,omop:3003467,Lymphocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52059,Monos#,skos:broadMatch,omop:3030599,Monocytes [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52060,Myelos#,skos:broadMatch,omop:3032657,Myelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52061,Nuc Rbcs#,skos:broadMatch,omop:3028129,Nucleated erythrocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52062,Plasma#,skos:broadMatch,omop:3031165,Plasma cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52063,Polys#,skos:broadMatch,omop:3031154,Polymorphonuclear cells [#/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52064,Promyelo#,skos:broadMatch,omop:3031780,Promyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52066,Voided Specimen,,,,,,,,Not a lab test
+mimic:52067,Young#,,,,,,,,Ambiguous name
+mimic:52068,24 Hr,,,,,,,,Not a lab test
+mimic:52070,Absolute CD19 Count,skos:broadMatch,omop:3010503,CD19 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52071,Absolute CD20 Count,skos:broadMatch,omop:3018071,CD20 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52072,Absolute CD56 Count,skos:broadMatch,omop:3026757,CD56 cells [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52076,Acid Phosphatase Stain,skos:broadMatch,omop:3006461,Microscopic observation [Identifier] in Blood or Marrow by Tartrate-resistant acid phosphatase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52077,Acidserum,skos:broadMatch,omop:3037556,Urate [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52078,Antithrombin III,skos:broadMatch,omop:3000515,Antithrombin actual/normal in Platelet poor plasma by Chromogenic method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52079,ASA Tol,skos:broadMatch,omop:3019107,Acetylsalicylate [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52080,Asd,,,,,,,,Ambiguous name
+mimic:52081,ASD & NA-F,,,,,,,,Ambiguous name
+mimic:52082,Aspirin Reactivity,skos:broadMatch,omop:3039998,Platelet aggregation arachidonate induced [Units/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52083,Autohem+g,,,,,,,,Ambiguous name
+mimic:52084,Autohem-g,,,,,,,,Ambiguous name
+mimic:52085,Bleed Tm,skos:broadMatch,omop:3011625,Bleeding time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52086,Bleed Tm,skos:broadMatch,omop:3011625,Bleeding time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52089,CD30,skos:broadMatch,omop:3002041,CD30 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52090,CD42,skos:broadMatch,omop:3002464,CD42 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52091,CD52,skos:broadMatch,omop:3015771,CD52 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52094,CD61,skos:broadMatch,omop:3022458,CD61 cells/100 cells in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52095,CD62,skos:broadMatch,omop:3042828,CD62 cells/100 cells in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52096,Chloroacetate,skos:broadMatch,omop:3023435,Microscopic observation [Identifier] in Tissue by Chloracetate esterase stain,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52097,Circ Ab,skos:broadMatch,omop:3044917,Immunoglobulin panel [Mass/volume] - Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",0,
+mimic:52098,Clot Lysis,skos:broadMatch,omop:3023055,Clot Lysis [Time] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52099,Clot Retraction,skos:broadMatch,omop:3013528,Clot Retraction [Time] in Blood by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52100,Clot Time,skos:broadMatch,omop:3041078,Clot formation [Time] in Blood by Thromboelastography,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52101,Cr,skos:broadMatch,omop:3051825,Creatinine [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52102,Crenated Cells,skos:broadMatch,omop:3005854,Burr cells [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52103,Cross Imm,skos:broadMatch,omop:3044917,Immunoglobulin panel [Mass/volume] - Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52104,Cryoglob,skos:broadMatch,omop:3021322,Cryoglobulin [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52105,Direct Antiplatelet Antibodies,skos:broadMatch,omop:3017451,Platelet associated Ab [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52106,Donath-l,skos:broadMatch,omop:3024486,Donath Landsteiner Ab [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52110,DSmear,,,,,,,,Ambiguous name
+mimic:52112,Euglobulin Lysis,skos:broadMatch,omop:3023055,Clot Lysis [Time] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52113,Factor IX Inhibitor,skos:broadMatch,omop:3004009,Coagulation factor IX inhibitor [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52114,Factor VIII Antigen,skos:broadMatch,omop:3006728,Coagulation factor VIII Ag [Presence] in Tissue by Immune stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52115,Fibrinoge,skos:broadMatch,omop:3016407,Fibrinogen [Mass/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52116,Fibrinogen,skos:broadMatch,omop:3016407,Fibrinogen [Mass/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 52115
+mimic:52117,"Fibrinogen, Immunologic",skos:broadMatch,omop:3016628,Fibrinogen Ag [Mass/volume] in Platelet poor plasma by Immunoassay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52119,Fitzgerld,skos:broadMatch,omop:3012816,Kininogen HMW [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52120,Fitzgerld,skos:broadMatch,omop:3012816,Kininogen HMW [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,Duplicate of itemid 52119
+mimic:52121,Fletcher,skos:broadMatch,omop:3002315,Prekallikrein (Fletcher Factor) [Units/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52122,Fsp,skos:broadMatch,omop:3000401,Fibrin+Fibrinogen fragments [Mass/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52124,G6pd Spec,skos:broadMatch,omop:3003994,Glucose-6-Phosphate dehydrogenase [Enzymatic activity/mass] in Red Blood Cells,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52125,Glutathione,skos:broadMatch,omop:3015416,Glutathione [Mass/volume] in Red Blood Cells,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52126,Heinz Aph,skos:broadMatch,omop:3022613,Heinz bodies [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52127,Helmet Cells,skos:broadMatch,omop:3023873,Helmet cells [Presence] in Blood by Light microscopy,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52128,Hemoglobin H Inclusion,skos:broadMatch,omop:40762276,Hemoglobin H inclusion bodies [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52130,Histiocytes,skos:broadMatch,omop:3043564,Histiocytes [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52133,Hmwk,skos:broadMatch,omop:3012816,Kininogen HMW [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52134,IG,skos:broadMatch,omop:3044917,Immunoglobulin panel [Mass/volume] - Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52136,Inhibitor,,,,,,,,Ambiguous name
+mimic:52137,Inh Scr,,,,,,,,Ambiguous name
+mimic:52138,Kct,skos:broadMatch,omop:3014712,Kaolin activated time [Units/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52139,LE Prep,skos:broadMatch,omop:3017650,Lupus erythematosus cells [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52140,LS,skos:broadMatch,omop:3044009,aPTT.lupus sensitive (LA screen),HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",0,
+mimic:52141,Malaria Smear,skos:broadMatch,omop:3045707,Microscopic observation [Identifier] in Blood by Malaria smear,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52142,Mean Platelet Volume,skos:broadMatch,omop:3043111,Platelet mean volume [Entitic volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52143,Methemalb,skos:broadMatch,omop:3024807,Methemalbumin [Presence] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52144,Methemoglobin,skos:broadMatch,omop:3004831,Methemoglobin [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52145,Mono Spot Test,skos:broadMatch,omop:3033533,Heterophile Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52146,Naphtol Acetate Stain,skos:broadMatch,omop:3014679,Microscopic observation [Identifier] in Tissue by Acetate esterase stain,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52147,NEUTX,,,,,,,,Ambiguous name
+mimic:52148,NEUTY,,,,,,,,Ambiguous name
+mimic:52149,NFletcher,skos:broadMatch,omop:3002315,Prekallikrein (Fletcher Factor) [Units/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52150,Non-Specific Esterase,skos:broadMatch,omop:3024873,Microscopic observation [Identifier] in Blood or Marrow by Esterase stain.non-specific,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52151,NRBC,skos:broadMatch,omop:3045168,Nucleated erythrocytes [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52152,"Osmotic Fragility, Incubated",skos:broadMatch,omop:3046583,Osmotic fragility [Interpretation] of Red Blood Cells--Incubated,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52153,Other Inhibitor,,,,,,,,Ambiguous name
+mimic:52154,P2Y12 Reaction Units,skos:broadMatch,omop:3048603,Platelet aggregation ADP induced [Units/volume] in Platelet rich plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52155,Periodic Acid Schiff Stain,skos:broadMatch,omop:3012525,Microscopic observation [Identifier] in Blood or Marrow by Periodic acid-Schiff stain,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52156,Peroxidase Staining,skos:broadMatch,omop:3026228,Microscopic observation [Identifier] in Blood or Marrow by Peroxidase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52157,Plasma Hemoglobin,skos:broadMatch,omop:3022493,Free Hemoglobin [Mass/volume] in Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52158,Plasminogen,skos:broadMatch,omop:3002535,Plasminogen [Units/volume] in Platelet poor plasma by Chromogenic method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52159,Platelet Aggregation,skos:broadMatch,omop:3020174,Platelet aggregation [Interpretation] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52160,Prekallekrein,skos:broadMatch,omop:3004231,Prekallikrein (Fletcher Factor) [Presence] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52161,Problem Specimen,,,,,,,,Not a lab test
+mimic:52162,Protein S,skos:broadMatch,omop:3002346,Protein S [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52163,PT Control,skos:broadMatch,omop:3033891,Prothrombin time (PT) in Control Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52164,PT Mean,skos:broadMatch,omop:3034426,Prothrombin time (PT),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52165,PTT Control,skos:broadMatch,omop:3038102,aPTT in Control Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52166,PTT-LA,skos:broadMatch,omop:3044009,aPTT.lupus sensitive (LA screen),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52167,PTT mea,skos:broadMatch,omop:3013176,aPTT normal/actual in Platelet poor plasma by Coagulation assay,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52168,Pyruvate Kinase,skos:broadMatch,omop:3015478,Pyruvate kinase [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52169,QFib,,,,,,,,Ambiguous name
+mimic:52170,Rbc,skos:broadMatch,omop:3020416,Erythrocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51279
+mimic:52173,Red Blood Cell Enzyme,skos:broadMatch,omop:43055529,Erythrocyte enzyme panel - Red Blood Cells,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52174,"Reptilase Time, Control",skos:broadMatch,omop:3011893,Reptilase time in Control Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52175,Ristocetin Response,skos:broadMatch,omop:3037533,von Willebrand factor (vWf) ristocetin cofactor actual/normal in Platelet poor plasma by Platelet aggregation,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52180,STA-CLOT,skos:broadMatch,omop:46235691,dRVVT W excess hexagonal phospholipid (STA-StaClot confirm),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52182,Sudan Black Staining,skos:broadMatch,omop:3012524,Microscopic observation [Identifier] in Blood or Marrow by Sudan black B stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52183,Sulf Hgb,skos:broadMatch,omop:3010904,Sulfhemoglobin [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52186,Test,,,,,,,,Not a lab test
+mimic:52187,Thrombin Time,skos:broadMatch,omop:3036489,Thrombin time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52188,Thrombin Time Control,skos:broadMatch,omop:3005080,Thrombin time in Control Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52189,Thrombin Time Control,skos:broadMatch,omop:3005080,Thrombin time in Control Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52190,Tissue Thromboplastin Inhibitor,skos:broadMatch,omop:3033295,Lupus anticoagulant neutralization dilute phospholipid actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Discouraged LOINC code
+mimic:52191,Tr- Acid,,,,,,,,Ambiguous name
+mimic:52192,Trap Stain,skos:broadMatch,omop:3006461,Microscopic observation [Identifier] in Blood or Marrow by Tartrate-resistant acid phosphatase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52193,Viii Ag,skos:broadMatch,omop:3052074,Coagulation factor VIII Ag actual/normal in Platelet poor plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52194,VIII-CIE,,,,,,,,Ambiguous name
+mimic:52196,WAM Manual Diff,skos:broadMatch,omop:40760892,CBC W Ordered Manual Differential panel - Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52197,WAM MANUAL DIFF 2,skos:broadMatch,omop:40760892,CBC W Ordered Manual Differential panel - Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,Duplicate of itemid 52196
+mimic:52198,ErytFlg,skos:broadMatch,omop:3020416,Erythrocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52199,FragFlg,skos:broadMatch,omop:3019880,Schistocytes [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52200,PltDist,skos:broadMatch,omop:3002736,Platelet distribution width [Entitic volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52201,PltScat,skos:broadMatch,omop:3024929,Platelets [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52202,PltClmp,skos:broadMatch,omop:3035460,Platelet clump [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52203,RBCAgg,skos:broadMatch,omop:3041228,Erythrocyte aggregates [Presence] in Blood by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52204,RBCDist,skos:broadMatch,omop:3019897,Erythrocyte distribution width [Ratio] by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52205,RetScat,skos:broadMatch,omop:3023520,Reticulocytes [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52206,RetFlg,skos:broadMatch,omop:3027945,Reticulocytes/100 erythrocytes in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52207,TurbHbI,skos:broadMatch,omop:3000963,Hemoglobin [Mass/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52208,BasoFlg,skos:broadMatch,omop:3013429,Basophils [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52209,EosFlg,skos:broadMatch,omop:3028615,Eosinophils [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52210,LeftShf,skos:broadMatch,omop:3014099,Leukocytes Left Shift [Presence] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52211,LymFlg,skos:broadMatch,omop:3004327,Lymphocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52212,MonoFlg,skos:broadMatch,omop:3011948,Monocytes/100 leukocytes in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52213,NRBCFlg,skos:broadMatch,omop:3007238,Nucleated erythrocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52214,AbnLymp,skos:broadMatch,omop:3008943,Abnormal lymphocytes [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52215,ATLFlg,,,,,,,,Ambiguous name
+mimic:52216,BlasFlg,skos:broadMatch,omop:3005105,Blasts [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52217,Bl/AbLy,,,,,,,,Ambiguous name
+mimic:52218,IG Flg,skos:broadMatch,omop:3044917,Immunoglobulin panel [Mass/volume] - Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52219,WBCScat,skos:broadMatch,omop:3000905,Leukocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52222,Atyps#,skos:broadMatch,omop:3031773,Variant lymphocytes [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52224,Bands#,skos:broadMatch,omop:3032644,Band form neutrophils [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52226,Basos#,skos:broadMatch,omop:3030870,Basophils [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52228,Blasts#,skos:broadMatch,omop:3032352,Blasts [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52229,Delete,,,,,,,,Not a lab test
+mimic:52230,Delete,,,,,,,,Not a lab test
+mimic:52231,Delete,,,,,,,,Not a lab test
+mimic:52232,Delete,,,,,,,,Not a lab test
+mimic:52233,Delete,,,,,,,,Not a lab test
+mimic:52234,Delete,,,,,,,,Not a lab test
+mimic:52235,Delete,,,,,,,,Not a lab test
+mimic:52236,Delete,,,,,,,,Not a lab test
+mimic:52237,Delete,,,,,,,,Not a lab test
+mimic:52238,Delete,,,,,,,,Not a lab test
+mimic:52239,Delete,,,,,,,,Not a lab test
+mimic:52240,Delete,,,,,,,,Not a lab test
+mimic:52241,Delete,,,,,,,,Not a lab test
+mimic:52242,Delete,,,,,,,,Not a lab test
+mimic:52243,Delete,,,,,,,,Not a lab test
+mimic:52244,Delete,,,,,,,,Not a lab test
+mimic:52245,Delete,,,,,,,,Not a lab test
+mimic:52246,Delete,,,,,,,,Not a lab test
+mimic:52247,Delete,,,,,,,,Not a lab test
+mimic:52248,Delete,,,,,,,,Not a lab test
+mimic:52249,Delete,,,,,,,,Not a lab test
+mimic:52250,Delete,,,,,,,,Not a lab test
+mimic:52251,Delete,,,,,,,,Not a lab test
+mimic:52252,Delete,,,,,,,,Not a lab test
+mimic:52253,Delete,,,,,,,,Not a lab test
+mimic:52254,Delete,,,,,,,,Not a lab test
+mimic:52255,Eos#,skos:broadMatch,omop:3031163,Eosinophils [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52258,Histiocyte,skos:broadMatch,omop:3007666,Histiocytes/100 cells in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52260,Hypersegmented Neutrophils,skos:broadMatch,omop:3017900,Segmented neutrophils/100 leukocytes in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52261,Hypersegmented Neutrophils #,skos:broadMatch,omop:3032385,Segmented neutrophils [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52265,Lymphs#,skos:broadMatch,omop:3004560,Lymphocytes [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52267,Macrophage#,skos:broadMatch,omop:3033163,Macrophages [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52269,Mesothelial cells #,skos:broadMatch,omop:3032331,Mesothelial cells [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52271,Metas#,skos:broadMatch,omop:3032891,Metamyelocytes [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52273,Monos#,skos:broadMatch,omop:3030850,Monocytes [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52277,NRBC#,skos:broadMatch,omop:3015637,Nucleated erythrocytes [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52280,Plasma#,skos:broadMatch,omop:3031165,Plasma cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52282,Polys#,skos:broadMatch,omop:3030884,Polymorphonuclear cells [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52284,Promyelocytes#,skos:broadMatch,omop:3031768,Promyelocytes [#/volume] in Cerebral spinal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52289,Young#,,,,,,,,Ambiguous name
+mimic:52290,Dna,,,,,,,,Not a lab test
+mimic:52291,Atyps#,skos:broadMatch,omop:3031784,Variant lymphocytes [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52292,Bands#,skos:broadMatch,omop:3032620,Band form neutrophils [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52293,Basos#,skos:broadMatch,omop:3030892,Basophils [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52294,Blasts,skos:broadMatch,omop:3028907,Blasts/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52295,Blasts#,skos:broadMatch,omop:3032088,Blasts [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52296,Eos#,skos:broadMatch,omop:3032048,Eosinophils [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52297,Histio#,skos:broadMatch,omop:3030564,Histiocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52298,Histiocyte,skos:broadMatch,omop:3040382,Histiocytes/100 cells in Synovial fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52299,Hypersegmented Neutrophils,skos:broadMatch,omop:3030913,Segmented neutrophils/100 leukocytes in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52300,Hypersegmented Neutrophils #,skos:broadMatch,omop:3031201,Segmented neutrophils [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52302,Lymphs#,skos:broadMatch,omop:3032064,Lymphocytes [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52303,Metas#,skos:broadMatch,omop:3032903,Metamyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52304,Monos#,skos:broadMatch,omop:3012175,Monocytes [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52306,Myelos#,skos:broadMatch,omop:3032657,Myelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52308,Plasma#,skos:broadMatch,omop:3031165,Plasma cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52309,Polys#,skos:broadMatch,omop:3031142,Polymorphonuclear cells [#/volume] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52310,Promyelo#,skos:broadMatch,omop:3031780,Promyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52314,Young,,,,,,,,Ambiguous name
+mimic:52315,Young#,,,,,,,,Ambiguous name
+mimic:52316,Acid Phosphatase Stain,skos:broadMatch,omop:3022960,Microscopic observation [Identifier] in Bone by Acid phosphatase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52317,Asd,,,,,,,,Ambiguous name
+mimic:52318,Asd&na-f,,,,,,,,Ambiguous name
+mimic:52320,CD30,skos:broadMatch,omop:3030293,CD30 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52321,CD42,skos:broadMatch,omop:3030517,CD42 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52322,CD52,skos:broadMatch,omop:3031510,CD52 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52323,CD61,skos:broadMatch,omop:3029330,CD61 cells/100 cells in Bone marrow,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52324,CD62,skos:broadMatch,omop:3042828,CD62 cells/100 cells in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52325,Chloroacetate Esterase,skos:broadMatch,omop:3025107,Microscopic observation [Identifier] in Blood or Marrow by Chloracetate esterase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52326,Naphthol Acetate Stain,skos:broadMatch,omop:21493420,Microscopic observation [Identifier] in Bone marrow by Acetate esterase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52327,Naphthol Butryrate,skos:broadMatch,omop:3017994,Microscopic observation [Identifier] in Bone marrow by Butyrate esterase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52328,Periodic Schiff Stain,skos:broadMatch,omop:3012525,Microscopic observation [Identifier] in Blood or Marrow by Periodic acid-Schiff stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52329,Peroxidase Stain,skos:broadMatch,omop:3026228,Microscopic observation [Identifier] in Blood or Marrow by Peroxidase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52330,Sudan Black Stain,skos:broadMatch,omop:3012524,Microscopic observation [Identifier] in Blood or Marrow by Sudan black B stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52333,Tr-acid,,,,,,,,Ambiguous name
+mimic:52334,Voided Specimen,,,,,,,,Not a lab test
+mimic:52336,Atyps#,skos:broadMatch,omop:3031796,Variant lymphocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52337,Bands#,skos:broadMatch,omop:3032632,Band form neutrophils [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52338,Basos#,skos:broadMatch,omop:3030548,Basophils [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52340,Blasts#,skos:broadMatch,omop:3031492,Blasts [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52342,CD30,skos:broadMatch,omop:3030734,CD30 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52343,CD42,skos:broadMatch,omop:3029687,CD42 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52344,CD52,skos:broadMatch,omop:3031091,CD52 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52345,CD55,skos:broadMatch,omop:3043265,CD55 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52346,CD59,skos:broadMatch,omop:3043227,CD59 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52347,CD61,skos:broadMatch,omop:3031011,CD61 cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52348,CD62,skos:broadMatch,omop:3042828,CD62 cells/100 cells in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52349,Chloroac,skos:broadMatch,omop:3033233,Microscopic observation [Identifier] in Specimen by Chloracetate esterase stain,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52350,Eos#,skos:broadMatch,omop:3032084,Eosinophils [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52351,Fetal Hgb,skos:broadMatch,omop:3019561,Hemoglobin F [Presence] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52352,FETAL LUNG MATURITY - LBC,skos:broadMatch,omop:3000788,Lamellar bodies [#/volume] in Amniotic fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52353,Histiocyte#,skos:broadMatch,omop:3030564,Histiocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52354,Histiocytes,skos:broadMatch,omop:3030588,Histiocytes/100 leukocytes in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52356,Hypersegmented Neutrophils#,skos:broadMatch,omop:3019355,Segmented neutrophils [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52357,Iron,skos:broadMatch,omop:3043264,Iron [Presence] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52359,Lymphs#,skos:broadMatch,omop:3003467,Lymphocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52360,Metamyelocytes#,skos:broadMatch,omop:3032903,Metamyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52361,Monos#,skos:broadMatch,omop:3031141,Monocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52362,Myelos#,skos:broadMatch,omop:3032657,Myelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52363,NRBC#,skos:broadMatch,omop:3028129,Nucleated erythrocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52364,Plasma#,skos:broadMatch,omop:3031165,Plasma cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52365,Polys#,skos:broadMatch,omop:3030894,Polymorphonuclear cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52366,Promyelocyte#,skos:broadMatch,omop:3031780,Promyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52367,TCR Alpha-Beta,skos:broadMatch,omop:40760521,CD3+TCR alpha beta+ cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52368,TCR Gamma-Delta,skos:broadMatch,omop:40760541,CD3+TCR gamma delta+ cells/100 cells in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52371,Young,,,,,,,,Ambiguous name
+mimic:52372,Young#,,,,,,,,Ambiguous name
+mimic:52374,,,,,,,,,Not a lab test
+mimic:52375,Atyps#,skos:broadMatch,omop:3031758,Variant lymphocytes [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52376,Bands#,skos:broadMatch,omop:3032632,Band form neutrophils [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52377,Basos#,skos:broadMatch,omop:3030902,Basophils [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52378,Blasts#,skos:broadMatch,omop:3031481,Blasts [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52379,Eos#,skos:broadMatch,omop:3032072,Eosinophils [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52380,Histiocyte#,skos:broadMatch,omop:3030564,Histiocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52381,Histiocytes,skos:broadMatch,omop:3041613,Histiocytes/100 cells in Pleural fluid by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52382,Hypersegmented  Neutrophils#,skos:broadMatch,omop:3032608,Segmented neutrophils [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52383,Hypersegmented Neutrophils,skos:broadMatch,omop:3030924,Segmented neutrophils/100 leukocytes in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52384,Lymphs#,skos:broadMatch,omop:3030845,Lymphocytes [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52385,Metas#,skos:broadMatch,omop:3032903,Metamyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52386,Monos#,skos:broadMatch,omop:3031735,Monocytes [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52387,Myelos#,skos:broadMatch,omop:3032657,Myelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52388,Plasma#,skos:broadMatch,omop:3031165,Plasma cells [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52389,Polys#,skos:broadMatch,omop:3030872,Polymorphonuclear cells [#/volume] in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52390,Promyelocytes#,skos:broadMatch,omop:3031780,Promyelocytes [#/volume] in Body fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:52392,Voided Specimen,,,,,,,,Not a lab test
+mimic:52393,Young#,,,,,,,,Ambiguous name
+mimic:52394,FL1-D,,,,,,,,Ambiguous name
+mimic:52395,FL1-%FL2,,,,,,,,Ambiguous name
+mimic:52396,FL1-S,,,,,,,,Ambiguous name
+mimic:52397,FL2-D,,,,,,,,Ambiguous name
+mimic:52398,FL2-%FL1,,,,,,,,Ambiguous name
+mimic:52399,FL2-S,,,,,,,,Ambiguous name
+mimic:52400,FSC-S,,,,,,,,Ambiguous name
+mimic:52401,SSC-D,,,,,,,,Ambiguous name
+mimic:52402,SSC-S,,,,,,,,Ambiguous name
+mimic:52403,Bile,skos:broadMatch,omop:3007153,Bile [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52404,Fat,skos:broadMatch,omop:3022481,Fat [Presence] in Stool,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52405,Prblm,,,,,,,,Not a lab test
+mimic:52407,WBC,skos:broadMatch,omop:3014441,Leukocytes [Presence] in Stool by Light microscopy,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52408,Bacturia,skos:broadMatch,omop:3026008,Bacteria identified in Urine by Culture,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52409,Budding Yeast,skos:broadMatch,omop:3020830,Yeast.budding [Presence] in Urine sediment,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52411,Hgb,skos:broadMatch,omop:3011397,Hemoglobin [Presence] in Urine by Test strip,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52412,HPF,,,,,,,,Not a lab test
+mimic:52413,Leuks,skos:broadMatch,omop:3035583,Leukocytes [#/area] in Urine sediment by Microscopy high power field,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:52414,LEUKS,skos:broadMatch,omop:3035583,Leukocytes [#/area] in Urine sediment by Microscopy high power field,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 52413
+mimic:52415,LPF,,,,,,,,Not a lab test
+mimic:52416,Myoglobin,skos:broadMatch,omop:3011470,Myoglobin [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52417,Pku,skos:broadMatch,omop:3001962,Phenylalanine [Presence] in DBS,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,
+mimic:52418,Problem Specimen,,,,,,,,Not a lab test
+mimic:52420,ZZDUMMY,,,,,,,,Not a lab test
+mimic:52421,GATE,,,,,,,,Not a lab test
+mimic:52422,RUN,,,,,,,,Not a lab test
+mimic:52423,SKIP,,,,,,,,Not a lab test
+mimic:52434,"Chloride, Whole Blood",skos:broadMatch,omop:3031248,Chloride [Moles/volume] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:52442,Lactate,skos:broadMatch,omop:3018405,Lactate [Moles/volume] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:52452,"Potassium, Whole Blood",skos:broadMatch,omop:3043409,Potassium [Moles/volume] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:52455,"Sodium, Whole Blood",skos:broadMatch,omop:3043706,Sodium [Moles/volume] in Arterial blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.5,
+mimic:52548,Cryoglobulin,skos:broadMatch,omop:3021322,Cryoglobulin [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52562,Folate,skos:broadMatch,omop:3036987,Folate [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52703,"Albumin, Urine",skos:broadMatch,omop:3025987,Albumin [Presence] in Urine,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52786,Bleeding Time,skos:broadMatch,omop:3011625,Bleeding time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52838,Factor II,skos:broadMatch,omop:3005353,Prothrombin activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52840,Factor IX,skos:broadMatch,omop:3026498,Coagulation factor IX activity [Units/volume] in Platelet poor plasma by Chromogenic method,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52842,Factor V,skos:broadMatch,omop:3005757,Coagulation factor V activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52844,Factor VII,skos:broadMatch,omop:3011547,Coagulation factor VII activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52846,Factor VIII,skos:broadMatch,omop:3019250,Coagulation factor VIII activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52849,Factor X,skos:broadMatch,omop:3004409,Coagulation factor X activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52851,Factor XI,skos:broadMatch,omop:3001850,Coagulation factor XI activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52853,Factor XII,skos:broadMatch,omop:3002348,Coagulation factor XII activity actual/normal in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52855,Factor XIII,skos:broadMatch,omop:3019757,Coagulation factor XIII coagulum dissolution [Units/volume] in Platelet poor plasma by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52858,Fibrin Degradation Products,skos:broadMatch,omop:3000401,Fibrin+Fibrinogen fragments [Mass/volume] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52889,Lupus Anticoagulant,skos:broadMatch,omop:3027184,Lupus anticoagulant [Interpretation] in Platelet poor plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:52921,PT,skos:broadMatch,omop:3034426,Prothrombin time (PT),HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52923,PTT,skos:broadMatch,omop:3013466,aPTT in Blood by Coagulation assay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52929,Reptilase Time,skos:broadMatch,omop:3005308,Reptilase time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52934,"Reticulocyte Count, Manual",skos:broadMatch,omop:3041154,Reticulocytes [#/volume] in Blood by Manual count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:52948,Thrombin,skos:broadMatch,omop:3036489,Thrombin time,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53012,NRBC,skos:broadMatch,omop:40771130,Nucleated erythrocytes/100 leukocytes [Ratio] in Synovial fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53083,NRBC,skos:broadMatch,omop:42868644,Nucleated erythrocytes/100 cells in Pleural fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53084,Alanine Aminotransferase,skos:broadMatch,omop:3006923,Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 50861
+mimic:53085,Albumin,skos:broadMatch,omop:3028286,Albumin [Mass/volume] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 50862
+mimic:53086,Alkaline Phosphatase,skos:broadMatch,omop:3035995,Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53087,Amylase,skos:broadMatch,omop:3016771,Amylase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53088,Asparate Aminotransferase,skos:broadMatch,omop:3013721,Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53089,"Bilirubin, Total",skos:broadMatch,omop:3024128,Bilirubin.total [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 50885
+mimic:53093,Gamma Glutamyltranferase,skos:broadMatch,omop:3026910,Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53094,HBV VL CT,skos:broadMatch,omop:3027346,Hepatitis B virus DNA [#/volume] (viral load) in Serum or Plasma by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53095,Lyme VsIE/PepC10 Antibody,skos:broadMatch,omop:3004072,Borrelia burgdorferi Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53096,"Protein, Total",skos:broadMatch,omop:3020630,Protein [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53097,COV10,,,,,,,,Ambiguous name
+mimic:53098,COV11,,,,,,,,Ambiguous name
+mimic:53099,COV12,,,,,,,,Ambiguous name
+mimic:53100,COV13,,,,,,,,Ambiguous name
+mimic:53104,"COVID-19, RAPID ANTIGEN",skos:broadMatch,omop:723477,SARS-CoV-2 (COVID-19) Ag [Presence] in Respiratory specimen by Rapid immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53105,E GENE CT,skos:broadMatch,omop:36033659,SARS-CoV-2 (COVID-19) E gene [Cycle Threshold #] in Respiratory specimen by NAA with probe detection,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53106,E GENE ENDPT,,,,,,,,Ambiguous name
+mimic:53107,FLUA1,,,,,,,,Ambiguous name
+mimic:53108,FLUA2,,,,,,,,Ambiguous name
+mimic:53109,FLUB1,,,,,,,,Ambiguous name
+mimic:53110,FLUB2,,,,,,,,Ambiguous name
+mimic:53111,N2 GENE CT,skos:broadMatch,omop:706155,SARS-CoV-2 (COVID-19) N gene [Cycle Threshold #] in Specimen by Nucleic acid amplification using CDC primer-probe set N2,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53112,N2 GENE ENDPT,,,,,,,,Ambiguous name
+mimic:53113,Rapid Respiratory Syncytial Virus,skos:broadMatch,omop:43534059,Respiratory syncytial virus Ag [Presence] in Nasopharynx by Rapid immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53114,RSV1,,,,,,,,Ambiguous name
+mimic:53115,RSV2,,,,,,,,Ambiguous name
+mimic:53116,(Albumin),skos:broadMatch,omop:3026692,Albumin [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53117,Alpha-1,skos:broadMatch,omop:3019891,Alpha 1 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53118,Alpha-2,skos:broadMatch,omop:3005504,Alpha 2 globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53119,Beta,skos:broadMatch,omop:3003304,Beta globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53120,Clostrid,skos:broadMatch,omop:46236184,Clostridium perfringens [Presence] in Specimen by Organism specific culture,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53121,Cryptococ,skos:broadMatch,omop:3024255,Cryptococcus sp Ag [Presence] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53122,Fl Scan,,,,,,,,Ambiguous name
+mimic:53123,"Immunoelectrophoresis, Ascites",skos:broadMatch,omop:3000265,Immunoelectrophoresis for Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53124,"Immunoglobulin G, Ascites",skos:broadMatch,omop:40758032,IgG [Mass/volume] in Peritoneal fluid,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53125,"PEP, Ascites, Gamma Region",skos:broadMatch,omop:3023700,Gamma globulin/Protein.total in Body fluid by Electrophoresis,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53126,"Uric Acid, Ascites",skos:broadMatch,omop:3028566,Urate [Moles/volume] in Specimen,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0,No suitable LOINC code
+mimic:53128,11-Deoxycorticosterone,skos:broadMatch,omop:3008895,11-Deoxycorticosterone [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53129,3t,skos:broadMatch,omop:3010340,Triiodothyronine (T3) [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:53130,4t,skos:broadMatch,omop:3016991,Thyroxine (T4) [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,0.1,
+mimic:53131,5' Nucleotidase,skos:broadMatch,omop:3013614,5'-Nucleotidase [Enzymatic activity/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53132,Absolute Lymphocyte Count,skos:broadMatch,omop:3004327,Lymphocytes [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 51133
+mimic:53133,Absolute Neutrophil,skos:broadMatch,omop:3013650,Neutrophils [#/volume] in Blood by Automated count,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,Duplicate of itemid 52075
+mimic:53134,Absolute Other WBC,skos:broadMatch,omop:3008511,Leukocytes other [#/volume] in Blood,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53135,"Acid Phosphatase, Prostatic Fraction",skos:broadMatch,omop:3035029,Prostatic acid phosphatase [Enzymatic activity/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53136,Adrenocorticotrophic Hormone,skos:broadMatch,omop:3033768,Corticotropin IgE Ab [Units/volume] in Serum,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53137,Afp Mom,skos:broadMatch,omop:3024370,Alpha-1-Fetoprotein [Multiple of the median] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53138,(Albumin),skos:broadMatch,omop:3028286,Albumin [Mass/volume] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53139,Aldosterone,skos:broadMatch,omop:3011337,Aldosterone [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53140,Aldosterone,skos:broadMatch,omop:3011337,Aldosterone [Mass/volume] in Serum or Plasma,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,Duplicate of itemid 53139
+mimic:53141,Alpha-1,skos:broadMatch,omop:3015322,Alpha 1 globulin [Mass/volume] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53142,Alpha-1-antitrypsin,skos:broadMatch,omop:3026285,Alpha 1 antitrypsin [Mass/volume] in Serum or Plasma,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53143,Alpha-2,skos:broadMatch,omop:3005229,Alpha 2 globulin [Mass/volume] in Serum or Plasma by Electrophoresis,HumanCurated,,"orcid:0000-0001-8822-1884,0000-0002-9348-9284",,
+mimic:53145,Anti-GBM Antibody,skos:broadMatch,omop:3032700,Glomerular basement membrane Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53146,Anti Hav,skos:broadMatch,omop:3035456,Hepatitis A virus Ab [Presence] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53147,Anti Hbc,skos:broadMatch,omop:3036282,Hepatitis B virus core Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53148,Anti Hbe,skos:broadMatch,omop:3036806,Hepatitis B virus e Ab [Presence] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53149,Anti-hbs,skos:broadMatch,omop:3013731,Hepatitis B virus surface Ab [Units/volume] in Serum or Plasma by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53150,Anti Hbs,skos:broadMatch,omop:3006453,Hepatitis B virus surface Ab [Presence] in Serum by Immunoassay,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53151,Anti-la,skos:broadMatch,omop:3008914,Sjogrens syndrome-B extractable nuclear Ab [Presence] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,
+mimic:53152,HIV FINAL,skos:broadMatch,omop:3010021,HIV 1 Ab [Units/volume] in Serum,HumanCurated,orcid:0000-0001-8822-1884,orcid:0000-0002-9348-9284,,


### PR DESCRIPTION
This pull request adds two mapping csv files for lab concepts from the `d_labitems` definitions table in MIMIC-IV v2.0. The first file `d_labitems_to_loinc.csv`  contains `itemid` to `LOINC` mappings. There will be a conflict when merging this file to main, as it uses the same file name as an older labs mapping file. This new file contains the latest lab concepts. However, its format is much different. The second file `d_labitems_to_omop.csv` contains `itemid` to `OMOP` mappings. 

Both files use the simple standard for sharing ontology mappings `SSSOM` format [@sssom](https://github.com/mapping-commons/sssom)