### PR TITLE
Fix Charlson age_score off-by-one at decade boundaries

### DIFF
--- a/mimic-iv/concepts/comorbidity/charlson.sql
+++ b/mimic-iv/concepts/comorbidity/charlson.sql
@@ -350,10 +350,10 @@ WITH diag AS (
     SELECT
         hadm_id
         , age
-        , CASE WHEN age <= 50 THEN 0
-            WHEN age <= 60 THEN 1
-            WHEN age <= 70 THEN 2
-            WHEN age <= 80 THEN 3
+        , CASE WHEN age < 50 THEN 0
+            WHEN age < 60 THEN 1
+            WHEN age < 70 THEN 2
+            WHEN age < 80 THEN 3
             ELSE 4 END AS age_score
     FROM `physionet-data.mimiciv_derived.age`
 )


### PR DESCRIPTION
## Bug

\`mimic-iv/concepts/comorbidity/charlson.sql\` computes the age component of the Charlson Comorbidity Index as:

\`\`\`sql
, CASE WHEN age <= 50 THEN 0
    WHEN age <= 60 THEN 1
    WHEN age <= 70 THEN 2
    WHEN age <= 80 THEN 3
    ELSE 4 END AS age_score
\`\`\`

## Root cause

Per the file's own references (Charlson et al. 1987; Quan et al. 2005), CCI adds one age point per decade starting at 50:

| age range  | points |
|------------|--------|
| <50        | 0 |
| 50–59      | 1 |
| 60–69      | 2 |
| 70–79      | 3 |
| ≥80        | 4 |

The boundaries belong to the **higher** bin (50 → 1, 80 → 4). With \`<=\` they collapse into the lower bin: an age-50 patient gets 0 instead of 1, age-60 gets 1 instead of 2, age-70 gets 2 instead of 3, and age-80 gets 3 instead of 4. Each integer decade boundary is consistently understated by 1.

## Fix

Switch the cutoffs to strict \`<\` so each decade is bounded as \`[lower, upper)\`. Auto-generated \`concepts_postgres\` and \`concepts_duckdb\` copies will pick up the fix on the next regeneration (they are marked _\"AUTOMATICALLY GENERATED. DO NOT EDIT IT DIRECTLY.\"_).