### PR TITLE
fix: use sed -E for macOS/BSD sed compatibility

### DIFF
--- a/mimic-iii/concepts/convert_mimiciii_concepts_bq_to_psql.sh
+++ b/mimic-iii/concepts/convert_mimiciii_concepts_bq_to_psql.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # This shell script converts BigQuery .sql files into PostgreSQL .sql files.
+# Use sed -E (POSIX ERE) so the script works on both GNU and BSD sed (macOS).
 
 # path in which we create the postgres concepts
 TARGET_PATH='../concepts_postgres'
@@ -72,7 +73,7 @@ do
   if ! [[ "$DIR_AND_TABLES_ALREADY_IN_PSQL" =~ "$d.$tbl" ]]; then
     echo "-- THIS SCRIPT IS AUTOMATICALLY GENERATED. DO NOT EDIT IT DIRECTLY." > "${TARGET_PATH}/${d}/${tbl}.sql"
     echo "DROP TABLE IF EXISTS ${tbl}; CREATE TABLE ${tbl} AS " >> "${TARGET_PATH}/${d}/${tbl}.sql"
-    cat "${d}/${tbl}.sql" | sed -r -e "${REGEX_ARRAY}" | sed -r -e "${REGEX_HOUR_INTERVAL}" | sed -r -e "${REGEX_INT}" | sed -r -e "${REGEX_DATETIME_DIFF}" | sed -r -e "${REGEX_DATETIME_TRUNC}" | sed -r -e "${REGEX_SCHEMA}" | sed -r -e "${REGEX_INTERVAL}" >> "${TARGET_PATH}/${d}/${tbl}.sql"
+    cat "${d}/${tbl}.sql" | sed -E -e "${REGEX_ARRAY}" | sed -E -e "${REGEX_HOUR_INTERVAL}" | sed -E -e "${REGEX_INT}" | sed -E -e "${REGEX_DATETIME_DIFF}" | sed -E -e "${REGEX_DATETIME_TRUNC}" | sed -E -e "${REGEX_SCHEMA}" | sed -E -e "${REGEX_INTERVAL}" >> "${TARGET_PATH}/${d}/${tbl}.sql"
   fi
 
   # write out a call to this script in the make concepts file
@@ -122,7 +123,7 @@ do
             if ! [[ "$DIR_AND_TABLES_ALREADY_IN_PSQL" =~ "$d.$tbl" ]]; then
               echo "-- THIS SCRIPT IS AUTOMATICALLY GENERATED. DO NOT EDIT IT DIRECTLY." > "${TARGET_PATH}/${d}/${tbl}.sql"
               echo "DROP TABLE IF EXISTS ${tbl}; CREATE TABLE ${tbl} AS " >> "${TARGET_PATH}/${d}/${tbl}.sql"
-              cat "${d}/${tbl}.sql" | sed -r -e "${REGEX_ARRAY}" | sed -r -e "${REGEX_HOUR_INTERVAL}" | sed -r -e "${REGEX_INT}" | sed -r -e "${REGEX_DATETIME_DIFF}" | sed -r -e "${REGEX_DATETIME_TRUNC}" | sed -r -e "${REGEX_SCHEMA}" | sed -r -e "${REGEX_INTERVAL}" >> "${TARGET_PATH}/${d}/${fn}"
+              cat "${d}/${tbl}.sql" | sed -E -e "${REGEX_ARRAY}" | sed -E -e "${REGEX_HOUR_INTERVAL}" | sed -E -e "${REGEX_INT}" | sed -E -e "${REGEX_DATETIME_DIFF}" | sed -E -e "${REGEX_DATETIME_TRUNC}" | sed -E -e "${REGEX_SCHEMA}" | sed -E -e "${REGEX_INTERVAL}" >> "${TARGET_PATH}/${d}/${fn}"
             fi
 
             # add statement to generate this table to make concepts script
