### PR TITLE
fix: BigQuery DATETIME_DIFF and D/C match in neuroblock_dose

### DIFF
--- a/mimic-iii/concepts/durations/neuroblock_dose.sql
+++ b/mimic-iii/concepts/durations/neuroblock_dose.sql
@@ -28,7 +28,8 @@ with drugmv as
     , 1 as drug
 
     -- the 'stopped' column indicates if a drug has been disconnected
-    , max(case when stopped in ('Stopped','D/C\'d') then 1 else 0 end) as drug_stopped
+    -- match other CareVue duration scripts (avoids apostrophe that breaks sqlglot)
+    , max(case when stopped = 'Stopped' OR stopped LIKE 'D/C%' then 1 else 0 end) as drug_stopped
 
     -- we only include continuous infusions, therefore expect a rate
     , max(case
@@ -68,7 +69,7 @@ with drugmv as
     , 1 as drug
 
     -- the 'stopped' column indicates if a drug has been disconnected
-    , max(case when stopped in ('Stopped','D/C\'d') then 1 else 0 end) as drug_stopped
+    , max(case when stopped = 'Stopped' OR stopped LIKE 'D/C%' then 1 else 0 end) as drug_stopped
     , max(case when valuenum <= 10 then 0 else 1 end) as drug_null
 
     -- educated guess!
@@ -179,7 +180,12 @@ select
           )
           = 1 then 1
 
-        when (CHARTTIME - (LAG(CHARTTIME, 1) OVER (partition by icustay_id, drug order by charttime))) > (interval '8 hours') then 1
+        -- BigQuery concepts use DATETIME_DIFF (postgres-style interval math is invalid here)
+        when DATETIME_DIFF(
+          CHARTTIME,
+          LAG(CHARTTIME, 1) OVER (partition by icustay_id, drug order by charttime),
+          HOUR
+        ) > 8 then 1
       else null
       end as drug_start
 

