### PR TITLE
Fix height.sql COALESCE using h1 for both args instead of h1/h2

### DIFF
--- a/mimic-iv/concepts/measurement/height.sql
+++ b/mimic-iv/concepts/measurement/height.sql
@@ -25,9 +25,9 @@ WITH ht_in AS (
 -- merge cm/height, only take 1 value per charted row
 , ht_stg0 AS (
     SELECT
-        COALESCE(h1.subject_id, h1.subject_id) AS subject_id
-        , COALESCE(h1.stay_id, h1.stay_id) AS stay_id
-        , COALESCE(h1.charttime, h1.charttime) AS charttime
+        COALESCE(h1.subject_id, h2.subject_id) AS subject_id
+        , COALESCE(h1.stay_id, h2.stay_id) AS stay_id
+        , COALESCE(h1.charttime, h2.charttime) AS charttime
         , COALESCE(h1.height, h2.height) AS height
     FROM ht_cm h1
     FULL OUTER JOIN ht_in h2

--- a/mimic-iv/concepts_duckdb/measurement/height.sql
+++ b/mimic-iv/concepts_duckdb/measurement/height.sql
@@ -21,9 +21,9 @@ WITH ht_in AS (
     NOT c.valuenum IS NULL AND c.itemid = 226730
 ), ht_stg0 AS (
   SELECT
-    COALESCE(h1.subject_id, h1.subject_id) AS subject_id,
-    COALESCE(h1.stay_id, h1.stay_id) AS stay_id,
-    COALESCE(h1.charttime, h1.charttime) AS charttime,
+    COALESCE(h1.subject_id, h2.subject_id) AS subject_id,
+    COALESCE(h1.stay_id, h2.stay_id) AS stay_id,
+    COALESCE(h1.charttime, h2.charttime) AS charttime,
     COALESCE(h1.height, h2.height) AS height
   FROM ht_cm AS h1
   FULL OUTER JOIN ht_in AS h2

--- a/mimic-iv/concepts_postgres/measurement/height.sql
+++ b/mimic-iv/concepts_postgres/measurement/height.sql
@@ -22,9 +22,9 @@ WITH ht_in AS (
     NOT c.valuenum IS NULL AND /* Height cm */ c.itemid = 226730
 ), ht_stg0 AS (
   SELECT
-    COALESCE(h1.subject_id, h1.subject_id) AS subject_id,
-    COALESCE(h1.stay_id, h1.stay_id) AS stay_id,
-    COALESCE(h1.charttime, h1.charttime) AS charttime,
+    COALESCE(h1.subject_id, h2.subject_id) AS subject_id,
+    COALESCE(h1.stay_id, h2.stay_id) AS stay_id,
+    COALESCE(h1.charttime, h2.charttime) AS charttime,
     COALESCE(h1.height, h2.height) AS height
   FROM ht_cm AS h1
   FULL OUTER JOIN ht_in AS h2


### PR DESCRIPTION
## Summary

In `height.sql`, the `ht_stg0` CTE merges height-in-cm (`h1`) and height-in-inches (`h2`) via a `FULL OUTER JOIN`. The `COALESCE` for `subject_id`, `stay_id`, and `charttime` uses `h1` as both arguments:

```sql
COALESCE(h1.subject_id, h1.subject_id) AS subject_id  -- should be h2
COALESCE(h1.stay_id, h1.stay_id) AS stay_id            -- should be h2
COALESCE(h1.charttime, h1.charttime) AS charttime      -- should be h2
COALESCE(h1.height, h2.height) AS height               -- this one is correct
```

When a patient has height charted only in inches (itemid 226707, an `h2` row with no matching `h1` row), the `FULL OUTER JOIN` produces a row where all `h1.*` columns are NULL. `COALESCE(NULL, NULL)` yields NULL for `subject_id`, `stay_id`, and `charttime`, making the record unjoinable to any patient — silently dropping all inch-only height measurements.

**Fix:** Change the second argument from `h1` to `h2` in all three COALESCE calls, matching the pattern already used for `height` on the next line. Applied to all three dialect files (BigQuery, PostgreSQL, DuckDB).

## Test plan

- [x] Verified line 31 already correctly uses `h2.height` as fallback
- [x] Verified the same copy-paste error exists in all three dialect files
- [ ] Query should now return non-NULL subject_id/stay_id for inch-only height records

🤖 Generated with [Claude Code](https://claude.ai/claude-code)