### PR TITLE
fix(mimic-iv): quote mimic_data_dir in load_gz and load_7z

### DIFF
--- a/mimic-iv/buildmimic/postgres/load_7z.sql
+++ b/mimic-iv/buildmimic/postgres/load_7z.sql
@@ -4,7 +4,7 @@
 
 -- To run from a terminal:
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
-\cd :mimic_data_dir
+\cd :'mimic_data_dir'
 
 -- making sure that all tables are emtpy and correct encoding is defined -utf8- 
 SET CLIENT_ENCODING TO 'utf8';

--- a/mimic-iv/buildmimic/postgres/load_gz.sql
+++ b/mimic-iv/buildmimic/postgres/load_gz.sql
@@ -4,7 +4,7 @@
 
 -- To run from a terminal:
 --  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
-\cd :mimic_data_dir
+\cd :'mimic_data_dir'
 
 -- making sure that all tables are emtpy and correct encoding is defined -utf8- 
 SET CLIENT_ENCODING TO 'utf8';


### PR DESCRIPTION
## Summary
- Use `\cd :''mimic_data_dir''` in `load_gz.sql` and `load_7z.sql`

## Test plan
- [ ] Compressed load with a spaced datadir path succeeds

Companion to the uncompressed `load.sql` quoting fix: gz/7z loaders still used unquoted `\cd :mimic_data_dir`.
