### PR TITLE
fix: score SAPS II fever before the normal-temp arm

### DIFF
--- a/mimic-iii/concepts/severityscores/sapsii.sql
+++ b/mimic-iii/concepts/severityscores/sapsii.sql
@@ -239,8 +239,8 @@ select
 
   , case
       when tempc_max is null then null
-      when tempc_min <  39.0 then 0
       when tempc_max >= 39.0 then 3
+      when tempc_min <  39.0 then 0
     end as temp_score
 
   , case

--- a/mimic-iii/concepts_duckdb/severityscores/sapsii.sql
+++ b/mimic-iii/concepts_duckdb/severityscores/sapsii.sql
@@ -213,10 +213,10 @@ WITH cpap AS (
     CASE
       WHEN tempc_max IS NULL
       THEN NULL
-      WHEN tempc_min < 39.0
-      THEN 0
       WHEN tempc_max >= 39.0
       THEN 3
+      WHEN tempc_min < 39.0
+      THEN 0
     END AS temp_score,
     CASE
       WHEN pao2fio2_vent_min IS NULL

--- a/mimic-iii/concepts_postgres/severityscores/sapsii.sql
+++ b/mimic-iii/concepts_postgres/severityscores/sapsii.sql
@@ -222,10 +222,10 @@ WITH cpap AS (
     CASE
       WHEN tempc_max IS NULL
       THEN NULL
-      WHEN tempc_min < 39.0
-      THEN 0
       WHEN tempc_max >= 39.0
       THEN 3
+      WHEN tempc_min < 39.0
+      THEN 0
     END AS temp_score,
     CASE
       WHEN pao2fio2_vent_min IS NULL


### PR DESCRIPTION
## Summary
- MIMIC-III SAPS II checked `tempc_min < 39` before `tempc_max ≥ 39`, so fever almost never scored.
- Reorder to match MIMIC-IV / Le Gall in all dialect copies.

## Test plan
- [ ] `min=36.5`, `max=39.5` → temp_score 3 (was 0)


Made with [Cursor](https://cursor.com)