### PR TITLE
fix: validate demo includes provider/caregiver/ingredientevents

### DIFF
--- a/mimic-iv/buildmimic/mysql/validate_demo.sql
+++ b/mimic-iv/buildmimic/mysql/validate_demo.sql
@@ -31,14 +31,17 @@ FROM (
     SELECT 'poe_detail' AS tbl, 3795 AS row_count UNION ALL
     SELECT 'prescriptions' AS tbl, 18087 AS row_count UNION ALL
     SELECT 'procedures_icd' AS tbl, 722 AS row_count UNION ALL
+    SELECT 'provider' AS tbl, 40508 AS row_count UNION ALL
     SELECT 'services' AS tbl, 319 AS row_count UNION ALL
     SELECT 'transfers' AS tbl, 1190 AS row_count UNION ALL
     -- icu data
     SELECT 'icustays' AS tbl, 140 AS row_count UNION ALL
+    SELECT 'caregiver' AS tbl, 15468 AS row_count UNION ALL
     SELECT 'd_items' AS tbl, 4014 AS row_count UNION ALL
     SELECT 'chartevents' AS tbl, 668862 AS row_count UNION ALL
     SELECT 'datetimeevents' AS tbl, 15280 AS row_count UNION ALL
     SELECT 'inputevents' AS tbl, 20404 AS row_count UNION ALL
+    SELECT 'ingredientevents' AS tbl, 25728 AS row_count UNION ALL
     SELECT 'outputevents' AS tbl, 9362 AS row_count UNION ALL
     SELECT 'procedureevents' AS tbl, 1468 AS row_count
 ) exp
@@ -64,14 +67,17 @@ INNER JOIN
     SELECT 'poe_detail' AS tbl, count(*) AS row_count FROM poe_detail UNION ALL
     SELECT 'prescriptions' AS tbl, count(*) AS row_count FROM prescriptions UNION ALL
     SELECT 'procedures_icd' AS tbl, count(*) AS row_count FROM procedures_icd UNION ALL
+    SELECT 'provider' AS tbl, count(*) AS row_count FROM provider UNION ALL
     SELECT 'services' AS tbl, count(*) AS row_count FROM services UNION ALL
     SELECT 'transfers' AS tbl, count(*) AS row_count FROM transfers UNION ALL
     -- icu data
     SELECT 'icustays' AS tbl, count(*) AS row_count FROM icustays UNION ALL
+    SELECT 'caregiver' AS tbl, count(*) AS row_count FROM caregiver UNION ALL
     SELECT 'chartevents' AS tbl, count(*) AS row_count FROM chartevents UNION ALL
     SELECT 'd_items' AS tbl, count(*) AS row_count FROM d_items UNION ALL
     SELECT 'datetimeevents' AS tbl, count(*) AS row_count FROM datetimeevents UNION ALL
     SELECT 'inputevents' AS tbl, count(*) AS row_count FROM inputevents UNION ALL
+    SELECT 'ingredientevents' AS tbl, count(*) AS row_count FROM ingredientevents UNION ALL
     SELECT 'outputevents' AS tbl, count(*) AS row_count FROM outputevents UNION ALL
     SELECT 'procedureevents' AS tbl, count(*) AS row_count FROM procedureevents
 ) obs

--- a/mimic-iv/buildmimic/postgres/load_7z.sql
+++ b/mimic-iv/buildmimic/postgres/load_7z.sql
@@ -6,7 +6,7 @@
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
 \cd :mimic_data_dir
 
--- making sure that all tables are emtpy and correct encoding is defined -utf8- 
+-- making sure that all tables are empty and correct encoding is defined -utf8- 
 SET CLIENT_ENCODING TO 'utf8';
 
 -- hosp schema

--- a/mimic-iv/buildmimic/postgres/load_gz.sql
+++ b/mimic-iv/buildmimic/postgres/load_gz.sql
@@ -6,7 +6,7 @@
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
 \cd :mimic_data_dir
 
