### PR TITLE
fix(mimic-iv-ed): quote postgres mimic_data_dir for paths with spaces

### DIFF
--- a/mimic-iv-ed/buildmimic/postgres/load.sql
+++ b/mimic-iv-ed/buildmimic/postgres/load.sql
@@ -12,7 +12,7 @@
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load.sql
 
 -- Change to the directory containing the data files
-\cd :mimic_data_dir
+\cd :'mimic_data_dir'
 
 -- If running scripts individually, you can set the schema where all tables are created as follows:
 SET search_path TO mimiciv_ed;

--- a/mimic-iv-ed/buildmimic/postgres/load_7z.sql
+++ b/mimic-iv-ed/buildmimic/postgres/load_7z.sql
@@ -12,7 +12,7 @@
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_7z.sql
 
 -- Change to the directory containing the data files
-\cd :mimic_data_dir
+\cd :'mimic_data_dir'
 
 -- If running scripts individually, you can set the schema where all tables are created as follows:
 SET search_path TO mimiciv_ed;

--- a/mimic-iv-ed/buildmimic/postgres/load_gz.sql
+++ b/mimic-iv-ed/buildmimic/postgres/load_gz.sql
@@ -12,7 +12,7 @@
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
 
 -- Change to the directory containing the data files
-\cd :mimic_data_dir
+\cd :'mimic_data_dir'
 
 -- If running scripts individually, you can set the schema where all tables are created as follows:
 SET search_path TO mimiciv_ed;


### PR DESCRIPTION
## Summary
- Use `\cd :''mimic_data_dir''` in ED `load.sql` / `load_gz.sql` / `load_7z.sql`

## Test plan
- [ ] Load with `mimic_data_dir` containing a space succeeds
- [ ] Path without spaces still works

Same space-safe psql quoting as the III datadir fix: unquoted `\cd :mimic_data_dir` splits on spaces. Quote the variable in all three ED load scripts.
