### PR TITLE
Fix DATETIME_DIFF divergence between PostgreSQL and BigQuery

### DIFF
--- a/mimic-iv/concepts/measurement/urine_output_rate.sql
+++ b/mimic-iv/concepts/measurement/urine_output_rate.sql
@@ -18,11 +18,10 @@ WITH tm AS (
 -- now calculate time since last UO measurement
 , uo_tm AS (
     SELECT tm.stay_id
-        , CASE
-            WHEN LAG(charttime) OVER w IS NULL
-                THEN DATETIME_DIFF(charttime, intime_hr, MINUTE)
-            ELSE DATETIME_DIFF(charttime, LAG(charttime) OVER w, MINUTE)
-        END AS tm_since_last_uo
+        , COALESCE(
+            DATETIME_DIFF(charttime, LAG(charttime) OVER w, SECOND) / 60.0
+            , DATETIME_DIFF(charttime, intime_hr, SECOND) / 60.0
+        ) AS tm_since_last_uo
         , uo.charttime
         , uo.urineoutput
     FROM tm
@@ -45,16 +44,19 @@ WITH tm AS (
         -- to 1 hour of UO, therefore we use '5' and '11' to restrict the
         -- period, rather than 6/12 this assumption may overestimate UO rate
         -- when documentation is done less than hourly
-        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, HOUR) <= 5
+        -- Use SECOND-based diff divided by 3600 for fractional hours,
+        -- ensuring consistent behavior between BigQuery and PostgreSQL
+        -- (see issue #1549). We compare <= 5 and <= 11 hours respectively.
+        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 5
             THEN iosum.urineoutput
             ELSE null END) AS urineoutput_6hr
-        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, HOUR) <= 5
+        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 5
             THEN iosum.tm_since_last_uo
             ELSE null END) / 60.0 AS uo_tm_6hr
-        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, HOUR) <= 11
+        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 11
             THEN iosum.urineoutput
             ELSE null END) AS urineoutput_12hr
-        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, HOUR) <= 11
+        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 11
             THEN iosum.tm_since_last_uo
             ELSE null END) / 60.0 AS uo_tm_12hr
         -- 24 hours

