### PR TITLE
Fix test_vasopressor_units Series.contains AttributeError

### DIFF
--- a/mimic-iv/tests/test_medication.py
+++ b/mimic-iv/tests/test_medication.py
@@ -58,7 +58,7 @@ def test_vasopressor_units(dataset, project_id):
         """
         df = gbq.read_gbq(query, project_id=project_id, dialect="standard")
         # if we find new uninspected rows, raise a warning. this will only happen when mimic-iv is updated.
-        if (~df['hadm_id'].contains(hadm_id_list)).any():
+        if (~df['hadm_id'].isin(hadm_id_list)).any():
             _LOGGER.warn(f"""New data found with non-standard unit. Inspect the data with this query:
 
             select *


### PR DESCRIPTION
## Summary
- `df['hadm_id'].contains(...)` raises AttributeError (pandas Series has no `.contains`)
- Use `.isin`

## Test plan
- [ ] Import/run test_vasopressor_units without AttributeError


Made with [Cursor](https://cursor.com)