### PR TITLE
docs: fix DATAETIME, access to, and to be function typos

### DIFF
--- a/mimic-iii/buildmimic/bigquery/README.md
+++ b/mimic-iii/buildmimic/bigquery/README.md
@@ -144,7 +144,7 @@ The information about the columns are compiled from several sources:
 
 Currently all columns are set as NULLABLE as the tables will be used for searching/querying only and users with Viewer role should not be able to modify the tables (ex: insert/delete/update data). However, depending on your environment, you may need to set the mode REQUIRED for the appropriate columns.
 
-We selected the type DATAETIME for all columns with dates and times. However, you could also use TIMESTAMP. As [discussed in the MIMIC-III documentation](https://mimic.physionet.org/mimicdata/time), columns with suffix DATE (ex: CHARTDATE) "will always have 00:00:00 as the hour, minute, and second values. This does not mean it was recorded at midnight: it indicates that we do not have the exact time, only the date". This is also true for other columns such DOB and DOD (patients table).
+We selected the type DATETIME for all columns with dates and times. However, you could also use TIMESTAMP. As [discussed in the MIMIC-III documentation](https://mimic.physionet.org/mimicdata/time), columns with suffix DATE (ex: CHARTDATE) "will always have 00:00:00 as the hour, minute, and second values. This does not mean it was recorded at midnight: it indicates that we do not have the exact time, only the date". This is also true for other columns such DOB and DOD (patients table).
 
 ---
 

--- a/mimic-iii/buildmimic/postgres/README.md
+++ b/mimic-iii/buildmimic/postgres/README.md
@@ -70,7 +70,7 @@ psql:postgres_create_tables.sql:12: ERROR:  syntax error at or near "NOT"
 LINE 1: CREATE SCHEMA IF NOT EXISTS mimiciii;
 ```
 
-The `IF NOT EXISTS` syntax was introduced in PostgreSQL 9.3. Make sure you have the latest PostgreSQL version. While one possible option is to modify the code here to be function under earlier versions, we highly recommend upgrading as most of the code written in this repository uses materialized views (which were introduced in PostgreSQL version 9.4).
+The `IF NOT EXISTS` syntax was introduced in PostgreSQL 9.3. Make sure you have the latest PostgreSQL version. While one possible option is to modify the code here to function under earlier versions, we highly recommend upgrading as most of the code written in this repository uses materialized views (which were introduced in PostgreSQL version 9.4).
 
 ## Peer authentication failed
 

--- a/mimic-iv/buildmimic/bigquery/README.md
+++ b/mimic-iv/buildmimic/bigquery/README.md
@@ -1,6 +1,6 @@
 # Loading MIMIC-IV to BigQuery
 
-**YOU DO NOT NEED TO INSTALL MIMIC-IV YOURSELF!** MIMIC-IV has been loaded onto BigQuery by the LCP, and is available for credentialed researchers to access. If you are credentialed, then you may be granted access MIMIC-IV on BigQuery instantly by following the [cloud configuration tutorial](https://mimic.mit.edu/docs/gettingstarted/cloud/).
+**YOU DO NOT NEED TO INSTALL MIMIC-IV YOURSELF!** MIMIC-IV has been loaded onto BigQuery by the LCP, and is available for credentialed researchers to access. If you are credentialed, then you may be granted access to MIMIC-IV on BigQuery instantly by following the [cloud configuration tutorial](https://mimic.mit.edu/docs/gettingstarted/cloud/).
 
 The following instructions are provided for transparency and were used to create the current copy of MIMIC-IV on BigQuery.
 


### PR DESCRIPTION
## Summary
- III postgres FAQ: `to be function` -> `to function`
- III bigquery README: `DATAETIME` -> `DATETIME`
- IV bigquery README: `access MIMIC-IV` -> `access to MIMIC-IV`

## Test plan
- [ ] Docs-only

Three independent documentation typos in III/IV build READMEs.
