### PR TITLE
fix(mimic-iii): do not bridge paused vasopressor gaps

### DIFF
--- a/mimic-iii/concepts/durations/vasopressor_durations.sql
+++ b/mimic-iii/concepts/durations/vasopressor_durations.sql
@@ -40,7 +40,7 @@ with io_cv as
 , io_mv as
 (
   select
-    icustay_id, linkorderid, starttime, endtime
+    icustay_id, starttime, endtime
   FROM `physionet-data.mimiciii_clinical.inputevents_mv` io
   -- Subselect the vasopressor ITEMIDs
   where itemid in
@@ -259,15 +259,17 @@ WHERE NOT EXISTS(SELECT * FROM vasocv s2
 GROUP BY s1.icustay_id, s1.starttime
 ORDER BY s1.icustay_id, s1.starttime
 )
--- now we extract the associated data for metavision patients
--- do not need to group by itemid because we group by linkorderid
+-- MetaVision rows: keep each order interval as-is.
+-- Do not collapse by linkorderid: Paused rows often leave multi-hour gaps
+-- before the next row of the same linkorderid (#1808). vasomv_grp still
+-- merges contiguous/overlapping intervals afterward.
 , vasomv as
 (
   select
-    icustay_id, linkorderid
-    , min(starttime) as starttime, max(endtime) as endtime
+    icustay_id
+    , starttime
+    , endtime
   from io_mv
-  group by icustay_id, linkorderid
 )
 , vasomv_grp as
 (

--- a/mimic-iii/concepts_duckdb/durations/vasopressor_durations.sql
+++ b/mimic-iii/concepts_duckdb/durations/vasopressor_durations.sql
@@ -30,7 +30,6 @@ WITH io_cv AS (
 ), io_mv AS (
   SELECT
     icustay_id,
-    linkorderid,
     starttime,
     endtime
   FROM mimiciii.inputevents_mv AS io
@@ -166,13 +165,9 @@ WITH io_cv AS (
 ), vasomv AS (
   SELECT
     icustay_id,
-    linkorderid,
-    MIN(starttime) AS starttime,
-    MAX(endtime) AS endtime
+    starttime,
+    endtime
   FROM io_mv
-  GROUP BY
-    icustay_id,
-    linkorderid
 ), vasomv_grp AS (
   SELECT
     s1.icustay_id,

--- a/mimic-iii/concepts_postgres/durations/vasopressor_durations.sql
+++ b/mimic-iii/concepts_postgres/durations/vasopressor_durations.sql
@@ -31,7 +31,6 @@ WITH io_cv AS (
 ), io_mv /* select only the ITEMIDs from the inputevents_mv table related to vasopressors */ AS (
   SELECT
     icustay_id,
-    linkorderid,
     starttime,
     endtime
   FROM mimiciii.inputevents_mv AS io
@@ -169,16 +168,12 @@ WITH io_cv AS (
   ORDER BY
     s1.icustay_id NULLS FIRST,
     s1.starttime NULLS FIRST
-), vasomv /* now we extract the associated data for metavision patients */ /* do not need to group by itemid because we group by linkorderid */ AS (
+), vasomv /* keep each MetaVision interval; do not bridge Paused gaps via linkorderid (#1808) */ AS (
   SELECT
     icustay_id,
-    linkorderid,
-    MIN(starttime) AS starttime,
-    MAX(endtime) AS endtime
+    starttime,
+    endtime
   FROM io_mv
-  GROUP BY
-    icustay_id,
-    linkorderid
 ), vasomv_grp AS (
   SELECT
     s1.icustay_id,


### PR DESCRIPTION
## Summary
- Stop collapsing MetaVision vasopressor rows with `GROUP BY linkorderid` + `min/max` times
- Keep each `inputevents_mv` row as its own interval; `vasomv_grp` still merges contiguous/overlapping intervals
- Update postgres and duckdb dialect copies
- Document the paused-gap rationale in SQL (BigQuery source + postgres copy cite #1808)

## Why
`vasopressor_durations` grouped MetaVision rows by `linkorderid` and took `min(starttime)` / `max(endtime)`. That is correct when successive rows abut, but after `statusdescription = 'Paused'` there is often a multi-hour gap (example `linkorderid = 8781494`, ~6h; see #1808, median ~1h 11m). Bridging that gap overstates vasopressor exposure.

## Duration threshold / behavior
- **Paused gaps:** leave as separate intervals (do not bridge via `linkorderid`)
- **Contiguous / overlapping:** still merged by `vasomv_grp`

## Test plan
- [x] No `GROUP BY linkorderid` remains in `vasomv`
- [x] SQL comments cite paused-gap / #1808 in BigQuery + postgres (duckdb transpile drops comments)
- [ ] `linkorderid = 8781494` (Paused gap ~6h) yields separate durations, not one bridged interval
- [ ] Contiguous non-paused orders still merge via `vasomv_grp`

Fixes #1808