### PR TITLE
Fix MIMIC-III sqlite import using str.strip instead of suffix removal

### DIFF
--- a/mimic-iii/buildmimic/sqlite/import.py
+++ b/mimic-iii/buildmimic/sqlite/import.py
@@ -19,12 +19,12 @@ for f in glob("*.csv.gz"):
     print("Starting processing {}".format(f))
     if os.path.getsize(f) < THRESHOLD_SIZE:
         df = pd.read_csv(f, index_col="ROW_ID")
-        df.to_sql(f.strip(".csv.gz").lower(), CONNECTION_STRING)
+        df.to_sql(f[: -len(".csv.gz")].lower(), CONNECTION_STRING)
     else:
         # If the file is too large, let's do the work in chunks
         for chunk in pd.read_csv(f, index_col="ROW_ID", chunksize=CHUNKSIZE):
             chunk.to_sql(
-                f.strip(".csv.gz").lower(), CONNECTION_STRING, if_exists="append"
+                f[: -len(".csv.gz")].lower(), CONNECTION_STRING, if_exists="append"
             )
     print("Finished processing {}".format(f))
 


### PR DESCRIPTION
## Bug

In \`mimic-iii/buildmimic/sqlite/import.py\`, the target table name is derived with:

\`\`\`python
df.to_sql(f.strip(\".csv.gz\").lower(), CONNECTION_STRING)
\`\`\`

## Root cause

\`str.strip(chars)\` treats the argument as a **set of characters** to remove from both ends, not a literal suffix. With \`\".csv.gz\"\` the set is \`{'.', 'c', 's', 'v', 'g', 'z'}\`, so in addition to the suffix it also strips any trailing character that happens to be in that set.

MIMIC-III's official filenames are uppercase (\`PATIENTS.csv.gz\`), and the stripping halts at the first non-matching uppercase character, so the correct table name survives in the common path. But if a user has **lowercase copies** of the files (case-insensitive filesystems, archives re-packed with lowercase names), names like \`services.csv.gz\` become:

\`\`\`python
>>> \"services.csv.gz\".strip(\".csv.gz\")
'service'
\`\`\`

The trailing \`s\` of \`services\` is silently eaten, and the table is created under the wrong name.

## Fix

Replace \`f.strip(\".csv.gz\")\` with \`f[: -len(\".csv.gz\")]\` on both call sites. This removes exactly the known suffix and is compatible with Python 3.8 (no \`str.removesuffix\`).