### PR TITLE
Fix KDIGO Stage 3 hardcoded 3.7 threshold in creatinine check

### DIFF
--- a/mimic-iii/concepts/organfailure/kdigo_stages.sql
+++ b/mimic-iii/concepts/organfailure/kdigo_stages.sql
@@ -17,7 +17,7 @@ with cr_stg AS
         -- For patients reaching Stage 3 by SCr >4.0 mg/dl
         -- require that the patient first achieve ... acute increase >= 0.3 within 48 hr
         -- *or* an increase of >= 1.5 times baseline
-        and (cr.creat_low_past_48hr <= 3.7 OR cr.creat >= (1.5*cr.creat_low_past_7day))
+        and (cr.creat >= (cr.creat_low_past_48hr+0.3) OR cr.creat >= (1.5*cr.creat_low_past_7day))
             then 3 
         -- TODO: initiation of RRT
         when cr.creat >= (cr.creat_low_past_7day*2.0) then 2

--- a/mimic-iv/concepts/organfailure/kdigo_stages.sql
+++ b/mimic-iv/concepts/organfailure/kdigo_stages.sql
@@ -20,7 +20,7 @@ WITH cr_stg AS (
                 --      an acute increase >= 0.3 within 48 hr
                 --      *or* an increase of >= 1.5 times baseline
                 AND (
-                    cr.creat_low_past_48hr <= 3.7 OR cr.creat >= (
+                    cr.creat >= (cr.creat_low_past_48hr + 0.3) OR cr.creat >= (
                         1.5 * cr.creat_low_past_7day
                     )
                 )


### PR DESCRIPTION
## Bug

The KDIGO AKI Stage 3 criterion for sCr >= 4.0 mg/dL requires evidence of an acute rise: either >= 0.3 mg/dL increase within 48 hours, or >= 1.5x the 7-day baseline. The 48-hour check uses the hardcoded expression `creat_low_past_48hr <= 3.7` (i.e., `4.0 - 0.3`), which is only correct when the current creatinine equals exactly 4.0.

For any creatinine above 4.0, this misclassifies patients. For example, a patient with creatinine = 5.0 and 48h-low = 3.9 has a 1.1 mg/dL acute rise but `3.9 <= 3.7` evaluates to FALSE, potentially missing the Stage 3 classification.

## Root cause

The hardcoded `3.7` in the Stage 3 branch of `kdigo_stages.sql` assumes creatinine is always exactly 4.0 at the threshold, rather than using the actual current creatinine value dynamically.

## Fix

Replace `cr.creat_low_past_48hr <= 3.7` with `cr.creat >= (cr.creat_low_past_48hr + 0.3)`, which correctly evaluates the >= 0.3 acute increase criterion for any creatinine value. This matches the pattern already used for Stage 1 (`cr.creat >= (cr.creat_low_past_48hr + 0.3)`).

Fixed in both canonical source files (mimic-iii/concepts and mimic-iv/concepts). The auto-generated postgres/duckdb variants would need regeneration.

Closes #1357