### PR TITLE
fix: SECOND-based DATETIME_DIFF in urine_output_rate

### DIFF
--- a/mimic-iv/concepts/measurement/urine_output_rate.sql
+++ b/mimic-iv/concepts/measurement/urine_output_rate.sql
@@ -47,24 +47,29 @@ WITH tm AS (
         -- to 1 hour of UO, therefore we use '5' and '11' to restrict the
         -- period, rather than 6/12 this assumption may overestimate UO rate
         -- when documentation is done less than hourly
-        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 5
+        , SUM(CASE
+            WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 5
             THEN iosum.urineoutput
             ELSE NULL END) AS urineoutput_6hr
         , ROUND(CAST(
             SUM(
                 CASE
-                    WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 5
+                    WHEN DATETIME_DIFF(
+                        io.charttime, iosum.charttime, SECOND
+                    ) / 3600.0 <= 5
                 THEN iosum.tm_since_last_uo
                 ELSE NULL END) / 60.0 AS NUMERIC
         ), 6) AS uo_tm_6hr
-        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 11
+        , SUM(CASE
+            WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 11
             THEN iosum.urineoutput
             ELSE NULL END) AS urineoutput_12hr
         , ROUND(CAST(
             SUM(
                 CASE
-                    WHEN
-                        DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 11
+                    WHEN DATETIME_DIFF(
+                        io.charttime, iosum.charttime, SECOND
+                    ) / 3600.0 <= 11
                 THEN iosum.tm_since_last_uo
                 ELSE NULL END) / 60.0 AS NUMERIC
         ), 6) AS uo_tm_12hr

--- a/mimic-iv/concepts/measurement/urine_output_rate.sql
+++ b/mimic-iv/concepts/measurement/urine_output_rate.sql
@@ -48,7 +48,9 @@ WITH tm AS (
         -- period, rather than 6/12 this assumption may overestimate UO rate
         -- when documentation is done less than hourly
         , SUM(CASE
-            WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 5
+            WHEN DATETIME_DIFF(
+                io.charttime, iosum.charttime, SECOND
+            ) / 3600.0 <= 5
             THEN iosum.urineoutput
             ELSE NULL END) AS urineoutput_6hr
         , ROUND(CAST(
@@ -61,7 +63,9 @@ WITH tm AS (
                 ELSE NULL END) / 60.0 AS NUMERIC
         ), 6) AS uo_tm_6hr
         , SUM(CASE
-            WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 11
+            WHEN DATETIME_DIFF(
+                io.charttime, iosum.charttime, SECOND
+            ) / 3600.0 <= 11
             THEN iosum.urineoutput
             ELSE NULL END) AS urineoutput_12hr
         , ROUND(CAST(

--- a/mimic-iv/concepts/measurement/urine_output_rate.sql
+++ b/mimic-iv/concepts/measurement/urine_output_rate.sql
@@ -16,12 +16,14 @@ WITH tm AS (
 )
 
 -- now calculate time since last UO measurement
+-- Use SECOND diffs (like kdigo_uo) so BigQuery and PostgreSQL agree (#1549).
+-- BigQuery DATETIME_DIFF(..., MINUTE/HOUR) truncates; SECOND/N keeps fractions.
 , uo_tm AS (
     SELECT tm.stay_id
         , CASE
             WHEN LAG(charttime) OVER w IS NULL
-                THEN DATETIME_DIFF(charttime, intime_hr, MINUTE)
-            ELSE DATETIME_DIFF(charttime, LAG(charttime) OVER w, MINUTE)
+                THEN DATETIME_DIFF(charttime, intime_hr, SECOND) / 60.0
+            ELSE DATETIME_DIFF(charttime, LAG(charttime) OVER w, SECOND) / 60.0
         END AS tm_since_last_uo
         , uo.charttime
         , uo.urineoutput
@@ -45,24 +47,24 @@ WITH tm AS (
         -- to 1 hour of UO, therefore we use '5' and '11' to restrict the
         -- period, rather than 6/12 this assumption may overestimate UO rate
         -- when documentation is done less than hourly
-        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, HOUR) <= 5
+        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 5
             THEN iosum.urineoutput
             ELSE NULL END) AS urineoutput_6hr
         , ROUND(CAST(
             SUM(
                 CASE
-                    WHEN DATETIME_DIFF(io.charttime, iosum.charttime, HOUR) <= 5
+                    WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 5
                 THEN iosum.tm_since_last_uo
                 ELSE NULL END) / 60.0 AS NUMERIC
         ), 6) AS uo_tm_6hr
-        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, HOUR) <= 11
+        , SUM(CASE WHEN DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 11
             THEN iosum.urineoutput
             ELSE NULL END) AS urineoutput_12hr
         , ROUND(CAST(
             SUM(
                 CASE
                     WHEN
-                        DATETIME_DIFF(io.charttime, iosum.charttime, HOUR) <= 11
+                        DATETIME_DIFF(io.charttime, iosum.charttime, SECOND) / 3600.0 <= 11
                 THEN iosum.tm_since_last_uo
                 ELSE NULL END) / 60.0 AS NUMERIC
         ), 6) AS uo_tm_12hr


### PR DESCRIPTION
## Summary
- BigQuery truncates MINUTE/HOUR diffs; Postgres returns fractions
- Use SECOND/60 and SECOND/3600 like kdigo_uo

Fixes #1549

## Test plan
- [ ] CI transpile / equivalence
