### PR TITLE
Fix 'ndication' typo mapped to 'impression' instead of 'indication'

### DIFF
--- a/mimic-iv-cxr/txt/section_parser.py
+++ b/mimic-iv-cxr/txt/section_parser.py
@@ -127,7 +127,7 @@ def normalize_section_names(section_names):
         "pfi": "history",
         'recommendation': 'recommendations',
         'wetread': 'wet read',
-        'ndication': 'impression',  # 1
+        'ndication': 'indication',  # 1
         'impresson': 'impression',  # 2
         'imprression': 'impression',  # 1
         'imoression': 'impression',  # 1


### PR DESCRIPTION
## Summary

In `section_parser.py`, the misspelling `'ndication'` (missing leading "i") is mapped to `'impression'` instead of `'indication'`.

**Bug:** Line 130 — `'ndication': 'impression'`  
**Root cause:** `'ndication'` is a typo for "indication" (the clinical reason for an exam), not "impression" (the radiologist's diagnostic conclusion). These are semantically distinct report sections.  
**Evidence:**  
- Line 148 maps `'idication'` (another single-letter-dropped indication typo) → `'indication'` correctly  
- Lines 99, 106, 108, 111 all map indication synonyms/typos → `'indication'`  
- All surrounding entries (lines 131–139) are misspellings of "impression" — `'ndication'` does not fit this group

**Impact:** When a report header reads "NDICATION:", the clinical indication text is misclassified as the impression, which `create_section_files.py` then extracts as the radiologist's conclusion for NLP labeling.

**Fix:** `'impression'` → `'indication'` on line 130.

## Test plan
- [x] Verified all other indication typos/synonyms map to `'indication'`
- [x] Confirmed downstream usage in `create_section_files.py` prioritizes `'impression'` sections
- [x] One-word change, no side effects