### PR TITLE
fix(mimic-iv): quote mimic_data_dir in uncompressed load.sql

### DIFF
--- a/mimic-iv/buildmimic/postgres/load.sql
+++ b/mimic-iv/buildmimic/postgres/load.sql
@@ -5,7 +5,7 @@
 -- To run from a terminal:
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load.sql
 -- The script assumes the files are in the hosp and icu subfolders of mimic_data_dir
-\cd :mimic_data_dir
+\cd :'mimic_data_dir'
 
 -- making sure correct encoding is defined as -utf8- 
 SET CLIENT_ENCODING TO 'utf8';


### PR DESCRIPTION
## Summary
- Use `\cd :''mimic_data_dir''` in `mimic-iv/.../load.sql`

## Test plan
- [ ] Uncompressed load with a spaced datadir path succeeds

The uncompressed IV `load.sql` still used unquoted `\cd :mimic_data_dir`. Apply the same psql quoted-variable form used for space-safe datadir handling.
