### PR TITLE
KDIGO improvements

### DIFF
--- a/mimic-iv/concepts/organfailure/kdigo_stages.sql
+++ b/mimic-iv/concepts/organfailure/kdigo_stages.sql
@@ -63,6 +63,7 @@ crrt_stg AS (
     	WHEN charttime IS NOT NULL THEN 3
         ELSE NULL END AS aki_stage_crrt
 FROM `physionet-data.mimiciv_derived.crrt`
+WHERE crrt_mode IS NOT NULL
 )
 -- get all charttimes documented
 , tm_stg AS

--- a/mimic-iv/concepts/organfailure/kdigo_stages.sql
+++ b/mimic-iv/concepts/organfailure/kdigo_stages.sql
@@ -62,7 +62,7 @@ crrt_stg AS (
 	CASE
     	WHEN charttime IS NOT NULL THEN 3
         ELSE NULL END AS aki_stage_crrt
-FROM `physionet-data.mimic_derived.crrt`
+FROM `physionet-data.mimiciv_derived.crrt`
 )
 -- get all charttimes documented
 , tm_stg AS

--- a/mimic-iv/concepts/organfailure/kdigo_uo.sql
+++ b/mimic-iv/concepts/organfailure/kdigo_uo.sql
@@ -73,24 +73,18 @@ select
 , ur.urineoutput_12hr
 , ur.urineoutput_24hr
 
--- calculate rates
--- we would like to improve the sensitivity of this calculation by:
--- (1) requiring UO documentation over at least N/2 hours
--- (2) excluding a rate if it was calculated over >>N hours
--- this is to remove cases where we have a very short measurement
---  (e.g. one UO measurement made for 1 hour determining the 6 hour rate)
--- and remove cases where we have very sparse measurements
---  (e.g. two UO measurements 12 hours apart used for the 6 hour rate calculation)
+-- calculate rates while requiring UO documentation over at least N hours
+-- as specified in KDIGO guidelines 2012 pg19
 , CASE
-  WHEN uo_tm_6hr > 3 AND uo_tm_6hr < 9
+  WHEN uo_tm_6hr >= 6 AND uo_tm_6hr < 12
   THEN ROUND(CAST((ur.urineoutput_6hr/wd.weight/uo_tm_6hr) AS NUMERIC), 4)
   ELSE NULL END AS uo_rt_6hr
 , CASE
-  WHEN uo_tm_12hr > 6 AND uo_tm_12hr < 18
+  WHEN uo_tm_12hr >= 12
   THEN ROUND(CAST((ur.urineoutput_12hr/wd.weight/uo_tm_12hr) AS NUMERIC), 4)
   ELSE NULL END AS uo_rt_12hr
 , CASE
-  WHEN uo_tm_24hr > 12 AND uo_tm_24hr < 36
+  WHEN uo_tm_24hr >= 24
   THEN ROUND(CAST((ur.urineoutput_24hr/wd.weight/uo_tm_24hr) AS NUMERIC), 4)
   ELSE NULL END AS uo_rt_24hr
 


### PR DESCRIPTION
This PR improves the implementation of the KDIGO guidelines for MIMIC-IV.

The big changes:

1. Refactored the UO query with better syntax for calculating a sum over the last X hours (no change in content)
2. Added the `aki_stage_smoothed` column which carries forward the highest AKI stage for 6 hours (arbitrary but seems reasonable). Helps smooth over the `aki_stage` alternating between the creatinine/UO derived stage, e.g.

time  | uo | cr | aki_stage | aki_stage_smoothed
--- | --- | --- | --- | ---
18:00:00 | 0.3833 | | 3 | 3
19:30:00	| | 0.8 | 0 | 3
3. Rewrote the UO query to more closely align with the ranges given by KDIGO - stage 1 uses UO from 6-12 hours, stage 2 uses UO from >= 12 hours, and stage 3 uses UO from >12 hours and >= 24 hours. Difference in UO stages across stays is below:

aki_stage_uo | n_row_updated | n_row_before | n_stay_updated | n_stay_before
--- | --- | --- | --- | ---
`NULL` | 1043972 | 628376 | 73181 | 73151
0 | 2222462 | 2586664 | 60458 | 68250
1 | 185797 | 135580 | 37718 | 27675
2 | 385465 | 358460 | 29103 | 27513
3 | 173559 | 195757 | 8317 | 9355

Seems to result in a lot more stage 1 AKI - but I think the logic is better. Would welcome any thoughts.