### PR TITLE
fix(mimic-iv-note): remove doubled https in duckdb download link

### DIFF
--- a/mimic-iv-note/buildmimic/duckdb/README.md
+++ b/mimic-iv-note/buildmimic/duckdb/README.md
@@ -29,7 +29,7 @@ or [Cygwin](https://www.cygwin.com/).
 ### Quick overview
 
 1. [Install](https://duckdb.org/docs/installation/) the CLI version of DuckDB
-2. [Download](https://https://physionet.org/content/mimic-iv-note/2.2/) the MIMIC-IV-NOTE files
+2. [Download](https://physionet.org/content/mimic-iv-note/2.2/) the MIMIC-IV-NOTE files
 3. Create DuckDB database and load data
 
 ### Install DuckDB


### PR DESCRIPTION
## Summary
- Remove doubled `https://https://` from the PhysioNet download link

## Test plan
- [ ] Link opens physionet.org/content/mimic-iv-note/2.2/

The MIMIC-IV-Note duckdb README linked `https://https://physionet.org/...`, which browsers reject. Drop the extra scheme prefix.