### PR TITLE
fix(mimic-iv): add missing temperature itemids to vitalsign concept

### DIFF
--- a/mimic-iv/concepts/measurement/vitalsign.sql
+++ b/mimic-iv/concepts/measurement/vitalsign.sql
@@ -53,12 +53,13 @@ SELECT
                     AND valuenum < 120
                     THEN (valuenum - 32) / 1.8
                 -- already in degC, no conversion necessary
-                WHEN itemid IN (223762)
+                -- includes core/blood temps (CCO) and Arctic Sun/Alsius temps
+                WHEN itemid IN (223762, 226329, 227632, 227634)
                     AND valuenum > 10
                     AND valuenum < 50
                     THEN valuenum END)
             AS NUMERIC), 2) AS temperature
-    , MAX(CASE WHEN itemid = 224642 THEN value END
+    , MAX(CASE WHEN itemid IN (224642, 227630, 227631) THEN value END
     ) AS temperature_site
     , AVG(CASE WHEN itemid IN (220277)
                 AND valuenum > 0
@@ -91,10 +92,14 @@ WHERE ce.stay_id IS NOT NULL
         , 220621 -- Glucose (serum)
         , 226537 -- Glucose (whole blood)
         -- TEMPERATURE
-        -- 226329 -- Blood Temperature CCO (C)
+        , 226329 -- Blood Temperature CCO (C)
+        , 227632 -- Arctic Sun/Alsius Temp #1 C
+        , 227634 -- Arctic Sun/Alsius Temp #2 C
         , 223762 -- "Temperature Celsius"
         , 223761  -- "Temperature Fahrenheit"
         , 224642 -- Temperature Site
+        , 227630 -- Arctic Sun Temp #1 Location
+        , 227631 -- Arctic Sun Temp #2 Location
     )
 GROUP BY ce.subject_id, ce.stay_id, ce.charttime
 ;

--- a/mimic-iv/concepts_duckdb/measurement/vitalsign.sql
+++ b/mimic-iv/concepts_duckdb/measurement/vitalsign.sql
@@ -41,13 +41,13 @@ SELECT
         THEN (
           valuenum - 32
         ) / 1.8
-        WHEN itemid IN (223762) AND valuenum > 10 AND valuenum < 50
+        WHEN itemid IN (223762, 226329, 227632, 227634) AND valuenum > 10 AND valuenum < 50
         THEN valuenum
       END
     ) AS DECIMAL(38, 9)),
     2
   ) AS temperature,
-  MAX(CASE WHEN itemid = 224642 THEN value END) AS temperature_site,
+  MAX(CASE WHEN itemid IN (224642, 227630, 227631) THEN value END) AS temperature_site,
   AVG(
     CASE WHEN itemid IN (220277) AND valuenum > 0 AND valuenum <= 100 THEN valuenum END
   ) AS spo2,
@@ -72,9 +72,14 @@ WHERE
     225664,
     220621,
     226537,
+    226329,
+    227632,
+    227634,
     223762,
     223761,
-    224642
+    224642,
+    227630,
+    227631
   )
 GROUP BY
   ce.subject_id,

--- a/mimic-iv/concepts_postgres/measurement/vitalsign.sql
+++ b/mimic-iv/concepts_postgres/measurement/vitalsign.sql
@@ -1,6 +1,8 @@
 -- THIS SCRIPT IS AUTOMATICALLY GENERATED. DO NOT EDIT IT DIRECTLY.
 DROP TABLE IF EXISTS mimiciv_derived.vitalsign; CREATE TABLE mimiciv_derived.vitalsign AS
-/* This query pivots the vital signs for the entire patient stay. */ /* The result is a tabler with stay_id, charttime, and various */ /* vital signs, with one row per charted time. */
+/* This query pivots the vital signs for the entire patient stay. */
+/* The result is a tabler with stay_id, charttime, and various */
+/* vital signs, with one row per charted time. */
 SELECT
   ce.subject_id,
   ce.stay_id,
@@ -42,13 +44,13 @@ SELECT
         THEN CAST((
           valuenum - 32
         ) AS DOUBLE PRECISION) / 1.8
-        WHEN itemid IN (223762) AND valuenum > 10 AND valuenum < 50
+        WHEN itemid IN (223762, 226329, 227632, 227634) AND valuenum > 10 AND valuenum < 50
         THEN valuenum
       END
     ) AS DECIMAL(38, 9)),
     2
   ) AS temperature,
-  MAX(CASE WHEN itemid = 224642 THEN value END) AS temperature_site,
+  MAX(CASE WHEN itemid IN (224642, 227630, 227631) THEN value END) AS temperature_site,
   AVG(
     CASE WHEN itemid IN (220277) AND valuenum > 0 AND valuenum <= 100 THEN valuenum END
   ) AS spo2,
@@ -72,10 +74,15 @@ WHERE
     220277, /* SPO2, peripheral */ /* GLUCOSE, both lab and fingerstick */
     225664, /* Glucose finger stick */
     220621, /* Glucose (serum) */
-    226537, /* Glucose (whole blood) */ /* TEMPERATURE */ /* 226329 -- Blood Temperature CCO (C) */
+    226537, /* Glucose (whole blood) */ /* TEMPERATURE */
+    226329, /* Blood Temperature CCO (C) */
+    227632, /* Arctic Sun/Alsius Temp #1 C */
+    227634, /* Arctic Sun/Alsius Temp #2 C */
     223762, /* "Temperature Celsius" */
     223761, /* "Temperature Fahrenheit" */
-    224642 /* Temperature Site */
+    224642, /* Temperature Site */
+    227630, /* Arctic Sun Temp #1 Location */
+    227631 /* Arctic Sun Temp #2 Location */
   )
 GROUP BY
   ce.subject_id,


### PR DESCRIPTION
## Summary
- Add missing temperature **itemids** to `vitalsign.sql` (Celsius CASE + site)
- Regenerate postgres and duckdb dialect copies from the BigQuery source

### Added itemids (for reviewers)

| itemid | Label | Used as |
| --- | --- | --- |
| **226329** | Blood Temperature CCO (C) | temperature (°C) |
| **227632** | Arctic Sun/Alsius Temp #1 C | temperature (°C) |
| **227634** | Arctic Sun/Alsius Temp #2 C | temperature (°C) |
| **227630** | Arctic Sun Temp #1 Location | `temperature_site` |
| **227631** | Arctic Sun Temp #2 Location | `temperature_site` |

Existing `223762` / `223761` (C/F) and `224642` (site) are unchanged.

## Why
The vitalsign concept omitted blood/CCO and Arctic Sun/Alsius temperature itemids documented in #1358.

## Test plan
- [x] `pytest tests/test_transpile.py` passes locally
- [x] Itemids listed above present in BigQuery + postgres + duckdb copies
- [ ] CI concept build on MIMIC-IV demo

Fixes #1358