### PR TITLE
fix: check $1 not pid in copy_concepts script

### DIFF
--- a/mimic-iv/concepts/copy_concepts_to_versioned_schema.sh
+++ b/mimic-iv/concepts/copy_concepts_to_versioned_schema.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # This script copies the concepts in the BigQuery table mimiciv_derived to mimiciv_${VERSION}_derived.
-if [ -z "$$1" ]; then
+if [ -z "$1" ]; then
   echo "Usage: $0 <version>"
   exit 1
 fi
 export SOURCE_DATASET=mimiciv_derived
-export TARGET_DATASET=mimiciv_$1_derived
+export TARGET_DATASET="mimiciv_${1}_derived"
 export PROJECT_ID=physionet-data
 
 # check if the target dataset exists
@@ -19,11 +19,11 @@ if bq ls --datasets --project_id ${PROJECT_ID} | grep -q ${TARGET_DATASET}; then
         if [[ "${TABLE:0:2}" == '--' ]]; then
             continue
         fi
-        bq rm -f -q ${PROJECT_ID}:${TARGET_DATASET}.${TABLE}
+        bq rm -f -q "${PROJECT_ID}:${TARGET_DATASET}.${TABLE}"
     done
 else
     echo "Creating dataset ${PROJECT_ID}:${TARGET_DATASET}"
-    bq mk --dataset ${PROJECT_ID}:${TARGET_DATASET}
+    bq mk --dataset "${PROJECT_ID}:${TARGET_DATASET}"
 fi
 
 echo "Copying tables from ${SOURCE_DATASET} to ${TARGET_DATASET}."
@@ -33,5 +33,5 @@ do
     if [[ "${TABLE:0:2}" == '--' ]]; then
       continue
     fi
-    bq cp -f -q ${PROJECT_ID}:${SOURCE_DATASET}.${TABLE} ${PROJECT_ID}:${TARGET_DATASET}.${TABLE}
+    bq cp -f -q "${PROJECT_ID}:${SOURCE_DATASET}.${TABLE}" "${PROJECT_ID}:${TARGET_DATASET}.${TABLE}"
 done


### PR DESCRIPTION
## Summary
- `$$1` was the shell pid, so the usage check never fired
- quote bq dataset/table args

## Test plan
- [ ] `bash -n mimic-iv/concepts/copy_concepts_to_versioned_schema.sh`
- [ ] running with no args prints usage and exits 1