### PR TITLE
add crrt to kdigo concept

### DIFF
--- a/mimic-iv/concepts/organfailure/kdigo_stages.sql
+++ b/mimic-iv/concepts/organfailure/kdigo_stages.sql
@@ -3,7 +3,7 @@
 -- Baseline creatinine is defined as the lowest creatinine in the past 7 days.
 
 -- get creatinine stages
-with cr_stg AS
+WITH cr_stg AS
 (
   SELECT
     cr.stay_id
@@ -11,27 +11,27 @@ with cr_stg AS
     , cr.creat_low_past_7day 
     , cr.creat_low_past_48hr
     , cr.creat
-    , case
+    , CASE
         -- 3x baseline
-        when cr.creat >= (cr.creat_low_past_7day*3.0) then 3
+        WHEN cr.creat >= (cr.creat_low_past_7day*3.0) THEN 3
         -- *OR* cr >= 4.0 with associated increase
-        when cr.creat >= 4
+        WHEN cr.creat >= 4
         -- For patients reaching Stage 3 by SCr >4.0 mg/dl
         -- require that the patient first achieve ... acute increase >= 0.3 within 48 hr
         -- *or* an increase of >= 1.5 times baseline
-        and (cr.creat_low_past_48hr <= 3.7 OR cr.creat >= (1.5*cr.creat_low_past_7day))
-            then 3 
+        AND (cr.creat_low_past_48hr <= 3.7 OR cr.creat >= (1.5*cr.creat_low_past_7day))
+            THEN 3 
         -- TODO: initiation of RRT
-        when cr.creat >= (cr.creat_low_past_7day*2.0) then 2
-        when cr.creat >= (cr.creat_low_past_48hr+0.3) then 1
-        when cr.creat >= (cr.creat_low_past_7day*1.5) then 1
-    else 0 end as aki_stage_creat
+        WHEN cr.creat >= (cr.creat_low_past_7day*2.0) THEN 2
+        WHEN cr.creat >= (cr.creat_low_past_48hr+0.3) THEN 1
+        WHEN cr.creat >= (cr.creat_low_past_7day*1.5) THEN 1
+    ELSE 0 END AS aki_stage_creat
   FROM `physionet-data.mimiciv_derived.kdigo_creatinine`
 )
 -- stages for UO / creat
-, uo_stg as
+, uo_stg AS
 (
-  select
+  SELECT
       uo.stay_id
     , uo.charttime
     , uo.weight
@@ -53,17 +53,6 @@ with cr_stg AS
   FROM `physionet-data.mimiciv_derived.kdigo_uo` uo
   INNER JOIN `physionet-data.mimiciv_icu.icustays` ie
     ON uo.stay_id = ie.stay_id
-)
--- get all charttimes documented
-, tm_stg AS
-(
-    SELECT
-      stay_id, charttime
-    FROM cr_stg
-    UNION DISTINCT
-    SELECT
-      stay_id, charttime
-    FROM uo_stg
 ),
 -- get CRRT data
 crrt_stg AS (
@@ -75,7 +64,23 @@ crrt_stg AS (
         ELSE NULL END AS aki_stage_crrt
 FROM `physionet-data.mimic_derived.crrt`
 )
-select
+-- get all charttimes documented
+, tm_stg AS
+(
+    SELECT
+      stay_id, charttime
+    FROM cr_stg
+    UNION DISTINCT
+    SELECT
+      stay_id, charttime
+    FROM uo_stg
+    UNION DISTINCT
+    SELECT
+      stay_id, charttime
+    FROM crrt_stg
+
+)
+SELECT
     ie.subject_id
   , ie.hadm_id
   , ie.stay_id

--- a/mimic-iv/concepts/organfailure/kdigo_stages.sql
+++ b/mimic-iv/concepts/organfailure/kdigo_stages.sql
@@ -26,7 +26,7 @@ WITH cr_stg AS
         WHEN cr.creat >= (cr.creat_low_past_48hr+0.3) THEN 1
         WHEN cr.creat >= (cr.creat_low_past_7day*1.5) THEN 1
     ELSE 0 END AS aki_stage_creat
-  FROM `physionet-data.mimiciv_derived.kdigo_creatinine`
+  FROM `physionet-data.mimiciv_derived.kdigo_creatinine` cr
 )
 -- stages for UO / creat
 , uo_stg AS

--- a/mimic-iv/concepts_postgres/organfailure/kdigo_stages.sql
+++ b/mimic-iv/concepts_postgres/organfailure/kdigo_stages.sql
@@ -52,7 +52,7 @@ with cr_stg AS
         WHEN uo.uo_tm_12hr >= 5 AND uo.uo_rt_12hr < 0.5 THEN 2
         WHEN uo.uo_tm_6hr >= 2 AND uo.uo_rt_6hr  < 0.5 THEN 1
     ELSE 0 END AS aki_stage_uo
-  from mimiciv_derived.kdigo_uo uo
+  FROM mimiciv_derived.kdigo_uo uo
   INNER JOIN mimiciv_icu.icustays ie
     ON uo.stay_id = ie.stay_id
 )
@@ -66,16 +66,6 @@ with cr_stg AS
     SELECT
       stay_id, charttime
     FROM uo_stg
-),
--- get CRRT data
-crrt_stg AS (
-  SELECT 
-	stay_id, 
-	charttime, 
-	CASE
-    	WHEN charttime IS NOT NULL THEN 3
-        ELSE NULL END AS aki_stage_crrt
-FROM mimic_derived.crrt
 )
 select
     ie.subject_id
@@ -90,12 +80,10 @@ select
   , uo.uo_rt_12hr
   , uo.uo_rt_24hr
   , uo.aki_stage_uo
-  , crrt.aki_stage_crrt
   -- Classify AKI using both creatinine/urine output criteria
   , GREATEST(
         COALESCE(cr.aki_stage_creat,0),
-        COALESCE(uo.aki_stage_uo,0),
-        COALESCE(crrt.aki_stage_crrt,0)
+        COALESCE(uo.aki_stage_uo,0)
         ) AS aki_stage
 FROM mimiciv_icu.icustays ie
 -- get all possible charttimes as listed in tm_stg
@@ -107,7 +95,4 @@ LEFT JOIN cr_stg cr
 LEFT JOIN uo_stg uo
   ON ie.stay_id = uo.stay_id
   AND tm.charttime = uo.charttime
-LEFT JOIN crrt_stg crrt
-  ON ie.stay_id = crrt.stay_id
-  AND tm.charttime = crrt.charttime
 ;


### PR DESCRIPTION
Dear MIMIC-Community,

I noticed that the presence of CRRT is missing as a parameter for KDIGO stage calculation. KDIGO states that "presence of CRRT" automatically classifies the patient as AKI stage 3.

I allowed myself to quickly write up a query which I believe would fix the problem.

I am so grateful to be able to contribute to this amazing project and I am looking forward to your input.

Kind regards
Christian