### PR TITLE
fix(mimic-iv): correct KDIGO stage 3 creatinine rise criteria

### DIFF
--- a/mimic-iv/concepts/organfailure/kdigo_stages.sql
+++ b/mimic-iv/concepts/organfailure/kdigo_stages.sql
@@ -20,9 +20,8 @@ WITH cr_stg AS (
                 --      an acute increase >= 0.3 within 48 hr
                 --      *or* an increase of >= 1.5 times baseline
                 AND (
-                    cr.creat_low_past_48hr <= 3.7 OR cr.creat >= (
-                        1.5 * cr.creat_low_past_7day
-                    )
+                    cr.creat >= (cr.creat_low_past_48hr + 0.3)
+                    OR cr.creat >= (1.5 * cr.creat_low_past_7day)
                 )
                 THEN 3
             -- TODO: initiation of RRT


### PR DESCRIPTION
Fixes #1357

## Summary
- Replaces the hard-coded `creat_low_past_48hr <= 3.7` shortcut in stage 3 creatinine logic
- Uses KDIGO-defined acute rise checks: `creat >= creat_low_past_48hr + 0.3` OR `creat >= 1.5 * creat_low_past_7day` when `creat >= 4.0`

## Test plan
- [x] SQL logic matches KDIGO guideline criteria described in #1357
- [ ] Review against clinical expectations for AKI staging queries

Made with [Cursor](https://cursor.com)