--- a/mimic-iv/concepts_postgres/measurement/urine_output_rate.sql
+++ b/mimic-iv/concepts_postgres/measurement/urine_output_rate.sql
@@ -17,11 +17,10 @@ WITH tm AS (
 ), uo_tm AS (
   SELECT
     tm.stay_id,
-    CASE
-      WHEN LAG(charttime) OVER w IS NULL
-      THEN EXTRACT(EPOCH FROM charttime - intime_hr) / 60.0
-      ELSE EXTRACT(EPOCH FROM charttime - LAG(charttime) OVER w) / 60.0
-    END AS tm_since_last_uo,
+    COALESCE(
+      DATETIME_DIFF(charttime, LAG(charttime) OVER w, 'SECOND') / 60.0,
+      DATETIME_DIFF(charttime, intime_hr, 'SECOND') / 60.0
+    ) AS tm_since_last_uo,
     uo.charttime,
     uo.urineoutput
   FROM tm
@@ -33,30 +32,33 @@ WITH tm AS (
     io.stay_id,
     io.charttime, /* we have joined each row to all rows preceding within 24 hours */ /* we can now sum these rows to get total UO over the last 24 hours */ /* we can use case statements to restrict it to only the last 6/12 hours */ /* therefore we have three sums: */ /* 1) over a 6 hour period */ /* 2) over a 12 hour period */ /* 3) over a 24 hour period */
     SUM(DISTINCT io.urineoutput) AS uo, /* note that we assume data charted at charttime corresponds */ /* to 1 hour of UO, therefore we use '5' and '11' to restrict the */ /* period, rather than 6/12 this assumption may overestimate UO rate */ /* when documentation is done less than hourly */
+    /* Use SECOND-based diff divided by 3600 for fractional hours, */
+    /* ensuring consistent behavior between BigQuery and PostgreSQL */
+    /* (see issue #1549). We compare <= 5 and <= 11 hours respectively. */
     SUM(
       CASE
-        WHEN EXTRACT(EPOCH FROM io.charttime - iosum.charttime) / 3600.0 <= 5
+        WHEN DATETIME_DIFF(io.charttime, iosum.charttime, 'SECOND') / 3600.0 <= 5
         THEN iosum.urineoutput
         ELSE NULL
       END
     ) AS urineoutput_6hr,
     CAST(SUM(
       CASE
-        WHEN EXTRACT(EPOCH FROM io.charttime - iosum.charttime) / 3600.0 <= 5
+        WHEN DATETIME_DIFF(io.charttime, iosum.charttime, 'SECOND') / 3600.0 <= 5
         THEN iosum.tm_since_last_uo
         ELSE NULL
       END
     ) AS DOUBLE PRECISION) / 60.0 AS uo_tm_6hr,
     SUM(
       CASE
-        WHEN EXTRACT(EPOCH FROM io.charttime - iosum.charttime) / 3600.0 <= 11
+        WHEN DATETIME_DIFF(io.charttime, iosum.charttime, 'SECOND') / 3600.0 <= 11
         THEN iosum.urineoutput
         ELSE NULL
       END
     ) AS urineoutput_12hr,
     CAST(SUM(
       CASE
-        WHEN EXTRACT(EPOCH FROM io.charttime - iosum.charttime) / 3600.0 <= 11
+        WHEN DATETIME_DIFF(io.charttime, iosum.charttime, 'SECOND') / 3600.0 <= 11
         THEN iosum.tm_since_last_uo
         ELSE NULL
       END

--- a/mimic-iv/concepts_postgres/postgres-functions.sql
+++ b/mimic-iv/concepts_postgres/postgres-functions.sql
@@ -73,17 +73,21 @@ LANGUAGE PLPGSQL;
 
 -- below requires a regex to convert datepart from primitive to a string
 -- i.e. encapsulate it in single quotes
+-- BigQuery's DATETIME_DIFF returns a truncated integer, not a fractional value.
+-- For example, DATETIME_DIFF('10:30', '05:00', HOUR) returns 5 in BigQuery,
+-- not 5.5. We replicate this behavior using TRUNC to ensure parity between
+-- the PostgreSQL and BigQuery implementations (see issue #1549).
 CREATE OR REPLACE FUNCTION DATETIME_DIFF(endtime TIMESTAMP(3), starttime TIMESTAMP(3), datepart TEXT) RETURNS NUMERIC AS $$
 BEGIN
-RETURN 
-    EXTRACT(EPOCH FROM endtime - starttime) /
+RETURN
+    TRUNC(EXTRACT(EPOCH FROM endtime - starttime) /
     CASE
         WHEN datepart = 'SECOND' THEN 1.0
         WHEN datepart = 'MINUTE' THEN 60.0
         WHEN datepart = 'HOUR' THEN 3600.0
         WHEN datepart = 'DAY' THEN 24*3600.0
         WHEN datepart = 'YEAR' THEN 365.242*24*3600.0
-    ELSE NULL END;
+    ELSE NULL END);
 END; $$
 LANGUAGE PLPGSQL;
 


### PR DESCRIPTION
## Summary

Fixes #1549.

As noted by @alistairewj, `DATETIME_DIFF` in PostgreSQL returned a fractional value while BigQuery returns a truncated integer. This caused subtle divergence in derived concept queries between the two backends, particularly in `urine_output_rate.sql` where `DATETIME_DIFF(..., HOUR)` was used in comparisons like `<= 5` and `<= 11`.

**Changes:**

- **`postgres-functions.sql`**: Wrapped the `DATETIME_DIFF` result with `TRUNC()` to match BigQuery's truncation-toward-zero behavior for all date parts (SECOND, MINUTE, HOUR, DAY, YEAR).
- **`urine_output_rate.sql` (BigQuery)**: Replaced `DATETIME_DIFF(..., HOUR)` comparisons with `DATETIME_DIFF(..., SECOND) / 3600.0` to get fractional hours, following the same approach already used in `kdigo_uo.sql`. Also updated the `uo_tm` CTE to use `COALESCE` with `SECOND`-based diffs instead of `MINUTE`-based diffs for consistency.
- **`urine_output_rate.sql` (PostgreSQL)**: Applied matching changes to keep the postgres-converted version in sync.

## Test plan

- [ ] Verify `postgres-functions.sql` `DATETIME_DIFF` now returns truncated integers matching BigQuery behavior
- [ ] Compare `urine_output_rate` results between BigQuery and PostgreSQL to confirm parity
- [ ] Verify no regression in other queries using `DATETIME_DIFF` (ventilation.sql, oasis.sql, icustay_detail.sql, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)