### PR TITLE
fix(mimic-iv): retain device-only rows in oxygen_delivery

### DIFF
--- a/mimic-iv/concepts/measurement/oxygen_delivery.sql
+++ b/mimic-iv/concepts/measurement/oxygen_delivery.sql
@@ -47,6 +47,21 @@ WITH ce_stg1 AS (
     FROM ce_stg1 ce
 )
 
+-- filter rn before joining so device-only rows from the FULL OUTER JOIN
+-- are retained (a post-join WHERE ce.rn = 1 would drop rows where ce is NULL)
+, ce_stg3 AS (
+    SELECT
+        subject_id
+        , stay_id
+        , charttime
+        , itemid
+        , value
+        , valuenum
+        , valueuom
+    FROM ce_stg2
+    WHERE rn = 1
+)
+
 , o2 AS (
     -- The below ITEMID can have multiple entries for charttime/storetime
     -- These are valid entries, and should be retained in derived tables.
@@ -85,12 +100,10 @@ WITH ce_stg1 AS (
         , ce.valuenum
         , o2.o2_device
         , o2.rn
-    FROM ce_stg2 ce
+    FROM ce_stg3 ce
     FULL OUTER JOIN o2
-                    ON ce.subject_id = o2.subject_id
-        AND ce.charttime = o2.charttime
-    -- limit to 1 row per subject_id/charttime/itemid from ce_stg2
-    WHERE ce.rn = 1
+        ON ce.subject_id = o2.subject_id
+            AND ce.charttime = o2.charttime
 )
 
 SELECT

--- a/mimic-iv/concepts_duckdb/measurement/oxygen_delivery.sql
+++ b/mimic-iv/concepts_duckdb/measurement/oxygen_delivery.sql
@@ -24,6 +24,18 @@ WITH ce_stg1 AS (
     valueuom,
     ROW_NUMBER() OVER (PARTITION BY subject_id, charttime, itemid ORDER BY storetime DESC, valuenum DESC) AS rn
   FROM ce_stg1 AS ce
+), ce_stg3 AS (
+  SELECT
+    subject_id,
+    stay_id,
+    charttime,
+    itemid,
+    value,
+    valuenum,
+    valueuom
+  FROM ce_stg2
+  WHERE
+    rn = 1
 ), o2 AS (
   SELECT
     subject_id,
@@ -45,11 +57,9 @@ WITH ce_stg1 AS (
     ce.valuenum,
     o2.o2_device,
     o2.rn
-  FROM ce_stg2 AS ce
+  FROM ce_stg3 AS ce
   FULL OUTER JOIN o2
     ON ce.subject_id = o2.subject_id AND ce.charttime = o2.charttime
-  WHERE
-    ce.rn = 1
 )
 SELECT
   subject_id,

--- a/mimic-iv/concepts_postgres/measurement/oxygen_delivery.sql
+++ b/mimic-iv/concepts_postgres/measurement/oxygen_delivery.sql
@@ -32,8 +32,31 @@ WITH ce_stg1 AS (
       ORDER BY storetime DESC NULLS LAST, valuenum DESC NULLS LAST
     ) AS rn
   FROM ce_stg1 AS ce
+), ce_stg3 /* filter rn before joining so device-only rows from the FULL OUTER JOIN */ /* are retained (a post-join WHERE ce.rn = 1 would drop rows where ce is NULL) */ AS (
+  SELECT
+    subject_id,
+    stay_id,
+    charttime,
+    itemid,
+    value,
+    valuenum,
+    valueuom
+  FROM ce_stg2
+  WHERE
+    rn = 1
 ), o2 AS (
-  /* The below ITEMID can have multiple entries for charttime/storetime */ /* These are valid entries, and should be retained in derived tables. */ /*   224181 -- Small Volume Neb Drug #1       | Respiratory | Text */ /* , 227570 -- Small Volume Neb Drug/Dose #1  | Respiratory | Text */ /* , 224833 -- SBT Deferred                   | Respiratory | Text */ /* , 224716 -- SBT Stopped                    | Respiratory | Text */ /* , 224740 -- RSBI Deferred                  | Respiratory | Text */ /* , 224829 -- Trach Tube Type                | Respiratory | Text */ /* , 226732 -- O2 Delivery Device(s)          | Respiratory | Text */ /* , 226873 -- Inspiratory Ratio              | Respiratory | Numeric */ /* , 226871 -- Expiratory Ratio               | Respiratory | Numeric */ /* maximum of 4 o2 devices on at once */
+  /* The below ITEMID can have multiple entries for charttime/storetime */
+  /* These are valid entries, and should be retained in derived tables. */
+  /*   224181 -- Small Volume Neb Drug #1       | Respiratory | Text */
+  /* , 227570 -- Small Volume Neb Drug/Dose #1  | Respiratory | Text */
+  /* , 224833 -- SBT Deferred                   | Respiratory | Text */
+  /* , 224716 -- SBT Stopped                    | Respiratory | Text */
+  /* , 224740 -- RSBI Deferred                  | Respiratory | Text */
+  /* , 224829 -- Trach Tube Type                | Respiratory | Text */
+  /* , 226732 -- O2 Delivery Device(s)          | Respiratory | Text */
+  /* , 226873 -- Inspiratory Ratio              | Respiratory | Numeric */
+  /* , 226871 -- Expiratory Ratio               | Respiratory | Numeric */
+  /* maximum of 4 o2 devices on at once */
   SELECT
     subject_id,
     stay_id,
@@ -57,12 +80,9 @@ WITH ce_stg1 AS (
     ce.valuenum,
     o2.o2_device,
     o2.rn
-  FROM ce_stg2 AS ce
+  FROM ce_stg3 AS ce
   FULL OUTER JOIN o2
     ON ce.subject_id = o2.subject_id AND ce.charttime = o2.charttime
-  /* limit to 1 row per subject_id/charttime/itemid from ce_stg2 */
-  WHERE
-    ce.rn = 1
 )
 SELECT
   subject_id,


### PR DESCRIPTION
## Summary
- Filter O2 flow `rn` in `ce_stg3` before the FULL OUTER JOIN in `oxygen_delivery.sql`
- Retain device-only charttimes (itemid 226732) that previously disappeared when `WHERE ce.rn = 1` ran after the join
- Regenerate postgres and duckdb dialect copies from the BigQuery source

## Test plan
- [x] `pytest tests/test_transpile.py -k oxygen_delivery` passes locally
- [ ] CI concept build on MIMIC-IV demo

`oxygen_delivery` FULL OUTER JOINs O2 flow (`ce_stg2`) with delivery devices (`o2`, itemid 226732), then applied `WHERE ce.rn = 1`. That filter drops rows where `ce` is NULL, so stays with device charting but no flow (e.g. `stay_id = 30813912` in #1570) never appear in the derived table. Move the `rn = 1` filter into `ce_stg3` before the join so device-only rows are kept. Regenerate postgres and duckdb dialect copies from the BigQuery source.

Fixes #1570