### PR TITLE
Fix --limit subject filter dropped for chunked tables in sqlite import.py

### DIFF
--- a/mimic-iv/buildmimic/sqlite/import.py
+++ b/mimic-iv/buildmimic/sqlite/import.py
@@ -165,7 +165,7 @@ def main():
             else:
                 # If the file is too large, let's do the work in chunks
                 for chunk in pd.read_csv(f, chunksize=CHUNKSIZE, low_memory=False, dtype=mimic_dtypes):
-                    chunk = process_dataframe(chunk)
+                    chunk = process_dataframe(chunk, subjects=subjects)
                     chunk.to_sql(tablename, connection, if_exists="append", index=False)
                     row_counts[tablename] += len(chunk)
             print("done!")


### PR DESCRIPTION
### Bug
`mimic-iv/buildmimic/sqlite/import.py`'s `--limit N` option is silently ignored for any table large enough to trigger chunked reading (chartevents, labevents, emar, …). The resulting SQLite database contains every row of those tables, defeating the purpose of `--limit`.

https://github.com/MIT-LCP/mimic-code/blob/5706978/mimic-iv/buildmimic/sqlite/import.py#L160-L170

```python
if os.path.getsize(f) < THRESHOLD_SIZE:
    df = pd.read_csv(f, dtype=mimic_dtypes)
    df = process_dataframe(df, subjects=subjects)
    df.to_sql(tablename, connection, index=False)
    row_counts[tablename] += len(df)
else:
    # If the file is too large, let's do the work in chunks
    for chunk in pd.read_csv(f, chunksize=CHUNKSIZE, low_memory=False, dtype=mimic_dtypes):
        chunk = process_dataframe(chunk)
        chunk.to_sql(tablename, connection, if_exists="append", index=False)
```

The small-file branch passes `subjects=subjects` to `process_dataframe`, but the chunked branch calls `process_dataframe(chunk)`. `process_dataframe`'s `subjects` parameter defaults to `None`, and its `df.loc[df['subject_id'].isin(subjects)]` filter is a no-op when `subjects` is `None`.

### Root cause
Missing `subjects=subjects` argument in the chunked call, so chunked tables skip the `subject_id` filter entirely.

### Fix
Pass `subjects=subjects` in the chunked branch, matching the non-chunked branch so the `--limit N` filter is applied consistently.