### PR TITLE
fix(sqlite import): apply --limit subject filter on chunked large-file path

### DIFF
--- a/mimic-iv/buildmimic/sqlite/import.py
+++ b/mimic-iv/buildmimic/sqlite/import.py
@@ -165,7 +165,7 @@ def main():
             else:
                 # If the file is too large, let's do the work in chunks
                 for chunk in pd.read_csv(f, chunksize=CHUNKSIZE, low_memory=False, dtype=mimic_dtypes):
-                    chunk = process_dataframe(chunk)
+                    chunk = process_dataframe(chunk, subjects=subjects)
                     chunk.to_sql(tablename, connection, if_exists="append", index=False)
                     row_counts[tablename] += len(chunk)
             print("done!")


### PR DESCRIPTION
## Bug

In \`mimic-iv/buildmimic/sqlite/import.py\`, when invoked with \`--limit N\`, the resulting database is inconsistent: small tables are restricted to the chosen N \`subject_id\`s, but large tables (anything above \`THRESHOLD_SIZE\` — e.g. \`chartevents\`, \`labevents\`) are imported in full, unfiltered.

## Root cause

\`process_dataframe(df, subjects=...)\` is what applies the subject filter (lines 50–58):

\`\`\`python
def process_dataframe(df: pd.DataFrame, subjects: t.Optional[t.List[int]] = None) -> pd.DataFrame:
    ...
    if subjects is not None and 'subject_id' in df:
        df = df.loc[df['subject_id'].isin(subjects)]
    return df
\`\`\`

The small-file branch calls it correctly:

\`\`\`python
df = process_dataframe(df, subjects=subjects)
\`\`\`

The large-file (chunked) branch dropped the keyword:

\`\`\`python
for chunk in pd.read_csv(f, chunksize=CHUNKSIZE, ...):
    chunk = process_dataframe(chunk)
\`\`\`

So \`subjects\` defaults to \`None\` and every chunk is written to SQLite unfiltered.

## Fix

Pass \`subjects=subjects\` to the chunked call so both branches apply identical filtering. One-line change; the happy path with no \`--limit\` is unaffected (\`subjects\` is \`None\`, and \`process_dataframe\` is a no-op for the filter step).