### PR TITLE
fix(mimic-iv): do not treat CANCELLED cultures as positive

### DIFF
--- a/mimic-iv/concepts/sepsis/suspicion_of_infection.sql
+++ b/mimic-iv/concepts/sepsis/suspicion_of_infection.sql
@@ -30,12 +30,13 @@ WITH ab_tbl AS (
         , CAST(MAX(chartdate) AS DATE) AS chartdate
         , MAX(charttime) AS charttime
         , MAX(spec_type_desc) AS spec_type_desc
-        -- identify negative cultures as NULL organism
-        -- or a specific itemid saying "NEGATIVE"
+        -- non-positive: NULL/empty organism, NEGATIVE (90856),
+        -- or CANCELLED culture (90760) — cancelled is not growth
         , MAX(
             CASE WHEN org_name IS NOT NULL
-                      AND org_itemid != 90856
+                      AND org_itemid NOT IN (90856, 90760)
                       AND org_name != ''
+                      AND org_name != 'CANCELLED'
                 THEN 1 ELSE 0
             END) AS positiveculture
     FROM `physionet-data.mimiciv_hosp.microbiologyevents`

--- a/mimic-iv/concepts_duckdb/sepsis/suspicion_of_infection.sql
+++ b/mimic-iv/concepts_duckdb/sepsis/suspicion_of_infection.sql
@@ -24,7 +24,10 @@ WITH ab_tbl AS (
     MAX(spec_type_desc) AS spec_type_desc,
     MAX(
       CASE
-        WHEN NOT org_name IS NULL AND org_itemid <> 90856 AND org_name <> ''
+        WHEN NOT org_name IS NULL
+        AND NOT org_itemid IN (90856, 90760)
+        AND org_name <> ''
+        AND org_name <> 'CANCELLED'
         THEN 1
         ELSE 0
       END

--- a/mimic-iv/concepts_postgres/sepsis/suspicion_of_infection.sql
+++ b/mimic-iv/concepts_postgres/sepsis/suspicion_of_infection.sql
@@ -22,10 +22,13 @@ WITH ab_tbl AS (
     MAX(hadm_id) AS hadm_id,
     CAST(MAX(chartdate) AS DATE) AS chartdate,
     MAX(charttime) AS charttime,
-    MAX(spec_type_desc) AS spec_type_desc, /* identify negative cultures as NULL organism */ /* or a specific itemid saying "NEGATIVE" */
+    MAX(spec_type_desc) AS spec_type_desc, /* non-positive: NULL/empty, NEGATIVE (90856), CANCELLED (90760) */
     MAX(
       CASE
-        WHEN NOT org_name IS NULL AND org_itemid <> 90856 AND org_name <> ''
+        WHEN NOT org_name IS NULL
+        AND NOT org_itemid IN (90856, 90760)
+        AND org_name <> ''
+        AND org_name <> 'CANCELLED'
         THEN 1
         ELSE 0
       END


### PR DESCRIPTION
﻿## Summary
- Exclude `org_itemid` 90760 (`CANCELLED`) from `positiveculture` in `suspicion_of_infection.sql`
- Also exclude `org_name = 'CANCELLED'`
- Update postgres and duckdb dialect copies

## Test plan
- [x] Source + dialect copies exclude 90760 / CANCELLED
- [ ] Specimen with only CANCELLED → `positive_culture = 0`
- [ ] Specimen with a real organism → `positive_culture = 1`

`positiveculture` treated any non-NULL, non-empty `org_name` as positive except NEGATIVE (`90856`). CANCELLED cultures (`org_itemid` 90760) are not microbial growth, but were counted as positive and could inflate `positive_culture` on the suspicion-of-infection table. Exclude CANCELLED the same way NEGATIVE is excluded.

Fixes #1677
