### PR TITLE
fix: duckdb error text cites import_duckdb.sh

### DIFF
--- a/mimic-iii/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iii/buildmimic/duckdb/import_duckdb.sh
@@ -54,7 +54,7 @@ elif [ ! -d "$MIMIC_DIR" ]; then
     yell "Specified directory \"$MIMIC_DIR\" does not exist."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -n "$3" ]; then
-    yell "import.sh takes a maximum of two arguments."
+    yell "import_duckdb.sh takes a maximum of two arguments."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -s "$OUTFILE" ]; then
 	yell "File \"$OUTFILE\" already exists."

--- a/mimic-iv-ed/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv-ed/buildmimic/duckdb/import_duckdb.sh
@@ -54,7 +54,7 @@ elif [ ! -d "$MIMIC_DIR" ]; then
     yell "Specified directory \"$MIMIC_DIR\" does not exist."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -n "$3" ]; then
-    yell "import.sh takes a maximum of two arguments."
+    yell "import_duckdb.sh takes a maximum of two arguments."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -s "$OUTFILE" ]; then
   yell "File \"$OUTFILE\" already exists."

--- a/mimic-iv-note/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv-note/buildmimic/duckdb/import_duckdb.sh
@@ -54,7 +54,7 @@ elif [ ! -d "$MIMIC_DIR" ]; then
     yell "Specified directory \"$MIMIC_DIR\" does not exist."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -n "$3" ]; then
-    yell "import.sh takes a maximum of two arguments."
+    yell "import_duckdb.sh takes a maximum of two arguments."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -s "$OUTFILE" ]; then
   yell "File \"$OUTFILE\" already exists."

--- a/mimic-iv/buildmimic/duckdb/import_duckdb.sh
+++ b/mimic-iv/buildmimic/duckdb/import_duckdb.sh
@@ -54,7 +54,7 @@ elif [ ! -d "$MIMIC_DIR" ]; then
     yell "Specified directory \"$MIMIC_DIR\" does not exist."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -n "$3" ]; then
-    yell "import.sh takes a maximum of two arguments."
+    yell "import_duckdb.sh takes a maximum of two arguments."
     die "Usage: ./import_duckdb.sh mimic_data_dir [output_db]"
 elif [ -s "$OUTFILE" ]; then
   yell "File \"$OUTFILE\" already exists."


### PR DESCRIPTION
## Summary
- error text said `import.sh` instead of `import_duckdb.sh` in iii/iv/ed/note duckdb importers

## Test plan
- [ ] `bash -n` on the four import_duckdb.sh scripts