--- making sure that all tables are emtpy and correct encoding is defined -utf8- 
+-- making sure that all tables are empty and correct encoding is defined -utf8- 
 SET CLIENT_ENCODING TO 'utf8';
 
 -- hosp schema

--- a/mimic-iv/buildmimic/postgres/validate_demo.sql
+++ b/mimic-iv/buildmimic/postgres/validate_demo.sql
@@ -22,14 +22,17 @@ WITH expected AS
     SELECT 'poe_detail' AS tbl, 3795 AS row_count UNION ALL
     SELECT 'prescriptions' AS tbl, 18087 AS row_count UNION ALL
     SELECT 'procedures_icd' AS tbl, 722 AS row_count UNION ALL
+    SELECT 'provider' AS tbl, 40508 AS row_count UNION ALL
     SELECT 'services' AS tbl, 319 AS row_count UNION ALL
     SELECT 'transfers' AS tbl, 1190 AS row_count UNION ALL
     -- icu data
     SELECT 'icustays' AS tbl, 140 AS row_count UNION ALL
+    SELECT 'caregiver' AS tbl, 15468 AS row_count UNION ALL
     SELECT 'd_items' AS tbl, 4014 AS row_count UNION ALL
     SELECT 'chartevents' AS tbl, 668862 AS row_count UNION ALL
     SELECT 'datetimeevents' AS tbl, 15280 AS row_count UNION ALL
     SELECT 'inputevents' AS tbl, 20404 AS row_count UNION ALL
+    SELECT 'ingredientevents' AS tbl, 25728 AS row_count UNION ALL
     SELECT 'outputevents' AS tbl, 9362 AS row_count UNION ALL
     SELECT 'procedureevents' AS tbl, 1468 AS row_count
 )
@@ -54,14 +57,17 @@ WITH expected AS
     SELECT 'poe_detail' AS tbl, count(*) AS row_count FROM mimiciv_hosp.poe_detail UNION ALL
     SELECT 'prescriptions' AS tbl, count(*) AS row_count FROM mimiciv_hosp.prescriptions UNION ALL
     SELECT 'procedures_icd' AS tbl, count(*) AS row_count FROM mimiciv_hosp.procedures_icd UNION ALL
+    SELECT 'provider' AS tbl, count(*) AS row_count FROM mimiciv_hosp.provider UNION ALL
     SELECT 'services' AS tbl, count(*) AS row_count FROM mimiciv_hosp.services UNION ALL
     SELECT 'transfers' AS tbl, count(*) AS row_count FROM mimiciv_hosp.transfers UNION ALL
     -- icu data
     SELECT 'icustays' AS tbl, count(*) AS row_count FROM mimiciv_icu.icustays UNION ALL
+    SELECT 'caregiver' AS tbl, count(*) AS row_count FROM mimiciv_icu.caregiver UNION ALL
     SELECT 'chartevents' AS tbl, count(*) AS row_count FROM mimiciv_icu.chartevents UNION ALL
     SELECT 'd_items' AS tbl, count(*) AS row_count FROM mimiciv_icu.d_items UNION ALL
     SELECT 'datetimeevents' AS tbl, count(*) AS row_count FROM mimiciv_icu.datetimeevents UNION ALL
     SELECT 'inputevents' AS tbl, count(*) AS row_count FROM mimiciv_icu.inputevents UNION ALL
+    SELECT 'ingredientevents' AS tbl, count(*) AS row_count FROM mimiciv_icu.ingredientevents UNION ALL
     SELECT 'outputevents' AS tbl, count(*) AS row_count FROM mimiciv_icu.outputevents UNION ALL
     SELECT 'procedureevents' AS tbl, count(*) AS row_count FROM mimiciv_icu.procedureevents
 )


### PR DESCRIPTION
## Summary
- demo validate scripts skipped provider, caregiver, and ingredientevents
- counts from mimic-iv-demo 2.2 csvs
- also typo: emtpy → empty in load comments

## Test plan
- [ ] run validate_demo.sql against a demo load; new tables PASSED