@@ -150,7 +151,7 @@ do
   if ! [[ "$DIR_AND_TABLES_ALREADY_IN_PSQL" =~ "$d.$tbl" ]]; then
     echo "-- THIS SCRIPT IS AUTOMATICALLY GENERATED. DO NOT EDIT IT DIRECTLY." > "${TARGET_PATH}/${d}/${tbl}.sql"
     echo "DROP TABLE IF EXISTS ${tbl}; CREATE TABLE ${tbl} AS " >> "${TARGET_PATH}/${d}/${tbl}.sql"
-    cat "${d}/${tbl}.sql" | sed -r -e "${REGEX_ARRAY}" | sed -r -e "${REGEX_HOUR_INTERVAL}" | sed -r -e "${REGEX_INT}" | sed -r -e "${REGEX_DATETIME_DIFF}" | sed -r -e "${REGEX_DATETIME_TRUNC}" | sed -r -e "${REGEX_SCHEMA}" | sed -r -e "${REGEX_INTERVAL}" >> "${TARGET_PATH}/${d}/${tbl}.sql"
+    cat "${d}/${tbl}.sql" | sed -E -e "${REGEX_ARRAY}" | sed -E -e "${REGEX_HOUR_INTERVAL}" | sed -E -e "${REGEX_INT}" | sed -E -e "${REGEX_DATETIME_DIFF}" | sed -E -e "${REGEX_DATETIME_TRUNC}" | sed -E -e "${REGEX_SCHEMA}" | sed -E -e "${REGEX_INTERVAL}" >> "${TARGET_PATH}/${d}/${tbl}.sql"
   fi
   # write out a call to this script in the make concepts file
   echo "\i ${d}/${tbl}.sql" >> $TARGET_PATH/postgres-make-concepts.sql

--- a/mimic-iv-ed/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv-ed/buildmimic/duckdb/import_duckdb.sh
@@ -74,7 +74,7 @@ fi
 export REGEX_TIMESTAMP='s/TIMESTAMP\([0-9]+\)/TIMESTAMP/g'
 
 # use sed + above regex to create tables within db
-sed -r -e "${REGEX_TIMESTAMP}" ../postgres/create.sql | 
+sed -E -e "${REGEX_TIMESTAMP}" ../postgres/create.sql | 
   duckdb "$OUTFILE"
 
 # goal: get path from find, e.g., ./1.0/icu/d_items

--- a/mimic-iv-note/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv-note/buildmimic/duckdb/import_duckdb.sh
@@ -77,7 +77,7 @@ MIMIC_DIR=${MIMIC_DIR%/}
 export REGEX_TIMESTAMP='s/TIMESTAMP\([0-9]+\)/TIMESTAMP/g'
 
 # use sed + above regex to create tables within db
-sed -r -e "${REGEX_TIMESTAMP}" ../postgres/create.sql | \
+sed -E -e "${REGEX_TIMESTAMP}" ../postgres/create.sql | \
   duckdb "$OUTFILE"
 
 # goal: get path from find, e.g., ./1.0/icu/d_items

--- a/mimic-iv/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv/buildmimic/duckdb/import_duckdb.sh
@@ -80,9 +80,9 @@ export REGEX_SPEC_TYPE='s/spec_type_desc(.+)NOT NULL/spec_type_desc\1/g'
 export REGEX_DRUG='s/drug +(VARCHAR.+)NOT NULL/drug \1/g'
 
 # use sed + above regex to create tables within db
-sed -r -e "${REGEX_TIMESTAMP}" ../postgres/create.sql | \
-  sed -r -e "${REGEX_SPEC_TYPE}" | \
-  sed -r -e "${REGEX_DRUG}" | \
+sed -E -e "${REGEX_TIMESTAMP}" ../postgres/create.sql | \
+  sed -E -e "${REGEX_SPEC_TYPE}" | \
+  sed -E -e "${REGEX_DRUG}" | \
   duckdb "$OUTFILE"
 
 # goal: get path from find, e.g., ./1.0/icu/d_items


### PR DESCRIPTION
## Summary
- Concept conversion and duckdb import scripts used `sed -r` (GNU-only)
- Switch to `sed -E` (works on GNU and BSD/macOS)

Fixes #868

## Test plan
- [ ] Run convert script on macOS without GNU sed

Made with [Cursor](https://cursor.com)