### PR TITLE
fix: use DATETIME_DIFF in neuroblock_dose for BigQuery

### DIFF
--- a/mimic-iii/concepts/durations/neuroblock_dose.sql
+++ b/mimic-iii/concepts/durations/neuroblock_dose.sql
@@ -179,7 +179,11 @@ select
           )
           = 1 then 1
 
-        when (CHARTTIME - (LAG(CHARTTIME, 1) OVER (partition by icustay_id, drug order by charttime))) > (interval '8 hours') then 1
+        when DATETIME_DIFF(
+          CHARTTIME,
+          LAG(CHARTTIME, 1) OVER (partition by icustay_id, drug order by charttime),
+          HOUR
+        ) > 8 then 1
       else null
       end as drug_start
 


### PR DESCRIPTION
## Summary
- BQ concepts still used postgres `interval` subtraction for the 8h gap check
- switch to `DATETIME_DIFF(..., HOUR)` like the other duration scripts

## Test plan
- [ ] BigQuery dry-run of neuroblock_dose.sql
