### PR TITLE
Fix BigQuery datetime subtraction in arterial_line_durations.sql

### DIFF
--- a/mimic-iii/concepts/durations/arterial_line_durations.sql
+++ b/mimic-iii/concepts/durations/arterial_line_durations.sql
@@ -131,7 +131,7 @@ with mv as
     , charttime_lag
     -- if the current observation indicates a line is present
     -- calculate the time since the last charted line
-    , charttime - charttime_lag as arterial_line_duration
+    , DATETIME_DIFF(charttime, charttime_lag, HOUR) as arterial_line_duration
     -- now we determine if the current line is "new"
     -- new == no documentation for 16 hours
     , case


### PR DESCRIPTION
## Bug
Fixes #843. Running `mimic-iii/concepts/durations/arterial_line_durations.sql` on BigQuery fails with `No matching signature for operator - for argument types: DATETIME, DATETIME`.

## Root cause
Line 134 uses PostgreSQL interval subtraction (`charttime - charttime_lag`), which BigQuery does not support for DATETIME values.

## Why this fix is correct
The same query already uses `DATETIME_DIFF(charttime, charttime_lag, HOUR)` on line 138 for the related 16-hour threshold check. Replacing the subtraction with the same BigQuery function makes the duration column valid and consistent with the rest of the file.


Made with [Cursor](https://cursor.com)