### PR TITLE
fix gh actions

### DIFF
--- a/.github/workflows/duckdb.yml
+++ b/.github/workflows/duckdb.yml
@@ -4,7 +4,7 @@ on:
     types: [submitted]
 
 jobs:
-  mimic-iv-sqlite:
+  mimic-iv-duckdb:
     # only run if PR is approved
     if: github.event.review.state == 'approved'
     runs-on: ubuntu-20.04
@@ -13,11 +13,13 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
 
-      - name: Install dependencies and download CLI
+      - name: Download duckdb CLI
         run: |
-          apt-get install unzip
           wget https://github.com/duckdb/duckdb/releases/download/v0.6.1/duckdb_cli-linux-amd64.zip
           unzip duckdb_cli-linux-amd64.zip
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          mkdir -p "$HOME/.local/bin"
+          mv duckdb "$HOME/.local/bin/duckdb"
 
       - name: Download demo data
         uses: ./.github/actions/download-demo

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -21,9 +21,9 @@ jobs:
 
       - name: Extract demo data to local folder
         run: |
-          mv demo/hosp/*.csv.gz ./
-          mv demo/icu/*.csv.gz ./
-          mv demo/ed/*.csv.gz ./
+          mv hosp/*.csv.gz ./
+          mv icu/*.csv.gz ./
+          mv ed/*.csv.gz ./
           gzip -d *.csv.gz
 
       - name: Start MySQL service

--- a/.github/workflows/psql.yml
+++ b/.github/workflows/psql.yml
@@ -30,9 +30,6 @@ jobs:
 
       - name: Download demo data
         uses: ./.github/actions/download-demo
-        with:
-            gcp-project-id: ${{ secrets.GCP_PROJECT_ID }}
-            gcp-sa-key: ${{ secrets.GCP_SA_KEY }}
 
       - name: Install postgresql-client
         run: |
@@ -43,7 +40,7 @@ jobs:
         run: |
           echo "Loading data into psql."
           psql -q -h $POSTGRES_HOST -U postgres -f ${BUILDCODE_PATH}/create.sql
-          psql -q -h $POSTGRES_HOST -U postgres -v mimic_data_dir=demo -f ${BUILDCODE_PATH}/load_gz.sql
+          psql -q -h $POSTGRES_HOST -U postgres -f ${BUILDCODE_PATH}/load_gz.sql
           echo "Validating build."
           psql -h $POSTGRES_HOST -U postgres -f ${BUILDCODE_PATH}/validate_demo.sql > results
           
@@ -76,7 +73,7 @@ jobs:
         run: |
           echo "Loading data into psql."
           psql -q -h $POSTGRES_HOST -U postgres -f ${BUILDCODE_PATH}/create.sql
-          psql -q -h $POSTGRES_HOST -U postgres -v mimic_data_dir=demo/ed -f ${BUILDCODE_PATH}/load_gz.sql
+          psql -q -h $POSTGRES_HOST -U postgres -v mimic_data_dir=ed/ -f ${BUILDCODE_PATH}/load_gz.sql
           echo "Validating build."
           psql -h $POSTGRES_HOST -U postgres -f ${BUILDCODE_PATH}/validate_demo.sql > results
           

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -24,9 +24,6 @@ jobs:
 
       - name: Download demo data
         uses: ./.github/actions/download-demo
-        with:
-            gcp-project-id: ${{ secrets.GCP_PROJECT_ID }}
-            gcp-sa-key: ${{ secrets.GCP_SA_KEY }}
 
       - name: Load icu/hosp data into SQLite
         run: |


### PR DESCRIPTION
Fixes GH actions to build the DB using the demo data properly. Most errors were due to the demo download being in the local folder rather than in a `demo/` folder.