### PR TITLE
fix NULL typo at mysql buildmimic-iv load.sql

### DIFF
--- a/mimic-iv/buildmimic/mysql/load.sql
+++ b/mimic-iv/buildmimic/mysql/load.sql
@@ -87,7 +87,7 @@ LOAD DATA LOCAL INFILE 'admissions.csv' INTO TABLE admissions
 
 DROP TABLE IF EXISTS caregiver;
 CREATE TABLE caregiver (	-- rows=454324
-   caregiver_id INT NOT NUL
+   caregiver_id INT NOT NULL
   )
   CHARACTER SET = UTF8MB4;
 


### PR DESCRIPTION
* I found typo at buildmimic-iv load.sql.
* It is just misspelled `NULL` as `NUL`, but  it does not work if it is `NUL`.
* issue is #1501
* close #1501 