### PR TITLE
FLOOR postgres DATETIME_DIFF to match BigQuery

### DIFF
--- a/mimic-iii/concepts_postgres/postgres-functions.sql
+++ b/mimic-iii/concepts_postgres/postgres-functions.sql
@@ -71,7 +71,8 @@ LANGUAGE PLPGSQL;
 -- i.e. encapsulate it in single quotes
 CREATE OR REPLACE FUNCTION DATETIME_DIFF(endtime TIMESTAMP(3), starttime TIMESTAMP(3), datepart TEXT) RETURNS NUMERIC AS $$
 BEGIN
-RETURN 
+-- FLOOR to match BigQuery DATETIME_DIFF truncation (#1549).
+RETURN FLOOR(
     EXTRACT(EPOCH FROM endtime - starttime) /
     CASE
         WHEN datepart = 'SECOND' THEN 1.0
@@ -79,7 +80,8 @@ RETURN
         WHEN datepart = 'HOUR' THEN 3600.0
         WHEN datepart = 'DAY' THEN 24*3600.0
         WHEN datepart = 'YEAR' THEN 365.242*24*3600.0
-    ELSE NULL END;
+    ELSE NULL END
+);
 END; $$
 LANGUAGE PLPGSQL;
 

--- a/mimic-iv/concepts_postgres/postgres-functions.sql
+++ b/mimic-iv/concepts_postgres/postgres-functions.sql
@@ -75,7 +75,8 @@ LANGUAGE PLPGSQL;
 -- i.e. encapsulate it in single quotes
 CREATE OR REPLACE FUNCTION DATETIME_DIFF(endtime TIMESTAMP(3), starttime TIMESTAMP(3), datepart TEXT) RETURNS NUMERIC AS $$
 BEGIN
-RETURN 
+-- FLOOR to match BigQuery DATETIME_DIFF truncation (#1549).
+RETURN FLOOR(
     EXTRACT(EPOCH FROM endtime - starttime) /
     CASE
         WHEN datepart = 'SECOND' THEN 1.0
@@ -83,7 +84,8 @@ RETURN
         WHEN datepart = 'HOUR' THEN 3600.0
         WHEN datepart = 'DAY' THEN 24*3600.0
         WHEN datepart = 'YEAR' THEN 365.242*24*3600.0
-    ELSE NULL END;
+    ELSE NULL END
+);
 END; $$
 LANGUAGE PLPGSQL;
 


### PR DESCRIPTION
## Summary
- Postgres `DATETIME_DIFF` returned fractional epochs; BigQuery truncates (#1549)
- Wrap ratio in `FLOOR` in iii/iv `postgres-functions.sql`

## Test plan
- [ ] `DATETIME_DIFF` minute/hour diffs match BQ for same timestamps
- [ ] Existing concept queries still run

Fixes #1549

Made with [Cursor](https://cursor.com)