### PR TITLE
Fix MIMIC-III KDIGO stage-3 SCr +0.3 criterion

### DIFF
--- a/mimic-iii/concepts/organfailure/kdigo_stages.sql
+++ b/mimic-iii/concepts/organfailure/kdigo_stages.sql
@@ -17,7 +17,7 @@ with cr_stg AS
         -- For patients reaching Stage 3 by SCr >4.0 mg/dl
         -- require that the patient first achieve ... acute increase >= 0.3 within 48 hr
         -- *or* an increase of >= 1.5 times baseline
-        and (cr.creat_low_past_48hr <= 3.7 OR cr.creat >= (1.5*cr.creat_low_past_7day))
+        and (cr.creat >= (cr.creat_low_past_48hr+0.3) OR cr.creat >= (1.5*cr.creat_low_past_7day))
             then 3 
         -- TODO: initiation of RRT
         when cr.creat >= (cr.creat_low_past_7day*2.0) then 2

--- a/mimic-iii/concepts_postgres/organfailure/kdigo_stages.sql
+++ b/mimic-iii/concepts_postgres/organfailure/kdigo_stages.sql
@@ -19,7 +19,7 @@ with cr_stg AS
         -- For patients reaching Stage 3 by SCr >4.0 mg/dl
         -- require that the patient first achieve ... acute increase >= 0.3 within 48 hr
         -- *or* an increase of >= 1.5 times baseline
-        and (cr.creat_low_past_48hr <= 3.7 OR cr.creat >= (1.5*cr.creat_low_past_7day))
+        and (cr.creat >= (cr.creat_low_past_48hr+0.3) OR cr.creat >= (1.5*cr.creat_low_past_7day))
             then 3 
         -- TODO: initiation of RRT
         when cr.creat >= (cr.creat_low_past_7day*2.0) then 2


### PR DESCRIPTION
## Summary
- Stage 3 used `creat_low_past_48hr <= 3.7` instead of an acute `+0.3` rise (IV already correct).

## Test plan
- [ ] Stage-3 branch matches IV / KDIGO wording

Made with [Cursor](https://cursor.com)