### PR TITLE
docs(duckdb): fix will one / intructions typos in READMEs

### DIFF
--- a/mimic-iii/buildmimic/duckdb/README.md
+++ b/mimic-iii/buildmimic/duckdb/README.md
@@ -29,7 +29,7 @@ wget -r -N -c -np -nH --cut-dirs=1 --user YOURUSERNAME --ask-password https://ph
 
 Replace `YOURUSERNAME` with your physionet username.
 
-The rest of these intructions assume the CSV files are in the folder structure as follows:
+The rest of these instructions assume the CSV files are in the folder structure as follows:
     
 ```
 mimic_data_dir/

--- a/mimic-iv-ed/buildmimic/duckdb/README.md
+++ b/mimic-iv-ed/buildmimic/duckdb/README.md
@@ -74,7 +74,7 @@ This will make you `mimic_data_dir` be `physionet.org/files/mimic-iv-ed/2.2`.
 The last step requires creating a DuckDB database and
 loading the data into it.
 
-You can do all of this will one shell script, `import_duckdb.sh`,
+You can do all of this with one shell script, `import_duckdb.sh`,
 located in this repository.
 
 See the help for it below:

--- a/mimic-iv-note/buildmimic/duckdb/README.md
+++ b/mimic-iv-note/buildmimic/duckdb/README.md
@@ -74,7 +74,7 @@ This will make you `mimic_data_dir` be `physionet.org/files/mimic-iv-note/2.2`.
 The last step requires creating a DuckDB database and
 loading the data into it.
 
-You can do all of this will one shell script, `import_duckdb.sh`,
+You can do all of this with one shell script, `import_duckdb.sh`,
 located in this repository.
 
 See the help for it below:

--- a/mimic-iv/buildmimic/duckdb/README.md
+++ b/mimic-iv/buildmimic/duckdb/README.md
@@ -78,7 +78,7 @@ This will make you `mimic_data_dir` be `physionet.org/files/mimiciv/2.2`.
 The last step requires creating a DuckDB database and
 loading the data into it.
 
-You can do all of this will one shell script, `import_duckdb.sh`,
+You can do all of this with one shell script, `import_duckdb.sh`,
 located in this repository.
 
 See the help for it below:


### PR DESCRIPTION
## Summary
- `will one` -> `with one` in iv/ed/note duckdb READMEs
- `intructions` -> `instructions` in the iii duckdb README

## Test plan
- [ ] Docs-only wording check

Fix two clear grammar/spelling typos in the duckdb load READMEs.
