### PR TITLE
Allow convert_file destination_dialect=bigquery

### DIFF
--- a/src/mimic_utils/__main__.py
+++ b/src/mimic_utils/__main__.py
@@ -17,7 +17,7 @@ def main():
     file_parser.add_argument("source_file", help="Source file.")
     file_parser.add_argument("destination_file", help="Destination file.")
     file_parser.add_argument("--source_dialect", choices=["bigquery", "postgres", "duckdb"], default='bigquery', help="SQL dialect to transpile.")
-    file_parser.add_argument("--destination_dialect", choices=["postgres", "duckdb"], default='postgres', help="SQL dialect to transpile.")
+    file_parser.add_argument("--destination_dialect", choices=["bigquery", "postgres", "duckdb"], default='postgres', help="SQL dialect to transpile.")
     file_parser.set_defaults(func=transpile_file)
     
     folder_parser = subparsers.add_parser('convert_folder', help='Transpile all SQL files in a folder.')

--- a/src/mimic_utils/transpile.py
+++ b/src/mimic_utils/transpile.py
@@ -47,10 +47,16 @@ def _strip_catalog(parsed: exp.Expression) -> None:
 
 def transpile_query(query: str, source_dialect: str = "bigquery", destination_dialect: str = "postgres") -> str:
     """Transpile a SQL string from ``source_dialect`` to ``destination_dialect``."""
+    parsed = sqlglot.parse_one(query, read=source_dialect)
+
+    # Identity / BQ target: folder CLI already accepts bigquery; keep catalog.
+    if destination_dialect == "bigquery":
+        sql = parsed.sql(dialect="bigquery", pretty=True, comments=True)
+        return _strip_timezone_types(sql)
+
     if destination_dialect not in _DESTINATION_DIALECTS:
         raise ValueError(f"Unsupported destination dialect: {destination_dialect}")
 
-    parsed = sqlglot.parse_one(query, read=source_dialect)
     _strip_catalog(parsed)
 
     # DuckDB does not accept the default /* ... */ block comment style, so we


### PR DESCRIPTION
## Summary
- `convert_folder` accepted `bigquery`; `convert_file` did not.
- `transpile_query` rejected bigquery destinations.

## Test plan
- [ ] `convert_file ... --destination_dialect=bigquery` succeeds
- [ ] existing postgres/duckdb transpile tests pass

Made with [Cursor](https://cursor.com)