### PR TITLE
fix: use printf for duckdb load progress (no literal \c)

### DIFF
--- a/mimic-iii/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iii/buildmimic/duckdb/import_duckdb.sh
@@ -84,7 +84,7 @@ make_table_name () {
 # load data into database
 find "$MIMIC_DIR" -type f -regex '.*\.csv\(.gz\)*' | while IFS= read -r FILE; do
     make_table_name "$FILE"
-    echo "Loading $FILE .. \c"
+    printf "Loading %s .. " "$FILE"
     try duckdb "$OUTFILE" <<-EOSQL
 		COPY $TABLE_NAME FROM '$FILE' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"');
 EOSQL

--- a/mimic-iv/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv/buildmimic/duckdb/import_duckdb.sh
@@ -110,7 +110,7 @@ find "$MIMIC_DIR" -type f -name '*.csv???' | sort | while IFS= read -r FILE; do
       (hosp|icu) ;; # OK
       (*) continue;
     esac
-    echo "Loading $FILE .. \c"
+    printf "Loading %s .. " "$FILE"
     OUTPUT=$(duckdb "$OUTFILE" 2>&1 <<-EOSQL
 		COPY $TABLE_NAME FROM '$FILE' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"');
 EOSQL


### PR DESCRIPTION
## Summary
- `echo ... \c` prints a literal `\c` on many shells
- use `printf` so "done!" stays on the same line

## Test plan
- [ ] run duckdb import; progress lines look normal