### PR TITLE
Fix FULL OUTER JOIN COALESCE in MIMIC-IV height concept

### DIFF
--- a/mimic-iv/concepts/measurement/height.sql
+++ b/mimic-iv/concepts/measurement/height.sql
@@ -25,9 +25,9 @@ WITH ht_in AS (
 -- merge cm/height, only take 1 value per charted row
 , ht_stg0 AS (
     SELECT
-        COALESCE(h1.subject_id, h1.subject_id) AS subject_id
-        , COALESCE(h1.stay_id, h1.stay_id) AS stay_id
-        , COALESCE(h1.charttime, h1.charttime) AS charttime
+        COALESCE(h1.subject_id, h2.subject_id) AS subject_id
+        , COALESCE(h1.stay_id, h2.stay_id) AS stay_id
+        , COALESCE(h1.charttime, h2.charttime) AS charttime
         , COALESCE(h1.height, h2.height) AS height
     FROM ht_cm h1
     FULL OUTER JOIN ht_in h2

--- a/mimic-iv/concepts_duckdb/measurement/height.sql
+++ b/mimic-iv/concepts_duckdb/measurement/height.sql
@@ -21,9 +21,9 @@ WITH ht_in AS (
     NOT c.valuenum IS NULL AND c.itemid = 226730
 ), ht_stg0 AS (
   SELECT
-    COALESCE(h1.subject_id, h1.subject_id) AS subject_id,
-    COALESCE(h1.stay_id, h1.stay_id) AS stay_id,
-    COALESCE(h1.charttime, h1.charttime) AS charttime,
+    COALESCE(h1.subject_id, h2.subject_id) AS subject_id,
+    COALESCE(h1.stay_id, h2.stay_id) AS stay_id,
+    COALESCE(h1.charttime, h2.charttime) AS charttime,
     COALESCE(h1.height, h2.height) AS height
   FROM ht_cm AS h1
   FULL OUTER JOIN ht_in AS h2

--- a/mimic-iv/concepts_postgres/measurement/height.sql
+++ b/mimic-iv/concepts_postgres/measurement/height.sql
@@ -22,9 +22,9 @@ WITH ht_in AS (
     NOT c.valuenum IS NULL AND /* Height cm */ c.itemid = 226730
 ), ht_stg0 AS (
   SELECT
-    COALESCE(h1.subject_id, h1.subject_id) AS subject_id,
-    COALESCE(h1.stay_id, h1.stay_id) AS stay_id,
-    COALESCE(h1.charttime, h1.charttime) AS charttime,
+    COALESCE(h1.subject_id, h2.subject_id) AS subject_id,
+    COALESCE(h1.stay_id, h2.stay_id) AS stay_id,
+    COALESCE(h1.charttime, h2.charttime) AS charttime,
     COALESCE(h1.height, h2.height) AS height
   FROM ht_cm AS h1
   FULL OUTER JOIN ht_in AS h2


### PR DESCRIPTION
## Summary
- Fix `ht_stg0` in MIMIC-IV `height.sql` to use `h2` columns in `COALESCE` fallbacks for `subject_id`, `stay_id`, and `charttime`
- Apply the same fix across BigQuery, Postgres, and DuckDB concept builds

## Problem
The FULL OUTER JOIN between inch-based (`ht_in`) and cm-based (`ht_cm`) height measurements used `COALESCE(h1.col, h1.col)`, which never falls back to `h2` values. Height records present only in `ht_in` were excluded from the derived table.

## Test plan
- [ ] Rebuild `mimiciv_derived.height` and verify inch-only measurements are retained
- [ ] Compare row counts before/after on a sample MIMIC-IV install

Fixes #2010

Made with [Cursor](https://cursor.com)