### PR TITLE
fix: correct pivoted OASIS preiculos score bands

### DIFF
--- a/mimic-iii/concepts/pivot/pivoted_oasis.sql
+++ b/mimic-iii/concepts/pivot/pivoted_oasis.sql
@@ -133,8 +133,8 @@ WITH co_hours AS
         when preiculos <     612 then 5   -- 0 00:10:12
         when preiculos <   17820 then 3   -- 0 04:57:00
         when preiculos <   86400 then 0   -- 1 day
-        when preiculos < 1123680 then 1   -- 12 23:48:00
-        else 2 end as preiculos_score
+        when preiculos < 1123680 then 2   -- 12 23:48:00
+        else 1 end as preiculos_score
     ,  case when age is null then null
         when age < 24 then 0
         when age <= 53 then 3

--- a/mimic-iii/concepts_duckdb/pivot/pivoted_oasis.sql
+++ b/mimic-iii/concepts_duckdb/pivot/pivoted_oasis.sql
@@ -134,8 +134,8 @@ WITH co_hours AS (
       WHEN preiculos < 86400
       THEN 0
       WHEN preiculos < 1123680
-      THEN 1
-      ELSE 2
+      THEN 2
+      ELSE 1
     END AS preiculos_score,
     CASE
       WHEN age IS NULL

--- a/mimic-iii/concepts_postgres/pivot/pivoted_oasis.sql
+++ b/mimic-iii/concepts_postgres/pivot/pivoted_oasis.sql
@@ -137,8 +137,8 @@ WITH co_hours AS (
       WHEN preiculos < 86400
       THEN 0 /* 1 day */
       WHEN preiculos < 1123680
-      THEN 1 /* 12 23:48:00 */
-      ELSE 2
+      THEN 2 /* 12 23:48:00 */
+      ELSE 1
     END AS preiculos_score,
     CASE
       WHEN age IS NULL


### PR DESCRIPTION
## Summary
- `pivoted_oasis` had the last two PreICULoS score arms swapped vs the published OASIS table and vs first-day `oasis.sql` (the latter was fixed in #1587 / #1568).
- Updated BigQuery, Postgres, and DuckDB copies.

## Test plan
- [ ] Diff bands against `severityscores/oasis.sql` (`<18708 → 2`, else `1`) and Johnson et al. OASIS+ table


Made with [Cursor](https://cursor.com)