### PR TITLE
Fix add_oracle_rowdelimiter output filename using str.strip instead of suffix removal

### DIFF
--- a/mimic-iii/buildmimic/oracle/add_oracle_rowdelimiter.py
+++ b/mimic-iii/buildmimic/oracle/add_oracle_rowdelimiter.py
@@ -63,7 +63,7 @@ def main(argv):
         print('Cannot find input file {}'.format(fn_in))
         sys.exit(2)
 
-    fn_out=fn_in.strip('.csv')+'_output.csv'
+    fn_out=fn_in[:-len('.csv')]+'_output.csv'
     print('\n'+'~'*40)
     print('Input filename = {}'.format(fn_in))
     print('Delimiter = {}'.format(delimiter))


### PR DESCRIPTION
## Bug

\`mimic-iii/buildmimic/oracle/add_oracle_rowdelimiter.py\` derives the output filename from the input with:

\`\`\`python
fn_out = fn_in.strip('.csv') + '_output.csv'
\`\`\`

\`str.strip(chars)\` treats its argument as a **set of characters** to remove from both ends, not a literal suffix. With \`'.csv'\` the set is \`{'.', 'c', 's', 'v'}\`, so any trailing run of those characters is eaten along with the extension. For the canonical MIMIC-III CSV filenames:

\`\`\`python
>>> 'patients.csv'.strip('.csv')
'patient'        # + '_output.csv'  ->  'patient_output.csv'
>>> 'admissions.csv'.strip('.csv')
'admission'      # + '_output.csv'  ->  'admission_output.csv'
>>> 'icustays.csv'.strip('.csv')
'icustay'        # + '_output.csv'  ->  'icustay_output.csv'
\`\`\`

So every input whose stem ends in one of \`c\`, \`s\`, or \`v\` silently loses those characters in the output filename. The row-delimited file then lands at a subtly renamed path, out of line with the input table name that downstream SQL\\*Loader control files expect.

## Root cause

Same \`str.strip\` vs suffix-removal misuse that PR #1989 fixed in \`mimic-iii/buildmimic/sqlite/import.py\`, applied here to the Oracle build path but missed by that fix.

## Why the fix is correct

Replacing \`fn_in.strip('.csv')\` with \`fn_in[:-len('.csv')]\` removes exactly the \`.csv\` suffix (4 characters) and nothing else, so \`patients.csv\` → \`patients_output.csv\`, \`icustays.csv\` → \`icustays_output.csv\`, etc. This matches the pattern already adopted by \`mimic-iii/buildmimic/sqlite/import.py\` post-#1989 and is compatible with the Python 2-compatible style this script uses (it still imports \`print_function\` from \`__future__\`), so no \`str.removesuffix\` / Python 3.9+ dependency is introduced.