### PR TITLE
Update charlson.sql for correct age-adjusted CCI score implementation

### DIFF
--- a/mimic-iv/concepts/comorbidity/charlson.sql
+++ b/mimic-iv/concepts/comorbidity/charlson.sql
@@ -263,10 +263,10 @@ WITH diag AS
     SELECT 
         hadm_id
         , age
-        , CASE WHEN age <= 40 THEN 0
-    WHEN age <= 50 THEN 1
-    WHEN age <= 60 THEN 2
-    WHEN age <= 70 THEN 3
+        , CASE WHEN age <= 50 THEN 0
+    WHEN age <= 60 THEN 1
+    WHEN age <= 70 THEN 2
+    WHEN age <= 80 THEN 3
     ELSE 4 END AS age_score
     FROM `physionet-data.mimic_derived.age`
 )

--- a/mimic-iv/concepts/postgres/comorbidity/charlson.sql
+++ b/mimic-iv/concepts/postgres/comorbidity/charlson.sql
@@ -265,10 +265,10 @@ WITH diag AS
     SELECT 
         hadm_id
         , age
-        , CASE WHEN age <= 40 THEN 0
-    WHEN age <= 50 THEN 1
-    WHEN age <= 60 THEN 2
-    WHEN age <= 70 THEN 3
+        , CASE WHEN age <= 50 THEN 0
+    WHEN age <= 60 THEN 1
+    WHEN age <= 70 THEN 2
+    WHEN age <= 80 THEN 3
     ELSE 4 END AS age_score
     FROM mimic_derived.age
 )


### PR DESCRIPTION
Follow-up on #1408 — the Charlson comorbidity score had slightly incorrect age adjustments. I've patched the two `charlson.sql` queries to account for this. 