### PR TITLE
Fix height FULL OUTER JOIN coalescing h1 instead of h2

### DIFF
--- a/mimic-iv/concepts/measurement/height.sql
+++ b/mimic-iv/concepts/measurement/height.sql
@@ -25,9 +25,9 @@ WITH ht_in AS (
 -- merge cm/height, only take 1 value per charted row
 , ht_stg0 AS (
     SELECT
-        COALESCE(h1.subject_id, h1.subject_id) AS subject_id
-        , COALESCE(h1.stay_id, h1.stay_id) AS stay_id
-        , COALESCE(h1.charttime, h1.charttime) AS charttime
+        COALESCE(h1.subject_id, h2.subject_id) AS subject_id
+        , COALESCE(h1.stay_id, h2.stay_id) AS stay_id
+        , COALESCE(h1.charttime, h2.charttime) AS charttime
         , COALESCE(h1.height, h2.height) AS height
     FROM ht_cm h1
     FULL OUTER JOIN ht_in h2

--- a/mimic-iv/concepts_duckdb/measurement/height.sql
+++ b/mimic-iv/concepts_duckdb/measurement/height.sql
@@ -21,9 +21,9 @@ WITH ht_in AS (
     NOT c.valuenum IS NULL AND c.itemid = 226730
 ), ht_stg0 AS (
   SELECT
-    COALESCE(h1.subject_id, h1.subject_id) AS subject_id,
-    COALESCE(h1.stay_id, h1.stay_id) AS stay_id,
-    COALESCE(h1.charttime, h1.charttime) AS charttime,
+    COALESCE(h1.subject_id, h2.subject_id) AS subject_id,
+    COALESCE(h1.stay_id, h2.stay_id) AS stay_id,
+    COALESCE(h1.charttime, h2.charttime) AS charttime,
     COALESCE(h1.height, h2.height) AS height
   FROM ht_cm AS h1
   FULL OUTER JOIN ht_in AS h2

--- a/mimic-iv/concepts_postgres/measurement/height.sql
+++ b/mimic-iv/concepts_postgres/measurement/height.sql
@@ -22,9 +22,9 @@ WITH ht_in AS (
     NOT c.valuenum IS NULL AND /* Height cm */ c.itemid = 226730
 ), ht_stg0 AS (
   SELECT
-    COALESCE(h1.subject_id, h1.subject_id) AS subject_id,
-    COALESCE(h1.stay_id, h1.stay_id) AS stay_id,
-    COALESCE(h1.charttime, h1.charttime) AS charttime,
+    COALESCE(h1.subject_id, h2.subject_id) AS subject_id,
+    COALESCE(h1.stay_id, h2.stay_id) AS stay_id,
+    COALESCE(h1.charttime, h2.charttime) AS charttime,
     COALESCE(h1.height, h2.height) AS height
   FROM ht_cm AS h1
   FULL OUTER JOIN ht_in AS h2


### PR DESCRIPTION
## Summary
In `ht_stg0`, `COALESCE(h1.subject_id, h1.subject_id)` (and stay_id/charttime) used `h1` for both arguments after the FULL OUTER JOIN of cm and inch heights. Inch-only rows from `ht_in` had NULL keys and were dropped downstream.

## Fix
Use `h2` as the fallback for subject_id, stay_id, and charttime in all three dialect copies of `height.sql`.

Fixes #2010


Made with [Cursor](https://cursor.com)