### PR TITLE
fix: use globs and quote paths in cxr label scripts

### DIFF
--- a/mimic-iv-cxr/txt/chexpert/run_chexpert_on_files.sh
+++ b/mimic-iv-cxr/txt/chexpert/run_chexpert_on_files.sh
@@ -22,11 +22,20 @@ fi
 sleep 2
 
 # loop through each .csv file in the section folder
-for fn in `ls $REPORT_PATH`; do
-    echo `date`: $fn
-    fn_stem=`echo $fn | cut -d. -f 1`
+for fn_path in "$REPORT_PATH"/*.csv; do
+    [ -f "$fn_path" ] || continue
+    fn=$(basename "$fn_path")
+    echo "$(date): $fn"
+    fn_stem=${fn%.csv}
     # run chexpert - must be run from chexpert folder
-    python $CHEXPERT_PATH/label.py  --verbose --reports_path $REPORT_PATH/$fn --output_path ${fn_stem}_labeled.csv --mention_phrases_dir $CHEXPERT_PATH/phrases/mention --unmention_phrases_dir $CHEXPERT_PATH/phrases/unmention --pre_negation_uncertainty_path $CHEXPERT_PATH/patterns/pre_negation_uncertainty.txt --negation_path $CHEXPERT_PATH/patterns/negation.txt --post_negation_uncertainty_path $CHEXPERT_PATH/patterns/post_negation_uncertainty.txt
-    echo `date`: done!
+    python "$CHEXPERT_PATH/label.py" --verbose \
+      --reports_path "$fn_path" \
+      --output_path "${fn_stem}_labeled.csv" \
+      --mention_phrases_dir "$CHEXPERT_PATH/phrases/mention" \
+      --unmention_phrases_dir "$CHEXPERT_PATH/phrases/unmention" \
+      --pre_negation_uncertainty_path "$CHEXPERT_PATH/patterns/pre_negation_uncertainty.txt" \
+      --negation_path "$CHEXPERT_PATH/patterns/negation.txt" \
+      --post_negation_uncertainty_path "$CHEXPERT_PATH/patterns/post_negation_uncertainty.txt"
+    echo "$(date): done!"
     echo ''
 done

--- a/mimic-iv-cxr/txt/negbio/run_negbio.sh
+++ b/mimic-iv-cxr/txt/negbio/run_negbio.sh
@@ -46,7 +46,7 @@ do
     # all intermediate files will be saved in this folder
     export OUTPUT_DIR=${INPUT_FILE::-4}
 
-    echo $OUTPUT_DIR - running NegBio..
+    echo "$OUTPUT_DIR - running NegBio.."
     python "$NEGBIO_PATH/negbio/negbio_csv2bioc.py" --output "$OUTPUT_DIR/report" "$INPUT_FILE"
     python $NEGBIO_PATH/negbio/negbio_pipeline.py section_split --pattern $NEGBIO_PATH/patterns/section_titles_cxr8.txt --output $OUTPUT_DIR/sections $OUTPUT_DIR/report/* --workers=6
     python $NEGBIO_PATH/negbio/negbio_pipeline.py ssplit --output $OUTPUT_DIR/ssplit $OUTPUT_DIR/sections/* --workers=6
@@ -57,7 +57,7 @@ do
 
     # ultimate filename we save the labels to
     export OUTPUT_LABELS=$OUTPUT_DIR/${fn::-4}_labels.csv
-    python $NEGBIO_PATH/negbio/ext/chexpert_collect_labels.py --phrases_file $NEGBIO_PATH/patterns/chexpert_phrases.yml --output $OUTPUT_LABELS $OUTPUT_DIR/neg/*
+    python "$NEGBIO_PATH/negbio/ext/chexpert_collect_labels.py" --phrases_file "$NEGBIO_PATH/patterns/chexpert_phrases.yml" --output "$OUTPUT_LABELS" "$OUTPUT_DIR"/neg/*
   fi
 done
 echo "Done looping through files."

--- a/mimic-iv-cxr/txt/negbio/run_negbio.sh
+++ b/mimic-iv-cxr/txt/negbio/run_negbio.sh
@@ -32,20 +32,22 @@ sleep 2
 #  mimic_cxr_001.csv
 #  mimic_cxr_002.csv
 # .. etc
-for fn in `ls $BASE_FOLDER`;
+for fn_path in "$BASE_FOLDER"/mimic_cxr_*.csv;
 do
+  [ -f "$fn_path" ] || continue
+  fn=$(basename "$fn_path")
   echo "Looping through files with mimic_cxr_###.csv pattern."
   # validate it's a mimic_cxr sections file
   if [[ $fn =~ ^mimic_cxr_[0-9]+.csv$ ]];
   then
-    export INPUT_FILE=${BASE_FOLDER}/$fn
+    export INPUT_FILE=$fn_path
     # remove extension from filename
     # sets the folder location to stem of original filename
     # all intermediate files will be saved in this folder
     export OUTPUT_DIR=${INPUT_FILE::-4}
 
     echo $OUTPUT_DIR - running NegBio..
-    python $NEGBIO_PATH/negbio/negbio_csv2bioc.py --output $OUTPUT_DIR/report $INPUT_FILE
+    python "$NEGBIO_PATH/negbio/negbio_csv2bioc.py" --output "$OUTPUT_DIR/report" "$INPUT_FILE"
     python $NEGBIO_PATH/negbio/negbio_pipeline.py section_split --pattern $NEGBIO_PATH/patterns/section_titles_cxr8.txt --output $OUTPUT_DIR/sections $OUTPUT_DIR/report/* --workers=6
     python $NEGBIO_PATH/negbio/negbio_pipeline.py ssplit --output $OUTPUT_DIR/ssplit $OUTPUT_DIR/sections/* --workers=6
     python $NEGBIO_PATH/negbio/negbio_pipeline.py parse --output $OUTPUT_DIR/parse $OUTPUT_DIR/ssplit/* --workers=6


### PR DESCRIPTION
## Summary
- replace `ls` loops with globs in negbio/chexpert runners
- quote paths so folders with spaces don't break

## Test plan
- [ ] `bash -n` on both scripts