### PR TITLE
fix: emtpy -> empty in mimic-iv-note load comments

### DIFF
--- a/mimic-iv-note/buildmimic/postgres/load.sql
+++ b/mimic-iv-note/buildmimic/postgres/load.sql
@@ -6,7 +6,7 @@
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
 \cd :mimic_data_dir
 
--- making sure that all tables are emtpy and correct encoding is defined -utf8- 
+-- making sure that all tables are empty and correct encoding is defined -utf8- 
 SET CLIENT_ENCODING TO 'utf8';
 
 \COPY mimiciv_note.discharge FROM 'discharge.csv' DELIMITER ',' CSV HEADER NULL '';

--- a/mimic-iv-note/buildmimic/postgres/load_7z.sql
+++ b/mimic-iv-note/buildmimic/postgres/load_7z.sql
@@ -6,7 +6,7 @@
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
 \cd :mimic_data_dir
 
--- making sure that all tables are emtpy and correct encoding is defined -utf8- 
+-- making sure that all tables are empty and correct encoding is defined -utf8- 
 SET CLIENT_ENCODING TO 'utf8';
 
 \COPY mimiciv_note.discharge FROM PROGRAM '7z e -so discharge.csv.gz' DELIMITER ',' CSV HEADER NULL '';

--- a/mimic-iv-note/buildmimic/postgres/load_gz.sql
+++ b/mimic-iv-note/buildmimic/postgres/load_gz.sql
@@ -6,7 +6,7 @@
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
 \cd :mimic_data_dir
 
--- making sure that all tables are emtpy and correct encoding is defined -utf8- 
+-- making sure that all tables are empty and correct encoding is defined -utf8- 
 SET CLIENT_ENCODING TO 'utf8';
 
 \COPY mimiciv_note.discharge FROM PROGRAM 'gzip -dc discharge.csv.gz' DELIMITER ',' CSV HEADER NULL '';


### PR DESCRIPTION
## Summary
- same typo as iv load_gz/load_7z, in note postgres load scripts

## Test plan
- [ ] n/a (comment only)
