### PR TITLE
fix: correct -f filename in load_7z / note load usage comments

### DIFF
--- a/mimic-iv-note/buildmimic/postgres/load.sql
+++ b/mimic-iv-note/buildmimic/postgres/load.sql
@@ -3,7 +3,7 @@
 ---------------------------------------------
 
 -- To run from a terminal:
---  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
+--  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load.sql
 \cd :mimic_data_dir
 
 -- making sure that all tables are emtpy and correct encoding is defined -utf8- 

--- a/mimic-iv-note/buildmimic/postgres/load_7z.sql
+++ b/mimic-iv-note/buildmimic/postgres/load_7z.sql
@@ -3,7 +3,7 @@
 -----------------------------------------
 
 -- To run from a terminal:
---  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
+--  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_7z.sql
 \cd :mimic_data_dir
 
 -- making sure that all tables are emtpy and correct encoding is defined -utf8- 

--- a/mimic-iv/buildmimic/postgres/load_7z.sql
+++ b/mimic-iv/buildmimic/postgres/load_7z.sql
@@ -3,7 +3,7 @@
 -----------------------------------------
 
 -- To run from a terminal:
---  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_gz.sql
+--  psql "dbname=<DBNAME> user=<USER>" -v mimic_data_dir=<PATH TO DATA DIR> -f load_7z.sql
 \cd :mimic_data_dir
 
 -- making sure that all tables are emtpy and correct encoding is defined -utf8- 


### PR DESCRIPTION
## Summary
- IV/note `load_7z.sql` usage: `-f load_gz.sql` -> `-f load_7z.sql`
- Note `load.sql` usage: `-f load_gz.sql` -> `-f load.sql`

## Test plan
- [ ] Comments only

Usage headers in the 7z (and note uncompressed) load scripts pointed at the wrong `-f` filename.
