### PR TITLE
Fix CXR last_paragraph section_idx off-by-one

### DIFF
--- a/mimic-iv-cxr/txt/section_parser.py
+++ b/mimic-iv-cxr/txt/section_parser.py
@@ -83,7 +83,8 @@ def section_text(text):
             sections.append('\n \n'.join(sections[-1].split('\n \n')[1:]))
             sections[-2] = sections[-2].split('\n \n')[0]
             section_names.append('last_paragraph')
-            section_idx.append(section_idx[-1] + len(sections[-2]))
+            # include the '\n \n' separator between the split parts
+            section_idx.append(section_idx[-1] + len(sections[-2]) + len('\n \n'))
 
     return sections, section_names, section_idx
 


### PR DESCRIPTION
## Summary
- `section_idx` for `last_paragraph` omitted the `\n \n` separator length, so slices did not match section text.

## Test plan
- [ ] `text[section_idx[i]:] == sections[i]` after last_paragraph split

Made with [Cursor](https://cursor.com)