### PR TITLE
Fix test_vasopressor_units AttributeError (Series has no .contains)

### DIFF
--- a/mimic-iv/tests/test_medication.py
+++ b/mimic-iv/tests/test_medication.py
@@ -58,7 +58,7 @@ def test_vasopressor_units(dataset, project_id):
         """
         df = gbq.read_gbq(query, project_id=project_id, dialect="standard")
         # if we find new uninspected rows, raise a warning. this will only happen when mimic-iv is updated.
-        if (~df['hadm_id'].contains(hadm_id_list)).any():
+        if (~df['hadm_id'].isin(hadm_id_list)).any():
             _LOGGER.warn(f"""New data found with non-standard unit. Inspect the data with this query:
 
             select *


### PR DESCRIPTION
### Bug
`test_vasopressor_units` in `mimic-iv/tests/test_medication.py` raises `AttributeError: 'Series' object has no attribute 'contains'` whenever the inner query returns any rows:

https://github.com/MIT-LCP/mimic-code/blob/5706978/mimic-iv/tests/test_medication.py#L60-L61

```python
df = gbq.read_gbq(query, project_id=project_id, dialect="standard")
# if we find new uninspected rows, raise a warning. this will only happen when mimic-iv is updated.
if (~df['hadm_id'].contains(hadm_id_list)).any():
```

### Root cause
`pandas.Series` has no `.contains()` method. The string accessor `Series.str.contains` exists for substring matching on strings, but the intent here is clearly "is each hadm_id in the known list of manually-inspected hadm_ids", which is `Series.isin(hadm_id_list)`.

### Fix
Replace `.contains(hadm_id_list)` with `.isin(hadm_id_list)`. The `~…any()` negation and the surrounding logic then work as intended: the warning fires when a row has an `hadm_id` not already on the allow-list, which is the documented behaviour of the surrounding comment ("if we find new uninspected rows, raise a warning").