### PR TITLE
Update BigQuery dataset build to use latest gh actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,15 +10,18 @@ env:
 jobs:
   create-tables:
     runs-on: ubuntu-latest
+    permissions:
+        contents: 'read'
+        id-token: 'write'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
 
       - id: 'auth'
-        uses: 'google-github-actions/auth@v0'
+        uses: 'google-github-actions/auth@v2'
         with:
-            project_id: ${{ secrets.GCP_PROJECT_ID }}
-            credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: 'mimic-code@physionet-data.iam.gserviceaccount.com'
+          workload_identity_provider: 'projects/569883598760/locations/global/workloadIdentityPools/github/providers/mimic-code'
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v0'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,10 @@ jobs:
           workload_identity_provider: 'projects/569883598760/locations/global/workloadIdentityPools/github/providers/mimic-code'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v0'
-
+        uses: 'google-github-actions/setup-gcloud@v2'
+        with:
+          version: '>= 363.0.0'
+          
       - name: Run make_concepts
         run: |
             echo "Generating tables on BigQuery"

--- a/mimic-iv/buildmimic/bigquery/make_version.sh
+++ b/mimic-iv/buildmimic/bigquery/make_version.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This script makes the _version table for each schema in BigQuery,
+# Currently hard-coded to the status as of 2025-04-20.
+export VERSION_TABLE="_version"
+
+# create an array of target datasets and versions
+# loop through them at the same time
+datasets=(
+  "mimiciv_icu:3.1"
+  "mimiciv_hosp:3.1"
+  "mimiciv_note:2.2"
+  "mimiciv_ed:2.2"
+)
+
+for entry in "${datasets[@]}"; do
+  TARGET_DATASET="${entry%%:*}"
+  MIMIC_VERSION="${entry##*:}"
+  export TARGET_DATASET
+  export MIMIC_VERSION
+  
+  echo "Creating ${TARGET_DATASET}.${VERSION_TABLE} table"
+    bq query <<EOF
+CREATE TABLE IF NOT EXISTS \`physionet-data.${TARGET_DATASET}.${VERSION_TABLE}\` (
+  attribute STRING,
+  value STRING
+);
+
+TRUNCATE TABLE \`physionet-data.${TARGET_DATASET}.${VERSION_TABLE}\`;
+
+INSERT INTO \`physionet-data.${TARGET_DATASET}.${VERSION_TABLE}\` (attribute, value)
+VALUES
+  ('mimic_version', '${MIMIC_VERSION}');
+EOF
+done

--- a/mimic-iv/buildmimic/bigquery/make_version.sh
+++ b/mimic-iv/buildmimic/bigquery/make_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script makes the _version table for each schema in BigQuery,
 # Currently hard-coded to the status as of 2025-04-20.
-export VERSION_TABLE="_version"
+export METADATA_TABLE="_metadata"
 
 # create an array of target datasets and versions
 # loop through them at the same time
@@ -18,16 +18,16 @@ for entry in "${datasets[@]}"; do
   export TARGET_DATASET
   export MIMIC_VERSION
   
-  echo "Creating ${TARGET_DATASET}.${VERSION_TABLE} table"
+  echo "Creating ${TARGET_DATASET}.${METADATA_TABLE} table"
     bq query <<EOF
-CREATE TABLE IF NOT EXISTS \`physionet-data.${TARGET_DATASET}.${VERSION_TABLE}\` (
+CREATE TABLE IF NOT EXISTS \`physionet-data.${TARGET_DATASET}.${METADATA_TABLE}\` (
   attribute STRING,
   value STRING
 );
 
-TRUNCATE TABLE \`physionet-data.${TARGET_DATASET}.${VERSION_TABLE}\`;
+TRUNCATE TABLE \`physionet-data.${TARGET_DATASET}.${METADATA_TABLE}\`;
 
-INSERT INTO \`physionet-data.${TARGET_DATASET}.${VERSION_TABLE}\` (attribute, value)
+INSERT INTO \`physionet-data.${TARGET_DATASET}.${METADATA_TABLE}\` (attribute, value)
 VALUES
   ('mimic_version', '${MIMIC_VERSION}');
 EOF

--- a/mimic-iv/concepts/make_concepts.sh
+++ b/mimic-iv/concepts/make_concepts.sh
@@ -24,13 +24,15 @@ GIT_COMMIT_HASH=$(git rev-parse HEAD)
 LATEST_GIT_TAG=$(git describe --tags --abbrev=0)
 
 echo "Creating ${TARGET_DATASET}.${VERSION_TABLE} table"
-bq query ${BQ_OPTIONS} --destination_table=${TARGET_DATASET}.${VERSION_TABLE} <<EOF
-CREATE TABLE IF NOT EXISTS \`${TARGET_DATASET}.${VERSION_TABLE}\` (
+bq query <<EOF
+CREATE TABLE IF NOT EXISTS \`physionet-data.${TARGET_DATASET}.${VERSION_TABLE}\` (
   attribute STRING,
   value STRING
 );
 
-INSERT INTO \`${TARGET_DATASET}.${VERSION_TABLE}\` (attribute, value)
+TRUNCATE TABLE \`physionet-data.${TARGET_DATASET}.${VERSION_TABLE}\`;
+
+INSERT INTO \`physionet-data.${TARGET_DATASET}.${VERSION_TABLE}\` (attribute, value)
 VALUES
   ('mimic_version', '${MIMIC_VERSION}'),
   ('mimic_code_version', '${LATEST_GIT_TAG}'),

--- a/mimic-iv/concepts/make_concepts.sh
+++ b/mimic-iv/concepts/make_concepts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script generates the concepts in the BigQuery table mimiciv_derived.
 export TARGET_DATASET=mimiciv_derived
-export VERSION_TABLE="_version"
+export METADATA_TABLE="_metadata"
 export MIMIC_VERSION="3.1"
 
 # specify bigquery query command options
@@ -23,16 +23,16 @@ done
 GIT_COMMIT_HASH=$(git rev-parse HEAD)
 LATEST_GIT_TAG=$(git describe --tags --abbrev=0)
 
-echo "Creating ${TARGET_DATASET}.${VERSION_TABLE} table"
+echo "Creating ${TARGET_DATASET}.${METADATA_TABLE} table"
 bq query <<EOF
-CREATE TABLE IF NOT EXISTS \`physionet-data.${TARGET_DATASET}.${VERSION_TABLE}\` (
+CREATE TABLE IF NOT EXISTS \`physionet-data.${TARGET_DATASET}.${METADATA_TABLE}\` (
   attribute STRING,
   value STRING
 );
 
-TRUNCATE TABLE \`physionet-data.${TARGET_DATASET}.${VERSION_TABLE}\`;
+TRUNCATE TABLE \`physionet-data.${TARGET_DATASET}.${METADATA_TABLE}\`;
 
-INSERT INTO \`physionet-data.${TARGET_DATASET}.${VERSION_TABLE}\` (attribute, value)
+INSERT INTO \`physionet-data.${TARGET_DATASET}.${METADATA_TABLE}\` (attribute, value)
 VALUES
   ('mimic_version', '${MIMIC_VERSION}'),
   ('mimic_code_version', '${LATEST_GIT_TAG}'),


### PR DESCRIPTION
Basically bumping the version of the gh actions (and using the new auth method). Also including a `_metadata` table on all the mimic-iv BigQuery datasets to indicate the mimic version of the underlying data.