### PR TITLE
docs(mimic-iii): replace retired Travis CI badge with GitHub Actions

### DIFF
--- a/mimic-iii/buildmimic/README.md
+++ b/mimic-iii/buildmimic/README.md
@@ -4,5 +4,5 @@ This directory contains scripts that can be used to create a new instance of the
 
 ## Automated tests (PostgreSQL scripts only)
 
-Pushing to this repository triggers [a simple set of tests](https://github.com/MIT-LCP/mimic-code/tree/main/mimic-iii/tests) to run on [Travis CI](https://travis-ci.org/). The status of the tests is [![Build Status](https://travis-ci.org/MIT-LCP/mimic-code.svg?branch=main)](https://travis-ci.org/MIT-LCP/mimic-code)
+Pushing to this repository triggers [CI workflows](https://github.com/MIT-LCP/mimic-code/actions) (including tests under [mimic-iii/tests](https://github.com/MIT-LCP/mimic-code/tree/main/mimic-iii/tests)).
 


### PR DESCRIPTION
## Summary
- Drop the dead Travis CI badge/link from `mimic-iii/buildmimic/README.md`
- Point readers at GitHub Actions / `mimic-iii/tests`

## Test plan
- [ ] Actions link opens this repo CI
- [ ] No travis-ci.org references remain in that README

Travis CI is retired and the badge 404s. Replace it with a pointer to GitHub Actions.
