### PR TITLE
Allow --destination_dialect=bigquery in convert_file

### DIFF
--- a/src/mimic_utils/__main__.py
+++ b/src/mimic_utils/__main__.py
@@ -10,7 +10,7 @@ def main():
     file_parser.add_argument("source_file", help="Source file.")
     file_parser.add_argument("destination_file", help="Destination file.")
     file_parser.add_argument("--source_dialect", choices=["bigquery", "postgres", "duckdb"], default='bigquery', help="SQL dialect to transpile.")
-    file_parser.add_argument("--destination_dialect", choices=["postgres", "duckdb"], default='postgres', help="SQL dialect to transpile.")
+    file_parser.add_argument("--destination_dialect", choices=["bigquery", "postgres", "duckdb"], default='postgres', help="SQL dialect to transpile.")
     file_parser.set_defaults(func=transpile_file)
     
     folder_parser = subparsers.add_parser('convert_folder', help='Transpile all SQL files in a folder.')


### PR DESCRIPTION
## Bug

The `convert_file` subcommand of `mimic_utils` rejects
`--destination_dialect bigquery` at argparse time, even though the
pipeline underneath supports bigquery as a destination. The
`convert_folder` subcommand accepts it.

```
$ python -m mimic_utils convert_file in.sql out.sql --destination_dialect bigquery
usage: python -m mimic_utils convert_file ...
python -m mimic_utils convert_file: error: argument --destination_dialect:
    invalid choice: 'bigquery' (choose from 'postgres', 'duckdb')
```

## Root cause

In `src/mimic_utils/__main__.py`:

```python
file_parser.add_argument("--destination_dialect",
    choices=["postgres", "duckdb"], default='postgres', ...)
...
folder_parser.add_argument("--destination_dialect",
    choices=["bigquery", "postgres", "duckdb"], default="postgres", ...)
```

`file_parser` is missing `"bigquery"` from its choices. Both subparsers
ultimately dispatch into `transpile_file` / `transpile_folder`, which
both call `transpile_query(..., destination_dialect=...)`. That function
validates the dialect via `_FUNCTION_MAPPING`, which contains
`{'bigquery': {}, 'postgres': {...}, 'duckdb': {...}}` — so bigquery is
a supported destination; the CLI choice list is the only thing blocking
it.

## Why the fix is correct

- The two subcommands call the same transpilation code; their
  destination choices should match.
- The underlying `transpile_query` / `_FUNCTION_MAPPING` already
  accepts `bigquery` as a destination dialect.
- Adds exactly one value to the choices list; default, help text, and
  dispatch remain unchanged.

## Change

`src/mimic_utils/__main__.py`: add `"bigquery"` to the `file_parser`
`--destination_dialect` choices.