### PR TITLE
Increase admissions language length for postgres schema

### DIFF
--- a/mimic-iv/buildmimic/postgres/create.sql
+++ b/mimic-iv/buildmimic/postgres/create.sql
@@ -32,7 +32,7 @@ CREATE TABLE mimiciv_hosp.admissions
   admission_location VARCHAR(60),
   discharge_location VARCHAR(60),
   insurance VARCHAR(255),
-  language VARCHAR(10),
+  language VARCHAR(25),
   marital_status VARCHAR(30),
   race VARCHAR(80),
   edregtime TIMESTAMP,


### PR DESCRIPTION
Currently languages like "American Sign Language" will error out when running /mimic-iv/buildmimic/postgres/load_gz.sql 