### PR TITLE
fix: quote DIRNAME in duckdb import case

### DIFF
--- a/mimic-iv-ed/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv-ed/buildmimic/duckdb/import_duckdb.sh
@@ -98,7 +98,7 @@ find "$MIMIC_DIR" -type f -name '*.csv???' | sort | while IFS= read -r FILE; do
 
     # skip directories which we do not expect in mimic-iv-ed
     # avoids syntax errors if mimic-iv in the same dir
-    case $DIRNAME in
+    case "$DIRNAME" in
       (ed) ;; # OK
       (*) continue;
     esac

--- a/mimic-iv-note/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv-note/buildmimic/duckdb/import_duckdb.sh
@@ -101,7 +101,7 @@ find "$MIMIC_DIR" -type f -name '*.csv???' | sort | while IFS= read -r FILE; do
 
     # skip directories which we do not expect in mimic-iv-note
     # avoids syntax errors if mimic-iv in the same dir
-    case $DIRNAME in
+    case "$DIRNAME" in
       (note) ;; # OK
       (*) continue;
     esac

--- a/mimic-iv/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv/buildmimic/duckdb/import_duckdb.sh
@@ -106,7 +106,7 @@ find "$MIMIC_DIR" -type f -name '*.csv???' | sort | while IFS= read -r FILE; do
 
     # skip directories which we do not expect in mimic-iv
     # avoids syntax errors if mimic-iv-ed in the same dir
-    case $DIRNAME in
+    case "$DIRNAME" in
       (hosp|icu) ;; # OK
       (*) continue;
     esac


### PR DESCRIPTION
## Summary
- unquoted `case $DIRNAME` breaks when the folder name has spaces
- quote it in iv/ed/note duckdb import scripts

## Test plan
- [ ] import with a datadir whose leaf folder has a space