### PR TITLE
fix: escape quotes in duckdb COPY file paths

### DIFF
--- a/mimic-iii/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iii/buildmimic/duckdb/import_duckdb.sh
@@ -84,9 +84,11 @@ make_table_name () {
 # load data into database
 find "$MIMIC_DIR" -type f -regex '.*\.csv\(.gz\)*' | while IFS= read -r FILE; do
     make_table_name "$FILE"
+    # escape single quotes for SQL string literal
+    FILE_SQL=${FILE//\'/\'\'}
     echo "Loading $FILE .. \c"
     try duckdb "$OUTFILE" <<-EOSQL
-		COPY $TABLE_NAME FROM '$FILE' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"');
+		COPY $TABLE_NAME FROM '$FILE_SQL' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"');
 EOSQL
     echo "done!"
 done && echo "Successfully finished loading data into $OUTFILE."

--- a/mimic-iv-ed/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv-ed/buildmimic/duckdb/import_duckdb.sh
@@ -95,6 +95,8 @@ make_table_name () {
 # load data into database
 find "$MIMIC_DIR" -type f -name '*.csv???' | sort | while IFS= read -r FILE; do
     make_table_name "$FILE"
+    # escape single quotes for SQL string literal
+    FILE_SQL=${FILE//\'/\'\'}
 
     # skip directories which we do not expect in mimic-iv-ed
     # avoids syntax errors if mimic-iv in the same dir
@@ -104,7 +106,7 @@ find "$MIMIC_DIR" -type f -name '*.csv???' | sort | while IFS= read -r FILE; do
     esac
     echo "Loading $FILE .. "
     try duckdb "$OUTFILE" <<-EOSQL
-		COPY $TABLE_NAME FROM '$FILE' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"');
+		COPY $TABLE_NAME FROM '$FILE_SQL' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"');
 EOSQL
     echo "done!"
 done && echo "Successfully finished loading data into $OUTFILE."

--- a/mimic-iv-note/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv-note/buildmimic/duckdb/import_duckdb.sh
@@ -98,6 +98,8 @@ make_table_name () {
 # load data into database
 find "$MIMIC_DIR" -type f -name '*.csv???' | sort | while IFS= read -r FILE; do
     make_table_name "$FILE"
+    # escape single quotes for SQL string literal
+    FILE_SQL=${FILE//\'/\'\'}
 
     # skip directories which we do not expect in mimic-iv-note
     # avoids syntax errors if mimic-iv in the same dir
@@ -107,7 +109,7 @@ find "$MIMIC_DIR" -type f -name '*.csv???' | sort | while IFS= read -r FILE; do
     esac
     echo "Loading $FILE .."
     OUTPUT=$(duckdb "$OUTFILE" 2>&1 <<-EOSQL
-		COPY $TABLE_NAME FROM '$FILE' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"');
+		COPY $TABLE_NAME FROM '$FILE_SQL' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"');
 EOSQL
     )
     # If the table is missing in the DB, we emit a warning and continue.

--- a/mimic-iv/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv/buildmimic/duckdb/import_duckdb.sh
@@ -103,6 +103,8 @@ make_table_name () {
 # load data into database
 find "$MIMIC_DIR" -type f -name '*.csv???' | sort | while IFS= read -r FILE; do
     make_table_name "$FILE"
+    # escape single quotes for SQL string literal
+    FILE_SQL=${FILE//\'/\'\'}
 
     # skip directories which we do not expect in mimic-iv
     # avoids syntax errors if mimic-iv-ed in the same dir
@@ -112,7 +114,7 @@ find "$MIMIC_DIR" -type f -name '*.csv???' | sort | while IFS= read -r FILE; do
     esac
     echo "Loading $FILE .. \c"
     OUTPUT=$(duckdb "$OUTFILE" 2>&1 <<-EOSQL
-		COPY $TABLE_NAME FROM '$FILE' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"');
+		COPY $TABLE_NAME FROM '$FILE_SQL' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"');
 EOSQL
     )
     # If the table is missing in the DB, we emit a warning and continue.


### PR DESCRIPTION
## Summary
- paths with `'` broke the COPY ... FROM '...' string
- escape by doubling quotes (iii/iv/ed/note)

## Test plan
- [ ] duckdb import with a quoted path segment succeeds