### PR TITLE
fix: load plain .csv in mimic-iii sqlite import.py

### DIFF
--- a/mimic-iii/buildmimic/sqlite/import.py
+++ b/mimic-iii/buildmimic/sqlite/import.py
@@ -26,9 +26,16 @@ if os.path.exists(DATABASE_NAME):
     print(msg)
     sys.exit()
 
+# Prefer .csv.gz when both exist for the same table; also load plain .csv
+# (import.sh already accepts both).
+files_by_table = {}
+for f in glob("*.csv"):
+    files_by_table[_table_name_from_csv(f)] = f
 for f in glob("*.csv.gz"):
+    files_by_table[_table_name_from_csv(f)] = f
+
+for table, f in sorted(files_by_table.items()):
     print("Starting processing {}".format(f))
-    table = _table_name_from_csv(f)
     if os.path.getsize(f) < THRESHOLD_SIZE:
         df = pd.read_csv(f, index_col="ROW_ID")
         df.to_sql(table, CONNECTION_STRING)


### PR DESCRIPTION
## Summary
- import.py only globbed `*.csv.gz`; plain `.csv` was skipped
- prefer `.csv.gz` when both exist for the same table

## Test plan
- [ ] run import.py with only `.csv` files present
