### PR TITLE
fix: convert SAPS I BUN and glucose cutoffs to mg/dL

### DIFF
--- a/mimic-iii/concepts/severityscores/saps.sql
+++ b/mimic-iii/concepts/severityscores/saps.sql
@@ -195,13 +195,14 @@ select
 
   , case
       when bun_max is null then null
-      when bun_max >= 55.0 then 4
-      when bun_max >= 36.0 then 3
-      when bun_max >= 29.0 then 2
-      when bun_max >= 7.50 then 1
-      when bun_min < 3.5 then 1
-      when  bun_max >= 3.5 and bun_max < 7.5
-        and bun_min >= 3.5 and bun_min < 7.5
+      -- BUN thresholds converted mmol/L → mg/dL (×2.8; PhysioNet Challenge 2012)
+      when bun_max >= 154.0 then 4
+      when bun_max >= 100.8 then 3
+      when bun_max >= 81.2 then 2
+      when bun_max >= 21.0 then 1
+      when bun_min < 9.8 then 1
+      when  bun_max >= 9.8 and bun_max < 21.0
+        and bun_min >= 9.8 and bun_min < 21.0
           then 0
     end as bun_score
 
@@ -231,14 +232,15 @@ select
 
   , case
       when glucose_max is null then null
-      when glucose_max >= 44.5 then 4
-      when glucose_min <   1.6 then 4
-      when glucose_max >= 27.8 then 3
-      when glucose_min <   2.8 then 3
-      when glucose_min <   3.9 then 2
-      when glucose_max >= 14.0 then 1
-      when glucose_max >=  3.9 and glucose_max < 14.0
-       and glucose_min >=  3.9 and glucose_min < 14.0
+      -- glucose thresholds converted mmol/L → mg/dL (×18; PhysioNet Challenge 2012)
+      when glucose_max >= 801.0 then 4
+      when glucose_min <  28.8 then 4
+      when glucose_max >= 500.4 then 3
+      when glucose_min <  50.4 then 3
+      when glucose_min <  70.2 then 2
+      when glucose_max >= 252.0 then 1
+      when glucose_max >=  70.2 and glucose_max < 252.0
+       and glucose_min >=  70.2 and glucose_min < 252.0
         then 0
       end as glucose_score
 

--- a/mimic-iii/concepts_duckdb/severityscores/saps.sql
+++ b/mimic-iii/concepts_duckdb/severityscores/saps.sql
@@ -198,17 +198,17 @@ WITH cpap AS (
     CASE
       WHEN bun_max IS NULL
       THEN NULL
-      WHEN bun_max >= 55.0
-      THEN 4
-      WHEN bun_max >= 36.0
+      WHEN bun_max >= 154.0
+      THEN 4 /* mmol/L×2.8 → mg/dL; PhysioNet Challenge 2012 */
+      WHEN bun_max >= 100.8
       THEN 3
-      WHEN bun_max >= 29.0
+      WHEN bun_max >= 81.2
       THEN 2
-      WHEN bun_max >= 7.50
+      WHEN bun_max >= 21.0
       THEN 1
-      WHEN bun_min < 3.5
+      WHEN bun_min < 9.8
       THEN 1
-      WHEN bun_max >= 3.5 AND bun_max < 7.5 AND bun_min >= 3.5 AND bun_min < 7.5
+      WHEN bun_max >= 9.8 AND bun_max < 21.0 AND bun_min >= 9.8 AND bun_min < 21.0
       THEN 0
     END AS bun_score,
     CASE
@@ -249,22 +249,22 @@ WITH cpap AS (
     CASE
       WHEN glucose_max IS NULL
       THEN NULL
-      WHEN glucose_max >= 44.5
+      WHEN glucose_max >= 801.0
+      THEN 4 /* mmol/L×18 → mg/dL; PhysioNet Challenge 2012 */
+      WHEN glucose_min < 28.8
       THEN 4
-      WHEN glucose_min < 1.6
-      THEN 4
-      WHEN glucose_max >= 27.8
+      WHEN glucose_max >= 500.4
       THEN 3
-      WHEN glucose_min < 2.8
+      WHEN glucose_min < 50.4
       THEN 3
-      WHEN glucose_min < 3.9
+      WHEN glucose_min < 70.2
       THEN 2
-      WHEN glucose_max >= 14.0
+      WHEN glucose_max >= 252.0
       THEN 1
-      WHEN glucose_max >= 3.9
-      AND glucose_max < 14.0
-      AND glucose_min >= 3.9
-      AND glucose_min < 14.0
+      WHEN glucose_max >= 70.2
+      AND glucose_max < 252.0
+      AND glucose_min >= 70.2
+      AND glucose_min < 252.0
       THEN 0
     END AS glucose_score,
     CASE

--- a/mimic-iii/concepts_postgres/severityscores/saps.sql
+++ b/mimic-iii/concepts_postgres/severityscores/saps.sql
@@ -205,17 +205,17 @@ WITH cpap AS (
     CASE
       WHEN bun_max IS NULL
       THEN NULL
-      WHEN bun_max >= 55.0
-      THEN 4
-      WHEN bun_max >= 36.0
+      WHEN bun_max >= 154.0
+      THEN 4 /* mmol/L×2.8 → mg/dL; PhysioNet Challenge 2012 */
+      WHEN bun_max >= 100.8
       THEN 3
-      WHEN bun_max >= 29.0
+      WHEN bun_max >= 81.2
       THEN 2
-      WHEN bun_max >= 7.50
+      WHEN bun_max >= 21.0
       THEN 1
-      WHEN bun_min < 3.5
+      WHEN bun_min < 9.8
       THEN 1
-      WHEN bun_max >= 3.5 AND bun_max < 7.5 AND bun_min >= 3.5 AND bun_min < 7.5
+      WHEN bun_max >= 9.8 AND bun_max < 21.0 AND bun_min >= 9.8 AND bun_min < 21.0
       THEN 0
     END AS bun_score,
     CASE
@@ -256,22 +256,22 @@ WITH cpap AS (
     CASE
       WHEN glucose_max IS NULL
       THEN NULL
-      WHEN glucose_max >= 44.5
+      WHEN glucose_max >= 801.0
+      THEN 4 /* mmol/L×18 → mg/dL; PhysioNet Challenge 2012 */
+      WHEN glucose_min < 28.8
       THEN 4
-      WHEN glucose_min < 1.6
-      THEN 4
-      WHEN glucose_max >= 27.8
+      WHEN glucose_max >= 500.4
       THEN 3
-      WHEN glucose_min < 2.8
+      WHEN glucose_min < 50.4
       THEN 3
-      WHEN glucose_min < 3.9
+      WHEN glucose_min < 70.2
       THEN 2
-      WHEN glucose_max >= 14.0
+      WHEN glucose_max >= 252.0
       THEN 1
-      WHEN glucose_max >= 3.9
-      AND glucose_max < 14.0
-      AND glucose_min >= 3.9
-      AND glucose_min < 14.0
+      WHEN glucose_max >= 70.2
+      AND glucose_max < 252.0
+      AND glucose_min >= 70.2
+      AND glucose_min < 252.0
       THEN 0
     END AS glucose_score,
     CASE


### PR DESCRIPTION
## Summary
- BUN/glucose labs are mg/dL; score arms still used the mmol/L cutoffs.
- Scale by 2.8 / 18 (PhysioNet Challenge 2012) in all dialect copies.

## Test plan
- [ ] Spot-check: glucose 100 mg/dL should score 0, not 4


Made with [Cursor](https://cursor.com)