--- a/mimic-iii/concepts_duckdb/durations/neuroblock_dose.sql
+++ b/mimic-iii/concepts_duckdb/durations/neuroblock_dose.sql
@@ -8,7 +8,7 @@ WITH drugmv AS (
     amount AS drug_amount,
     starttime,
     endtime
-  FROM mimiciii.inputevents_mv
+  FROM mimiciii_clinical.inputevents_mv
   WHERE
     itemid IN (222062, 221555)
     AND statusdescription <> 'Rewritten'
@@ -18,7 +18,7 @@ WITH drugmv AS (
     icustay_id,
     charttime,
     1 AS drug,
-    MAX(CASE WHEN stopped IN ('Stopped', 'D/C''d') THEN 1 ELSE 0 END) AS drug_stopped,
+    MAX(CASE WHEN stopped = 'Stopped' OR stopped LIKE 'D/C%' THEN 1 ELSE 0 END) AS drug_stopped,
     MAX(
       CASE
         WHEN itemid >= 40000 AND NOT amount IS NULL
@@ -30,7 +30,7 @@ WITH drugmv AS (
     ) AS drug_null,
     MAX(CASE WHEN itemid >= 40000 THEN COALESCE(rate, amount) ELSE rate END) AS drug_rate,
     MAX(amount) AS drug_amount
-  FROM mimiciii.inputevents_cv
+  FROM mimiciii_clinical.inputevents_cv
   WHERE
     itemid IN (
       30114,
@@ -55,11 +55,11 @@ WITH drugmv AS (
     icustay_id,
     charttime,
     1 AS drug,
-    MAX(CASE WHEN stopped IN ('Stopped', 'D/C''d') THEN 1 ELSE 0 END) AS drug_stopped,
+    MAX(CASE WHEN stopped = 'Stopped' OR stopped LIKE 'D/C%' THEN 1 ELSE 0 END) AS drug_stopped,
     MAX(CASE WHEN valuenum <= 10 THEN 0 ELSE 1 END) AS drug_null,
     MAX(CASE WHEN valuenum <= 10 THEN valuenum ELSE NULL END) AS drug_rate,
     MAX(CASE WHEN valuenum > 10 THEN valuenum ELSE NULL END) AS drug_amount
-  FROM mimiciii.chartevents
+  FROM mimiciii_clinical.chartevents
   WHERE
     itemid IN (1856, 2164, 2548, 2285, 2290, 2670, 2546, 1098, 2390, 2511, 1028, 1858)
   GROUP BY
@@ -100,13 +100,11 @@ WITH drugmv AS (
       THEN 1
       WHEN LAG(drug_stopped, 1) OVER (PARTITION BY icustay_id, drug ORDER BY charttime NULLS FIRST) = 1
       THEN 1
-      WHEN (
-        CHARTTIME - (
-          LAG(CHARTTIME, 1) OVER (PARTITION BY icustay_id, drug ORDER BY charttime NULLS FIRST)
-        )
-      ) > (
-        INTERVAL '8' HOURS
-      )
+      WHEN DATE_DIFF(
+        'HOUR',
+        LAG(CHARTTIME, 1) OVER (PARTITION BY icustay_id, drug ORDER BY charttime NULLS FIRST),
+        CHARTTIME
+      ) > 8
       THEN 1
       ELSE NULL
     END AS drug_start

--- a/mimic-iii/concepts_postgres/durations/neuroblock_dose.sql
+++ b/mimic-iii/concepts_postgres/durations/neuroblock_dose.sql
@@ -1,6 +1,9 @@
 -- THIS SCRIPT IS AUTOMATICALLY GENERATED. DO NOT EDIT IT DIRECTLY.
 DROP TABLE IF EXISTS mimiciii_derived.neuroblock_dose; CREATE TABLE mimiciii_derived.neuroblock_dose AS
-/* This query extracts dose+durations of neuromuscular blocking agents */ /* Note: we assume that injections will be filtered for carevue as they will have starttime = stopttime. */ /* Get drug administration data from CareVue and MetaVision */ /* metavision is simple and only requires one temporary table */
+/* This query extracts dose+durations of neuromuscular blocking agents */
+/* Note: we assume that injections will be filtered for carevue as they will have starttime = stopttime. */
+/* Get drug administration data from CareVue and MetaVision */
+/* metavision is simple and only requires one temporary table */
 WITH drugmv AS (
   SELECT
     icustay_id,
@@ -9,7 +12,7 @@ WITH drugmv AS (
     amount AS drug_amount,
     starttime,
     endtime
-  FROM mimiciii.inputevents_mv
+  FROM mimiciii_clinical.inputevents_mv
   WHERE
     itemid IN (
       222062, /* Vecuronium (664 rows, 154 infusion rows) */
@@ -21,8 +24,8 @@ WITH drugmv AS (
   SELECT
     icustay_id,
     charttime, /* where clause below ensures all rows are instance of the drug */
-    1 AS drug, /* the 'stopped' column indicates if a drug has been disconnected */
-    MAX(CASE WHEN stopped IN ('Stopped', 'D/C''d') THEN 1 ELSE 0 END) AS drug_stopped, /* we only include continuous infusions, therefore expect a rate */
+    1 AS drug, /* the 'stopped' column indicates if a drug has been disconnected */ /* match other CareVue duration scripts (avoids apostrophe that breaks sqlglot) */
+    MAX(CASE WHEN stopped = 'Stopped' OR stopped LIKE 'D/C%' THEN 1 ELSE 0 END) AS drug_stopped, /* we only include continuous infusions, therefore expect a rate */
     MAX(
       CASE
         WHEN itemid >= 40000 AND NOT amount IS NULL
@@ -34,7 +37,7 @@ WITH drugmv AS (
     ) AS drug_null,
     MAX(CASE WHEN itemid >= 40000 THEN COALESCE(rate, amount) ELSE rate END) AS drug_rate,
     MAX(amount) AS drug_amount
-  FROM mimiciii.inputevents_cv
+  FROM mimiciii_clinical.inputevents_cv
   WHERE
     itemid IN (
       30114, /* Cisatracurium (63994 rows) */
@@ -60,11 +63,11 @@ WITH drugmv AS (
     icustay_id,
     charttime, /* where clause below ensures all rows are instance of the drug */
     1 AS drug, /* the 'stopped' column indicates if a drug has been disconnected */
-    MAX(CASE WHEN stopped IN ('Stopped', 'D/C''d') THEN 1 ELSE 0 END) AS drug_stopped,
+    MAX(CASE WHEN stopped = 'Stopped' OR stopped LIKE 'D/C%' THEN 1 ELSE 0 END) AS drug_stopped,
     MAX(CASE WHEN valuenum <= 10 THEN 0 ELSE 1 END) AS drug_null, /* educated guess! */
     MAX(CASE WHEN valuenum <= 10 THEN valuenum ELSE NULL END) AS drug_rate,
     MAX(CASE WHEN valuenum > 10 THEN valuenum ELSE NULL END) AS drug_amount
-  FROM mimiciii.chartevents
+  FROM mimiciii_clinical.chartevents
   WHERE
     itemid IN (
       1856, /* Vecuronium mcg/min  (8 rows) */
@@ -118,13 +121,7 @@ WITH drugmv AS (
       THEN 1
       WHEN LAG(drug_stopped, 1) OVER (PARTITION BY icustay_id, drug ORDER BY charttime NULLS FIRST) = 1
       THEN 1
-      WHEN (
-        CHARTTIME - (
-          LAG(CHARTTIME, 1) OVER (PARTITION BY icustay_id, drug ORDER BY charttime NULLS FIRST)
-        )
-      ) > (
-        INTERVAL '8 HOURS'
-      )
+      WHEN CAST(EXTRACT(EPOCH FROM DATE_TRUNC('hour', CHARTTIME) - DATE_TRUNC('hour', LAG(CHARTTIME, 1) OVER (PARTITION BY icustay_id, drug ORDER BY charttime NULLS FIRST))) / 3600 AS BIGINT) > 8
       THEN 1
       ELSE NULL
     END AS drug_start
@@ -227,7 +224,8 @@ WITH drugmv AS (
     drug_groups_sum,
     drug_rate
 )
-/* now assign this data to every hour of the patient's stay */ /* drug_amount for carevue is not accurate */
+/* now assign this data to every hour of the patient's stay */
+/* drug_amount for carevue is not accurate */
 SELECT
   icustay_id,
   starttime,


### PR DESCRIPTION
## Summary
- BigQuery `neuroblock_dose` still used postgres `interval` subtraction for the 8h gap check; switch to `DATETIME_DIFF(..., HOUR)` like arterial/central line durations.
- Replace `'D/C\'d'` with `stopped LIKE 'D/C%'` (same pattern as other CareVue duration scripts) so sqlglot can parse/transpile the file — this was breaking `duckdb-concepts-iii` / `psql-concepts-iii` on main-dependent PRs.
- Regenerate postgres and duckdb dialect copies.

## Test plan
- [x] `pytest tests/test_transpile.py` (336 passed)
- [ ] Confirm concept transpile no longer fails on `neuroblock_dose.sql`
- [ ] Spot-check: gap > 8 hours starts a new infusion interval

Made with [Cursor](https://cursor.com)