### PR TITLE
Fix MIMIC-III pivoted height FULL OUTER JOIN coalescing h1 instead of h2

### DIFF
--- a/mimic-iii/concepts/pivot/pivoted_height.sql
+++ b/mimic-iii/concepts/pivot/pivoted_height.sql
@@ -52,8 +52,8 @@ WITH ht_in AS
 , ht_stg0 AS
 (
   SELECT
-  COALESCE(h1.subject_id, h1.subject_id) as subject_id
-  , COALESCE(h1.charttime, h1.charttime) AS charttime
+  COALESCE(h1.subject_id, h2.subject_id) as subject_id
+  , COALESCE(h1.charttime, h2.charttime) AS charttime
   , COALESCE(h1.height, h2.height) as height
   FROM ht_cm h1
   FULL OUTER JOIN ht_in h2


### PR DESCRIPTION
## Summary
- Fixes the same COALESCE bug as #2010 in `mimic-iii/concepts/pivot/pivoted_height.sql`
- `ht_stg0` now falls back to `h2.subject_id` and `h2.charttime` when merging cm/inch height rows from a FULL OUTER JOIN
- Without this fix, inch-only height measurements are dropped because null join keys from `h2` were not preserved

## Test plan
- [ ] Regenerate `mimic-iii/concepts/pivot/pivoted_height` and confirm inch-only heights are retained
- [ ] Compare row counts before/after for patients with inch-only height charting

Fixes #2010 (MIMIC-III variant).

Made with [Cursor](https://cursor.com)