### PR TITLE
fix: load plain .csv files in duckdb import

### DIFF
--- a/mimic-iv/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv/buildmimic/duckdb/import_duckdb.sh
@@ -101,7 +101,7 @@ make_table_name () {
 
 
 # load data into database
-find "$MIMIC_DIR" -type f -name '*.csv???' | sort | while IFS= read -r FILE; do
+find "$MIMIC_DIR" -type f \( -name '*.csv' -o -name '*.csv.gz' \) | sort | while IFS= read -r FILE; do
     make_table_name "$FILE"
 
     # skip directories which we do not expect in mimic-iv


### PR DESCRIPTION
## Summary
- `find … -name '*.csv???'` only matched `.csv.gz`
- also match plain `.csv` as the duckdb readme describes

## Test plan
- [ ] dir with `hosp/*.csv` loads
- [ ] dir with `hosp/*.csv.gz` still loads
