### PR TITLE
Revise comment for HADM_ID column in ADMISSIONS table

### DIFF
--- a/mimic-iii/buildmimic/postgres/postgres_add_comments.sql
+++ b/mimic-iii/buildmimic/postgres/postgres_add_comments.sql
@@ -57,7 +57,7 @@ COMMENT ON COLUMN ADMISSIONS.ROW_ID is
 COMMENT ON COLUMN ADMISSIONS.SUBJECT_ID is
    'Foreign key. Identifies the patient.';
 COMMENT ON COLUMN ADMISSIONS.HADM_ID is
-   'Primary key. Identifies the hospital stay.';
+   'Identifies the hospital stay.';
 COMMENT ON COLUMN ADMISSIONS.ADMITTIME is
    'Time of admission to the hospital.';
 COMMENT ON COLUMN ADMISSIONS.DISCHTIME is


### PR DESCRIPTION
Updated comment for ADMISSIONS.HADM_ID to clarify its purpose. ROW_ID is the primary key.