### PR TITLE
fix: BigQuery DATETIME_DIFF in arterial/central line durations

### DIFF
--- a/mimic-iii/concepts/durations/arterial_line_durations.sql
+++ b/mimic-iii/concepts/durations/arterial_line_durations.sql
@@ -131,7 +131,7 @@ with mv as
     , charttime_lag
     -- if the current observation indicates a line is present
     -- calculate the time since the last charted line
-    , charttime - charttime_lag as arterial_line_duration
+    , DATETIME_DIFF(charttime, charttime_lag, HOUR) as arterial_line_duration
     -- now we determine if the current line is "new"
     -- new == no documentation for 16 hours
     , case

--- a/mimic-iii/concepts/durations/central_line_durations.sql
+++ b/mimic-iii/concepts/durations/central_line_durations.sql
@@ -126,7 +126,7 @@ with mv as
     , charttime_lag
     -- if the current observation indicates a line is present
     -- calculate the time since the last charted line
-    , charttime - charttime_lag as central_line_duration
+    , DATETIME_DIFF(charttime, charttime_lag, HOUR) as central_line_duration
     -- now we determine if the current line is "new"
     -- new == no documentation for 16 hours
     , case


### PR DESCRIPTION
## Summary
- Replaces `charttime - charttime_lag` with `DATETIME_DIFF(..., HOUR)` in arterial and central line duration queries

Fixes #843

## Test plan
- [ ] BigQuery dry-run of both duration scripts

Made with [Cursor](https://cursor.com)