### PR TITLE
Fix KDIGO AKI Stage 3 SCr criterion to use a +0.3 increase instead of hardcoded 3.7

### DIFF
--- a/mimic-iii/concepts/organfailure/kdigo_stages.sql
+++ b/mimic-iii/concepts/organfailure/kdigo_stages.sql
@@ -17,7 +17,7 @@ with cr_stg AS
         -- For patients reaching Stage 3 by SCr >4.0 mg/dl
         -- require that the patient first achieve ... acute increase >= 0.3 within 48 hr
         -- *or* an increase of >= 1.5 times baseline
-        and (cr.creat_low_past_48hr <= 3.7 OR cr.creat >= (1.5*cr.creat_low_past_7day))
+        and (cr.creat >= (cr.creat_low_past_48hr+0.3) OR cr.creat >= (1.5*cr.creat_low_past_7day))
             then 3 
         -- TODO: initiation of RRT
         when cr.creat >= (cr.creat_low_past_7day*2.0) then 2

--- a/mimic-iv/concepts/organfailure/kdigo_stages.sql
+++ b/mimic-iv/concepts/organfailure/kdigo_stages.sql
@@ -20,7 +20,7 @@ WITH cr_stg AS (
                 --      an acute increase >= 0.3 within 48 hr
                 --      *or* an increase of >= 1.5 times baseline
                 AND (
-                    cr.creat_low_past_48hr <= 3.7 OR cr.creat >= (
+                    cr.creat >= (cr.creat_low_past_48hr + 0.3) OR cr.creat >= (
                         1.5 * cr.creat_low_past_7day
                     )
                 )


### PR DESCRIPTION
## Bug

In `kdigo_stages.sql`, the creatinine-based AKI **Stage 3** branch for patients reaching SCr >= 4.0 mg/dL is meant to require an *acute increase of >= 0.3 within 48 hours* (or >= 1.5x baseline), per the [KDIGO 2012 AKI guideline](https://kdigo.org/wp-content/uploads/2016/10/KDIGO-2012-AKI-Guideline-English.pdf) (p.21). It is implemented as:

```sql
when cr.creat >= 4
  and (cr.creat_low_past_48hr <= 3.7 OR cr.creat >= (1.5*cr.creat_low_past_7day))
  then 3
```

## Root cause

The hardcoded `creat_low_past_48hr <= 3.7` only encodes a 0.3 increase when `creat` is *exactly* 4.0 (4.0 − 3.7 = 0.3). For any creatinine above 4.0 the test no longer matches the intended threshold. For example, `creat = 5.0` with a 48h low of `3.8` is a real increase of 1.2 mg/dL — clearly Stage 3 — yet `3.8 <= 3.7` is false and the 1.5x-baseline arm may also fail, so the patient is not flagged.

## Fix

Replace the hardcoded `3.7` with the actual >= 0.3 increase condition, matching the comment directly above it:

```sql
and (cr.creat >= (cr.creat_low_past_48hr + 0.3) OR cr.creat >= (1.5*cr.creat_low_past_7day))
```

This is the change confirmed by the maintainer in #1357. Applied to both the MIMIC-IV and MIMIC-III BigQuery source files (the reporter noted both are affected). The `concepts_postgres`/`concepts_duckdb` copies are auto-generated from these sources and should be regenerated via the conversion scripts.

Fixes #1357