### PR TITLE
fix icustay_hourly: function unnest(integer) does not exist

### DIFF
--- a/mimic-iv/concepts/demographics/icustay_hourly.sql
+++ b/mimic-iv/concepts/demographics/icustay_hourly.sql
@@ -31,7 +31,6 @@ WITH all_hours AS (
 )
 
 SELECT stay_id
-    , CAST(hr_unnested AS INT64) AS hr
-    , DATETIME_ADD(endtime, INTERVAL CAST(hr_unnested AS INT64) HOUR) AS endtime
-FROM all_hours
-CROSS JOIN UNNEST(all_hours.hrs) AS hr_unnested;
+    , CAST(hrs AS INT64) AS hr
+    , DATETIME_ADD(endtime, INTERVAL CAST(hrs AS INT64) HOUR) AS endtime
+FROM all_hours;

--- a/mimic-iv/concepts_duckdb/demographics/icustay_hourly.sql
+++ b/mimic-iv/concepts_duckdb/demographics/icustay_hourly.sql
@@ -16,7 +16,6 @@ WITH all_hours AS (
 )
 SELECT
   stay_id,
-  TRY_CAST(hr_unnested AS BIGINT) AS hr,
-  endtime + TRY_CAST(hr_unnested AS BIGINT) * INTERVAL '1' HOUR AS endtime
+  TRY_CAST(hrs AS BIGINT) AS hr,
+  endtime + TRY_CAST(hrs AS BIGINT) * INTERVAL '1' HOUR AS endtime
 FROM all_hours
-CROSS JOIN UNNEST(all_hours.hrs) AS _t(hr_unnested)

--- a/mimic-iv/concepts_postgres/demographics/icustay_hourly.sql
+++ b/mimic-iv/concepts_postgres/demographics/icustay_hourly.sql
@@ -14,7 +14,6 @@ WITH all_hours AS (
 )
 SELECT
   stay_id,
-  CAST(hr_unnested AS BIGINT) AS hr,
-  endtime + CAST(hr_unnested AS BIGINT) * INTERVAL '1 HOUR' AS endtime
+  CAST(hrs AS BIGINT) AS hr,
+  endtime + CAST(hrs AS BIGINT) * INTERVAL '1 HOUR' AS endtime
 FROM all_hours
-CROSS JOIN UNNEST(all_hours.hrs) AS _t(hr_unnested)


### PR DESCRIPTION
all_hours.hrs is a row of integer already, so we don't need nor able to use unnest in this case. 