### PR TITLE
fix: quote sqlite import.sh paths for spaces

### DIFF
--- a/mimic-iii/buildmimic/sqlite/import.sh
+++ b/mimic-iii/buildmimic/sqlite/import.sh
@@ -28,11 +28,11 @@ for FILE in *; do
     TABLE_NAME=$(echo "${FILE%%.*}" | tr "[:upper:]" "[:lower:]")
     case "$FILE" in
         *csv)
-            IMPORT_CMD=".import $FILE $TABLE_NAME"
+            IMPORT_CMD=".import \"$FILE\" $TABLE_NAME"
         ;;
         # need to decompress csv before load
         *csv.gz)
-            IMPORT_CMD=".import \"|gzip -dc $FILE\" $TABLE_NAME"
+            IMPORT_CMD=".import \"|gzip -dc \\\"$FILE\\\"\" $TABLE_NAME"
         ;;
         # not a data file so skip
         *)
@@ -40,7 +40,7 @@ for FILE in *; do
         ;;
     esac
     echo "Loading $FILE."
-    sqlite3 $OUTFILE <<EOF
+    sqlite3 "$OUTFILE" <<EOF
 .headers on
 .mode csv
 $IMPORT_CMD

--- a/mimic-iv/buildmimic/sqlite/import.sh
+++ b/mimic-iv/buildmimic/sqlite/import.sh
@@ -29,11 +29,11 @@ for FILE in */**.csv*; do
       TABLE_NAME=$(echo "${BASENAME%%.*}" | tr "[:upper:]" "[:lower:]")
       case "$FILE" in
           *csv)
-              IMPORT_CMD=".import $FILE $TABLE_NAME"
+              IMPORT_CMD=".import \"$FILE\" $TABLE_NAME"
           ;;
           # need to decompress csv before load
           *csv.gz)
-              IMPORT_CMD=".import \"|gzip -dc $FILE\" $TABLE_NAME"
+              IMPORT_CMD=".import \"|gzip -dc \\\"$FILE\\\"\" $TABLE_NAME"
           ;;
           # not a data file so skip
           *)
@@ -41,7 +41,7 @@ for FILE in */**.csv*; do
           ;;
       esac
       echo "Loading $FILE."
-      sqlite3 $OUTFILE <<EOF
+      sqlite3 "$OUTFILE" <<EOF
 .headers on
 .mode csv
 $IMPORT_CMD


### PR DESCRIPTION
## Summary
- `.import` / `gzip -dc` broke when the csv path had spaces
- quote paths in iii + iv `import.sh`

## Test plan
- [ ] import a csv from a directory with a space in the name
