### PR TITLE
docs(duckdb): fix broken why_duckdb documentation links

### DIFF
--- a/mimic-iii/buildmimic/duckdb/README.md
+++ b/mimic-iii/buildmimic/duckdb/README.md
@@ -10,7 +10,7 @@ Unlike SQLite, an OLTP database,
 DuckDB is an OLAP database, and therefore optimized for analytical queries.
 This will result in faster queries for researchers using MIMIC-III
 with DuckDB compared to SQLite.
-To learn more, please read their ["why duckdb"](https://duckdb.org/docs/why_duckdb)
+To learn more, please read their ["why duckdb"](https://duckdb.org/why_duckdb)
 page.
 
 ## Download MIMIC-III files

--- a/mimic-iv-ed/buildmimic/duckdb/README.md
+++ b/mimic-iv-ed/buildmimic/duckdb/README.md
@@ -9,7 +9,7 @@ Unlike SQLite, an OLTP database,
 DuckDB is an OLAP database, and therefore optimized for analytical queries.
 This will result in faster queries for researchers using MIMIC-IV-ED
 with DuckDB compared to SQLite.
-To learn more, please read their ["why duckdb"](https://duckdb.org/docs/why_duckdb)
+To learn more, please read their ["why duckdb"](https://duckdb.org/why_duckdb)
 page.
 
 The instructions to load MIMIC-IV-ED into a DuckDB

--- a/mimic-iv-note/buildmimic/duckdb/README.md
+++ b/mimic-iv-note/buildmimic/duckdb/README.md
@@ -9,7 +9,7 @@ Unlike SQLite, an OLTP database,
 DuckDB is an OLAP database, and therefore optimized for analytical queries.
 This will result in faster queries for researchers using MIMIC-IV-NOTE
 with DuckDB compared to SQLite.
-To learn more, please read their ["why duckdb"](https://duckdb.org/docs/why_duckdb)
+To learn more, please read their ["why duckdb"](https://duckdb.org/why_duckdb)
 page.
 
 The instructions to load MIMIC-IV-NOTE into a DuckDB

--- a/mimic-iv/buildmimic/duckdb/README.md
+++ b/mimic-iv/buildmimic/duckdb/README.md
@@ -9,7 +9,7 @@ Unlike SQLite, an OLTP database,
 DuckDB is an OLAP database, and therefore optimized for analytical queries.
 This will result in faster queries for researchers using MIMIC-IV
 with DuckDB compared to SQLite.
-To learn more, please read their ["why duckdb"](https://duckdb.org/docs/why_duckdb)
+To learn more, please read their ["why duckdb"](https://duckdb.org/why_duckdb)
 page.
 
 The instructions to load MIMIC-IV into a DuckDB


### PR DESCRIPTION
## Summary
- Point "why duckdb" links at `https://duckdb.org/why_duckdb` in iii/iv/ed/note READMEs

## Test plan
- [ ] Links resolve (no 404)

The old `https://duckdb.org/docs/why_duckdb` URL 404s. Update all four duckdb build READMEs to the current path.
