### PR TITLE
fix: emtpy -> empty in mimic-iv postgres load comments

### DIFF
--- a/mimic-iv/buildmimic/postgres/load_7z.sql
+++ b/mimic-iv/buildmimic/postgres/load_7z.sql
@@ -6,7 +6,7 @@
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
 \cd :mimic_data_dir
 
--- making sure that all tables are emtpy and correct encoding is defined -utf8- 
+-- making sure that all tables are empty and correct encoding is defined -utf8- 
 SET CLIENT_ENCODING TO 'utf8';
 
 -- hosp schema

--- a/mimic-iv/buildmimic/postgres/load_gz.sql
+++ b/mimic-iv/buildmimic/postgres/load_gz.sql
@@ -6,7 +6,7 @@
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
 \cd :mimic_data_dir
 
--- making sure that all tables are emtpy and correct encoding is defined -utf8- 
+-- making sure that all tables are empty and correct encoding is defined -utf8- 
 SET CLIENT_ENCODING TO 'utf8';
 
 -- hosp schema


### PR DESCRIPTION
## Summary
- fix typo in load_gz.sql / load_7z.sql comments

## Test plan
- [ ] comments only; no runtime change