### PR TITLE
fix: escape password and quote ids in create_mimic_user

### DIFF
--- a/mimic-iii/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iii/buildmimic/duckdb/import_duckdb.sh
@@ -54,7 +54,7 @@ elif [ ! -d "$MIMIC_DIR" ]; then
     yell "Specified directory \"$MIMIC_DIR\" does not exist."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -n "$3" ]; then
-    yell "import_duckdb.sh takes a maximum of two arguments."
+    yell "import.sh takes a maximum of two arguments."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -s "$OUTFILE" ]; then
 	yell "File \"$OUTFILE\" already exists."

--- a/mimic-iii/buildmimic/postgres/create_mimic_user.sh
+++ b/mimic-iii/buildmimic/postgres/create_mimic_user.sh
@@ -20,6 +20,13 @@ else
   echo "User is set to '$MIMIC_USER'";
 fi
 
+# escape ' in password for SQL string literal
+MIMIC_PASSWORD_SQL=$(printf '%s' "$MIMIC_PASSWORD" | sed "s/'/''/g")
+# quote SQL identifiers (double any embedded ")
+sql_ident () { printf '%s' "$1" | sed 's/"/""/g; s/^/"/; s/$/"/'; }
+MIMIC_USER_SQL=$(sql_ident "$MIMIC_USER")
+MIMIC_DB_SQL=$(sql_ident "$MIMIC_DB")
+
 PSQL='psql'
 
 # add in the host/port, if they were specified (not null, -n)
@@ -58,11 +65,11 @@ fi
 if [ "$MIMIC_USER" != "postgres" ]; then
     # we need to create this user via postgres
     # use SUDO to login as postgres
-    $PSQL -U postgres -d postgres -c "DROP USER IF EXISTS $MIMIC_USER; CREATE USER $MIMIC_USER WITH PASSWORD '$MIMIC_PASSWORD';"
+    $PSQL -U postgres -d postgres -c "DROP USER IF EXISTS $MIMIC_USER_SQL; CREATE USER $MIMIC_USER_SQL WITH PASSWORD '$MIMIC_PASSWORD_SQL';"
 fi
 
 if [ "$MIMIC_DB" != "postgres" ]; then
   # drop and recreate the database
-  $PSQL -U postgres -d postgres -c "DROP DATABASE IF EXISTS $MIMIC_DB;"
-  $PSQL -U postgres -d postgres -c "CREATE DATABASE $MIMIC_DB OWNER $MIMIC_USER;"
+  $PSQL -U postgres -d postgres -c "DROP DATABASE IF EXISTS $MIMIC_DB_SQL;"
+  $PSQL -U postgres -d postgres -c "CREATE DATABASE $MIMIC_DB_SQL OWNER $MIMIC_USER_SQL;"
 fi

--- a/mimic-iv-ed/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv-ed/buildmimic/duckdb/import_duckdb.sh
@@ -54,7 +54,7 @@ elif [ ! -d "$MIMIC_DIR" ]; then
     yell "Specified directory \"$MIMIC_DIR\" does not exist."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -n "$3" ]; then
-    yell "import_duckdb.sh takes a maximum of two arguments."
+    yell "import.sh takes a maximum of two arguments."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -s "$OUTFILE" ]; then
   yell "File \"$OUTFILE\" already exists."

--- a/mimic-iv-note/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv-note/buildmimic/duckdb/import_duckdb.sh
@@ -54,7 +54,7 @@ elif [ ! -d "$MIMIC_DIR" ]; then
     yell "Specified directory \"$MIMIC_DIR\" does not exist."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -n "$3" ]; then
-    yell "import_duckdb.sh takes a maximum of two arguments."
+    yell "import.sh takes a maximum of two arguments."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -s "$OUTFILE" ]; then
   yell "File \"$OUTFILE\" already exists."

--- a/mimic-iv/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv/buildmimic/duckdb/import_duckdb.sh
@@ -54,7 +54,7 @@ elif [ ! -d "$MIMIC_DIR" ]; then
     yell "Specified directory \"$MIMIC_DIR\" does not exist."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -n "$3" ]; then
-    yell "import_duckdb.sh takes a maximum of two arguments."
+    yell "import.sh takes a maximum of two arguments."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -s "$OUTFILE" ]; then
   yell "File \"$OUTFILE\" already exists."


### PR DESCRIPTION
## Summary
- escape `'` in MIMIC_PASSWORD for the SQL string literal
- quote MIMIC_USER / MIMIC_DB as postgres identifiers

## Test plan
- [ ] MIMIC_PASSWORD=\"a'b\" succeeds
- [ ] MIMIC_USER with hyphen/odd chars creates cleanly