### PR TITLE
fix(lods): remove incorrect BUN >= 7.50 renal point

### DIFF
--- a/mimic-iii/concepts/severityscores/lods.sql
+++ b/mimic-iii/concepts/severityscores/lods.sql
@@ -174,7 +174,6 @@ select
       when urineoutput >= 10000.0 then 3
       when creatinine_max >= 1.20 then 1
       when bun_max >= 17.0 then 1
-      when bun_max >= 7.50 then 1
     else 0
   end as renal
 

--- a/mimic-iii/concepts/severityscores/lods.sql
+++ b/mimic-iii/concepts/severityscores/lods.sql
@@ -161,6 +161,8 @@ select
   end as cardiovascular
 
   -- renal
+  -- BUN cutoffs are mg/dL (Le Gall et al., JAMA 1996): 0 if <17, 1 if 17-27,
+  -- 3 if 28-55, 5 if >=56. Do not add mmol/L-style thresholds (e.g. 7.50).
   , case
       when bun_max is null
         or urineoutput is null

--- a/mimic-iii/concepts_duckdb/severityscores/lods.sql
+++ b/mimic-iii/concepts_duckdb/severityscores/lods.sql
@@ -145,8 +145,6 @@ WITH cpap AS (
       THEN 1
       WHEN bun_max >= 17.0
       THEN 1
-      WHEN bun_max >= 7.50
-      THEN 1
       ELSE 0
     END AS renal,
     CASE

--- a/mimic-iii/concepts_postgres/severityscores/lods.sql
+++ b/mimic-iii/concepts_postgres/severityscores/lods.sql
@@ -154,8 +154,6 @@ WITH cpap AS (
       THEN 1
       WHEN bun_max >= 17.0
       THEN 1
-      WHEN bun_max >= 7.50
-      THEN 1
       ELSE 0
     END AS renal, /* pulmonary */
     CASE

--- a/mimic-iii/concepts_postgres/severityscores/lods.sql
+++ b/mimic-iii/concepts_postgres/severityscores/lods.sql
@@ -134,7 +134,7 @@ WITH cpap AS (
       WHEN sysbp_min < 90
       THEN 1
       ELSE 0
-    END AS cardiovascular, /* renal */
+    END AS cardiovascular, /* renal */ /* BUN cutoffs are mg/dL (Le Gall et al., JAMA 1996): 0 if <17, 1 if 17-27, */ /* 3 if 28-55, 5 if >=56. Do not add mmol/L-style thresholds (e.g. 7.50). */
     CASE
       WHEN bun_max IS NULL OR urineoutput IS NULL OR creatinine_max IS NULL
       THEN NULL

--- a/mimic-iv/concepts/score/lods.sql
+++ b/mimic-iv/concepts/score/lods.sql
@@ -168,7 +168,6 @@ WITH cpap AS (
             WHEN urineoutput >= 10000.0 THEN 3
             WHEN creatinine_max >= 1.20 THEN 1
             WHEN bun_max >= 17.0 THEN 1
-            WHEN bun_max >= 7.50 THEN 1
             ELSE 0
         END AS renal
 

--- a/mimic-iv/concepts/score/lods.sql
+++ b/mimic-iv/concepts/score/lods.sql
@@ -155,6 +155,8 @@ WITH cpap AS (
         END AS cardiovascular
 
         -- renal
+        -- BUN cutoffs are mg/dL (Le Gall et al., JAMA 1996): 0 if <17, 1 if 17-27,
+        -- 3 if 28-55, 5 if >=56. Do not add mmol/L-style thresholds (e.g. 7.50).
         , CASE
             WHEN bun_max IS NULL
                 OR urineoutput IS NULL

--- a/mimic-iv/concepts_duckdb/score/lods.sql
+++ b/mimic-iv/concepts_duckdb/score/lods.sql
@@ -148,8 +148,6 @@ WITH cpap AS (
       THEN 1
       WHEN bun_max >= 17.0
       THEN 1
-      WHEN bun_max >= 7.50
-      THEN 1
       ELSE 0
     END AS renal,
     CASE

--- a/mimic-iv/concepts_postgres/score/lods.sql
+++ b/mimic-iv/concepts_postgres/score/lods.sql
@@ -153,8 +153,6 @@ WITH cpap AS (
       THEN 1
       WHEN bun_max >= 17.0
       THEN 1
-      WHEN bun_max >= 7.50
-      THEN 1
       ELSE 0
     END AS renal, /* pulmonary */
     CASE

--- a/mimic-iv/concepts_postgres/score/lods.sql
+++ b/mimic-iv/concepts_postgres/score/lods.sql
@@ -133,7 +133,7 @@ WITH cpap AS (
       WHEN sbp_min < 90
       THEN 1
       ELSE 0
-    END AS cardiovascular, /* renal */
+    END AS cardiovascular, /* renal */ /* BUN cutoffs are mg/dL (Le Gall et al., JAMA 1996): 0 if <17, 1 if 17-27, */ /* 3 if 28-55, 5 if >=56. Do not add mmol/L-style thresholds (e.g. 7.50). */
     CASE
       WHEN bun_max IS NULL OR urineoutput IS NULL OR creatinine_max IS NULL
       THEN NULL


### PR DESCRIPTION
## Summary
- Remove the erroneous `bun_max >= 7.50 THEN 1` branch from MIMIC-III and MIMIC-IV `lods.sql`
- Mirror the deletion in postgres and duckdb dialect copies
- Document intended BUN **mg/dL** cutoffs (17 / 28 / 56) beside the renal `CASE` so a mmol/L-style arm is not reintroduced

## Why
Le Gall et al. (JAMA 1996) score serum urea nitrogen as:
- 0 for BUN < 17 mg/dL
- 1 for 17–27
- 3 for 28–55
- 5 for ≥56

MIMIC stores BUN in mg/dL. The extra `>= 7.50` arm incorrectly awarded renal points for BUN ~7.5–16.9 (and sat under the `>= 17` check in the same `CASE`).

## Test plan
- [x] No `7.50` threshold remains in any `lods.sql`
- [x] Inline comment cites Le Gall mg/dL cutoffs next to renal scoring
- [ ] LODS renal: BUN 10 → 0; BUN 20 → 1; BUN 30 → 3; BUN 60 → 5 (when other renal inputs allow)

Fixes #1065