### PR TITLE
fix(mimic-iv-note): quote postgres mimic_data_dir for paths with spaces

### DIFF
--- a/mimic-iv-note/buildmimic/postgres/load.sql
+++ b/mimic-iv-note/buildmimic/postgres/load.sql
@@ -4,7 +4,7 @@
 
 -- To run from a terminal:
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
-\cd :mimic_data_dir
+\cd :'mimic_data_dir'
 
 -- making sure that all tables are emtpy and correct encoding is defined -utf8- 
 SET CLIENT_ENCODING TO 'utf8';

--- a/mimic-iv-note/buildmimic/postgres/load_7z.sql
+++ b/mimic-iv-note/buildmimic/postgres/load_7z.sql
@@ -4,7 +4,7 @@
 
 -- To run from a terminal:
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
-\cd :mimic_data_dir
+\cd :'mimic_data_dir'
 
 -- making sure that all tables are emtpy and correct encoding is defined -utf8- 
 SET CLIENT_ENCODING TO 'utf8';

--- a/mimic-iv-note/buildmimic/postgres/load_gz.sql
+++ b/mimic-iv-note/buildmimic/postgres/load_gz.sql
@@ -4,7 +4,7 @@
 
 -- To run from a terminal:
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
-\cd :mimic_data_dir
+\cd :'mimic_data_dir'
 
 -- making sure that all tables are emtpy and correct encoding is defined -utf8- 
 SET CLIENT_ENCODING TO 'utf8';


### PR DESCRIPTION
## Summary
- Use `\cd :''mimic_data_dir''` in note `load.sql` / `load_gz.sql` / `load_7z.sql`

## Test plan
- [ ] Load with a spaced datadir path succeeds
- [ ] Path without spaces still works

Same space-safe psql quoting as III/ED: unquoted `\cd :mimic_data_dir` splits on spaces.
