### PR TITLE
fix: duckdb iii usage comment says mimic3.db

### DIFF
--- a/mimic-iii/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iii/buildmimic/duckdb/import_duckdb.sh
@@ -39,7 +39,7 @@ echo "$0 $* " | grep -Eq " -h | --help " && usage
 
 # rename CLI positional args to more friendly variable names
 MIMIC_DIR=$1
-# allow optional specification of duckdb name, otherwise default to mimic4.db
+# allow optional specification of duckdb name, otherwise default to mimic3.db
 OUTFILE=mimic3.db
 if [ -n "$2" ]; then
     OUTFILE=$2


### PR DESCRIPTION
## Summary
- comment said mimic4.db; default outfile is mimic3.db

## Test plan
- [ ] n/a (comment only)
