### PR TITLE
change dir as import_duckdb relies on relative dirs

### DIFF
--- a/.github/workflows/duckdb.yml
+++ b/.github/workflows/duckdb.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Load icu/hosp data into duckdb
         run: |
           echo "Running duckdb build."
-          ./${BUILDCODE_PATH}/import_duckdb.sh ./
+          cd ${BUILDCODE_PATH}
+          ./import_duckdb.sh ./
 
           echo `md5sum mimic4.db`
 


### PR DESCRIPTION
The `import_duckdb.sh` script expects to be run relative to the postgres folder to load in the create.sql script

(still not sure if I like it though)