### PR TITLE
docs(mimic-iv-cxr): fix broken module and /txt markdown links

### DIFF
--- a/mimic-iv-cxr/README.md
+++ b/mimic-iv-cxr/README.md
@@ -1,5 +1,5 @@
 # MIMIC-CXR
 
-MIMIC-CXR is a publicly available database of chest x-rays with free-text radiology reports. You can read more about the dataset on [the PhysioNet project page](https://mimic.mit.edu//iv/modules/cxr/about/).
+MIMIC-CXR is a publicly available database of chest x-rays with free-text radiology reports. You can read more about the dataset on [the PhysioNet project page](https://mimic.mit.edu/docs/iv/modules/cxr/).
 
 This repository is intended to support use of the data by providing code, documentation, and a central location for discussion (in the form of GitHub issues). Feedback and contributions are always welcome!

--- a/mimic-iv-cxr/txt/README.md
+++ b/mimic-iv-cxr/txt/README.md
@@ -20,8 +20,8 @@ The script can be run (from this folder) as follows:
 
 ## CheXpert
 
-Instructions for generating CheXpert annotations from the reports are available [in the chexpert subfolder](/txt/chexpert).
+Instructions for generating CheXpert annotations from the reports are available [in the chexpert subfolder](/mimic-iv-cxr/txt/chexpert).
 
 ## NegBio
 
-Instructions for generating CheXpert annotations from the reports are available [in the negbio subfolder](/txt/negbio).
+Instructions for generating CheXpert annotations from the reports are available [in the negbio subfolder](/mimic-iv-cxr/txt/negbio).

--- a/mimic-iv-cxr/txt/chexpert/README.md
+++ b/mimic-iv-cxr/txt/chexpert/README.md
@@ -4,7 +4,7 @@ This folder provides code and instructions for running the CheXpert NLP tool on 
 
 ## Requirements
 
-1. Sectioned report CSVs using the create_section_files.py script. See the [txt folder](/txt/) for details.
+1. Sectioned report CSVs using the create_section_files.py script. See the [txt folder](/mimic-iv-cxr/txt/) for details.
     * From this, note the path containing the CSVs, e.g. `/data/mimic-cxr/sections`. This folder should have 22 files, with filenames `mimic_cxr_000.csv`, `mimic_cxr_001.csv`, ...
 2. We use the `conda` manager to create a virtual environment to run the code in. To use `conda`, you will need to install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/) (Miniconda is a light-weight alternative of Anaconda).
 

--- a/mimic-iv-cxr/txt/negbio/README.md
+++ b/mimic-iv-cxr/txt/negbio/README.md
@@ -4,7 +4,7 @@ This folder provides code and instructions for running the NegBio NLP tool on MI
 
 ## Requirements
 
-1. Sectioned report CSVs using the create_section_files.py script. See the [txt folder](/txt/) for details.
+1. Sectioned report CSVs using the create_section_files.py script. See the [txt folder](/mimic-iv-cxr/txt/) for details.
     * From this, note the path containing the CSVs, e.g. `/data/mimic-cxr/sections`. This folder should have 22 files, with filenames `mimic_cxr_000.csv`, `mimic_cxr_001.csv`, ...
 2. We use the `conda` manager to create a virtual environment to run the code in. To use `conda`, you will need to install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Anaconda](https://www.anaconda.com/) (Miniconda is a light-weight alternative of Anaconda).
 


### PR DESCRIPTION
## Summary
- Fix double-slash / wrong CXR about URL on mimic.mit.edu
- Prefix chexpert/negbio `/txt/` links with `/mimic-iv-cxr`

## Test plan
- [ ] CXR about and txt/chexpert/negbio links resolve on GitHub

The CXR README linked `mimic.mit.edu//iv/modules/cxr/about/` (404). Subfolder READMEs linked `/txt/` at the repo root. Point them at `/docs/iv/modules/cxr/` and `/mimic-iv-cxr/txt/...`.
