### PR TITLE
Fix section_text last_paragraph start index off by separator length

### DIFF
--- a/mimic-iv-cxr/txt/section_parser.py
+++ b/mimic-iv-cxr/txt/section_parser.py
@@ -83,7 +83,7 @@ def section_text(text):
             sections.append('\n \n'.join(sections[-1].split('\n \n')[1:]))
             sections[-2] = sections[-2].split('\n \n')[0]
             section_names.append('last_paragraph')
-            section_idx.append(section_idx[-1] + len(sections[-2]))
+            section_idx.append(section_idx[-1] + len(sections[-2]) + len('\n \n'))
 
     return sections, section_names, section_idx
 


### PR DESCRIPTION
## Bug

`section_parser.section_text` returns a `section_idx` list documented as "list of start indices of the text in the section" — offsets back into the original report string. When the report has no `impression`/`findings` section and the final section contains `'\n \n'`, the function synthesises a `'last_paragraph'` section by splitting on that separator:

```python
if '\n \n' in sections[-1]:
    sections.append('\n \n'.join(sections[-1].split('\n \n')[1:]))
    sections[-2] = sections[-2].split('\n \n')[0]
    section_names.append('last_paragraph')
    section_idx.append(section_idx[-1] + len(sections[-2]))
```

The computed offset for the new `'last_paragraph'` section is `section_idx[-1] + len(sections[-2])`, but `sections[-2]` at that point holds only the *first* part of the split — the original section up to (but not including) the `'\n \n'` separator. `str.split` removes the separator, so the second part (which becomes the new `'last_paragraph'`) actually starts `len('\n \n')` (3) characters later in the original text.

## Root cause

The offset math omits the length of the separator that `split()` consumed. For every other entry in `section_idx`, the value is the end of the section-header regex match (`s.end()`) — i.e. already past the `:\s` separator — so using raw offsets relative to the original text is the invariant callers rely on. This branch breaks that invariant.

## Why the fix is correct

Adding `len('\n \n')` puts the offset at the first character of the last paragraph in the original text, matching what `text[section_idx[i]:]` gives for every other produced index:

```diff
-            section_idx.append(section_idx[-1] + len(sections[-2]))
+            section_idx.append(section_idx[-1] + len(sections[-2]) + len('\n \n'))
```

- `sections[-2]` is the first part (unchanged by this commit).
- `section_idx[-1]` is still the original section's start index at the point of append (not yet mutated).
- `len('\n \n')` is the separator length that `str.split('\n \n')` drops.

No other behavioural change: the returned `sections` list is identical, `section_names` is identical, only the previously-incorrect `section_idx[-1]` for the `last_paragraph` entry moves forward by 3 to the correct position.