### PR TITLE
Fix test_vasopressor_units crashing on Series.contains

### DIFF
--- a/mimic-iv/tests/test_medication.py
+++ b/mimic-iv/tests/test_medication.py
@@ -58,7 +58,7 @@ def test_vasopressor_units(dataset, project_id):
         """
         df = gbq.read_gbq(query, project_id=project_id, dialect="standard")
         # if we find new uninspected rows, raise a warning. this will only happen when mimic-iv is updated.
-        if (~df['hadm_id'].contains(hadm_id_list)).any():
+        if (~df['hadm_id'].isin(hadm_id_list)).any():
             _LOGGER.warn(f"""New data found with non-standard unit. Inspect the data with this query:
 
             select *


### PR DESCRIPTION
## Bug

\`test_vasopressor_units\` in \`mimic-iv/tests/test_medication.py\` crashes with \`AttributeError\` whenever the preceding \`gbq.read_gbq\` query returns any rows, before ever reaching its real assertion:

\`\`\`
AttributeError: 'Series' object has no attribute 'contains'
\`\`\`

## Root cause

The test pulls rows with a non-standard \`rateuom\` for each vasopressor and then checks whether any row's \`hadm_id\` falls outside a whitelist of known-inspected \`hadm_id\`s:

\`\`\`python
df = gbq.read_gbq(query, project_id=project_id, dialect=\"standard\")
# if we find new uninspected rows, raise a warning. this will only happen when mimic-iv is updated.
if (~df['hadm_id'].contains(hadm_id_list)).any():
    _LOGGER.warn(...)
\`\`\`

\`pandas.Series\` has **no** \`.contains()\` method — \`contains\` only lives on the \`.str\` accessor and does substring-matching against a single pattern, not membership-testing against a list. The correct pandas idiom for \"row's value is in this list\" is \`Series.isin(...)\`, which is clearly what the surrounding code intends (`hadm_id_list` is a plain list of integers, not a regex).

As written, the moment the query returns any row the test hits the \`.contains(hadm_id_list)\` call, raises \`AttributeError\`, and fails. The hit path is what the test is *supposed to* log a warning for, so the bug masks the whole reason this check exists.

## Fix

Replace \`.contains(hadm_id_list)\` with \`.isin(hadm_id_list)\`:

\`\`\`diff
-        if (~df['hadm_id'].contains(hadm_id_list)).any():
+        if (~df['hadm_id'].isin(hadm_id_list)).any():
\`\`\`

The outer \`~...any()\` still expresses \"any row falls outside the whitelist\", matching the comment and the downstream warning log.