### PR TITLE
fix: compare APS III equidistant arms to min not max

### DIFF
--- a/.github/workflows/lint_sqlfluff.yml
+++ b/.github/workflows/lint_sqlfluff.yml
@@ -35,8 +35,12 @@ jobs:
         shell: bash
         run: sqlfluff lint --format github-annotation --annotation-level failure --nofail ${{ steps.get_files_to_lint.outputs.lintees }} > annotations.json
       - name: Annotate
+        # Fork PRs cannot create check runs with GITHUB_TOKEN; lint already ran.
+        continue-on-error: true
+        if: steps.get_files_to_lint.outputs.lintees != ''
         uses: yuzutech/annotations-action@v0.6.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           title: "SQLFluff Lint"
           input: "./annotations.json"
+          ignore-missing-file: true

--- a/mimic-iii/concepts/pivot/pivoted_invasive_lines.sql
+++ b/mimic-iii/concepts/pivot/pivoted_invasive_lines.sql
@@ -19,8 +19,9 @@ WITH stg0 AS
         , CASE WHEN itemid < 8000 THEN value ELSE NULL END AS line_type
         , CASE WHEN itemid > 8000 THEN value ELSE NULL END AS line_site
         -- the stopped column is always present for invasive lines
+        -- LIKE avoids apostrophe escaping that breaks sqlglot transpile
         , CASE 
-              WHEN ce.stopped = 'D/C\'d' THEN 1
+              WHEN ce.stopped LIKE 'D/C%' THEN 1
               WHEN ce.stopped = 'NotStopd' THEN 0
           ELSE NULL END AS line_dc
     FROM `physionet-data.mimiciii_clinical.chartevents` ce

--- a/mimic-iii/concepts/severityscores/apsiii.sql
+++ b/mimic-iii/concepts/severityscores/apsiii.sql
@@ -577,10 +577,10 @@ from cohort
       when abs(resprate_max-19) < abs(resprate_min-19)
         then smin.resprate_score
       -- values are equidistant - pick the larger score
-      when abs(resprate_max-19) = abs(resprate_max-19)
+      when abs(resprate_max-19) = abs(resprate_min-19)
       and  smax.resprate_score >= smin.resprate_score
         then smax.resprate_score
-      when abs(resprate_max-19) = abs(resprate_max-19)
+      when abs(resprate_max-19) = abs(resprate_min-19)
       and  smax.resprate_score < smin.resprate_score
         then smin.resprate_score
     end as resprate_score
@@ -592,10 +592,10 @@ from cohort
       when abs(hematocrit_max-45.5) < abs(hematocrit_min-45.5)
         then smin.hematocrit_score
       -- values are equidistant - pick the larger score
-      when abs(hematocrit_max-45.5) = abs(hematocrit_max-45.5)
+      when abs(hematocrit_max-45.5) = abs(hematocrit_min-45.5)
       and  smax.hematocrit_score >= smin.hematocrit_score
         then smax.hematocrit_score
-      when abs(hematocrit_max-45.5) = abs(hematocrit_max-45.5)
+      when abs(hematocrit_max-45.5) = abs(hematocrit_min-45.5)
       and  smax.hematocrit_score < smin.hematocrit_score
         then smin.hematocrit_score
     end as hematocrit_score
@@ -607,10 +607,10 @@ from cohort
       when abs(wbc_max-11.5) < abs(wbc_min-11.5)
         then smin.wbc_score
       -- values are equidistant - pick the larger score
-      when abs(wbc_max-11.5) = abs(wbc_max-11.5)
+      when abs(wbc_max-11.5) = abs(wbc_min-11.5)
       and  smax.wbc_score >= smin.wbc_score
         then smax.wbc_score
-      when abs(wbc_max-11.5) = abs(wbc_max-11.5)
+      when abs(wbc_max-11.5) = abs(wbc_min-11.5)
       and  smax.wbc_score < smin.wbc_score
         then smin.wbc_score
     end as wbc_score
@@ -649,10 +649,10 @@ from cohort
       when abs(sodium_max-145.5) < abs(sodium_min-145.5)
         then smin.sodium_score
       -- values are equidistant - pick the larger score
-      when abs(sodium_max-145.5) = abs(sodium_max-145.5)
+      when abs(sodium_max-145.5) = abs(sodium_min-145.5)
       and  smax.sodium_score >= smin.sodium_score
         then smax.sodium_score
-      when abs(sodium_max-145.5) = abs(sodium_max-145.5)
+      when abs(sodium_max-145.5) = abs(sodium_min-145.5)
       and  smax.sodium_score < smin.sodium_score
         then smin.sodium_score
     end as sodium_score
@@ -664,10 +664,10 @@ from cohort
       when abs(albumin_max-3.5) < abs(albumin_min-3.5)
         then smin.albumin_score
       -- values are equidistant - pick the larger score
-      when abs(albumin_max-3.5) = abs(albumin_max-3.5)
+      when abs(albumin_max-3.5) = abs(albumin_min-3.5)
       and  smax.albumin_score >= smin.albumin_score
         then smax.albumin_score
-      when abs(albumin_max-3.5) = abs(albumin_max-3.5)
+      when abs(albumin_max-3.5) = abs(albumin_min-3.5)
       and  smax.albumin_score < smin.albumin_score
         then smin.albumin_score
     end as albumin_score
@@ -684,10 +684,10 @@ from cohort
       when abs(glucose_max-130) < abs(glucose_min-130)
         then smin.glucose_score
       -- values are equidistant - pick the larger score
-      when abs(glucose_max-130) = abs(glucose_max-130)
+      when abs(glucose_max-130) = abs(glucose_min-130)
       and  smax.glucose_score >= smin.glucose_score
         then smax.glucose_score
-      when abs(glucose_max-130) = abs(glucose_max-130)
+      when abs(glucose_max-130) = abs(glucose_min-130)
       and  smax.glucose_score < smin.glucose_score
         then smin.glucose_score
     end as glucose_score

--- a/mimic-iii/concepts_duckdb/pivot/pivoted_invasive_lines.sql
+++ b/mimic-iii/concepts_duckdb/pivot/pivoted_invasive_lines.sql
@@ -28,13 +28,13 @@ WITH stg0 AS (
     CASE WHEN itemid < 8000 THEN value ELSE NULL END AS line_type,
     CASE WHEN itemid > 8000 THEN value ELSE NULL END AS line_site,
     CASE
-      WHEN ce.stopped = 'D/C''d'
+      WHEN ce.stopped LIKE 'D/C%'
       THEN 1
       WHEN ce.stopped = 'NotStopd'
       THEN 0
       ELSE NULL
     END AS line_dc
-  FROM mimiciii.chartevents AS ce
+  FROM mimiciii_clinical.chartevents AS ce
   WHERE
     ce.itemid IN (
       229,
@@ -138,8 +138,8 @@ WITH stg0 AS (
     mv.location AS line_site,
     starttime,
     endtime
-  FROM mimiciii.procedureevents_mv AS mv
-  INNER JOIN mimiciii.d_items AS di
+  FROM mimiciii_clinical.procedureevents_mv AS mv
+  INNER JOIN mimiciii_clinical.d_items AS di
     ON mv.itemid = di.itemid
   WHERE
     mv.itemid IN (

--- a/mimic-iii/concepts_duckdb/severityscores/apsiii.sql
+++ b/mimic-iii/concepts_duckdb/severityscores/apsiii.sql
@@ -606,10 +606,10 @@ WITH pa AS (
       THEN smax.resprate_score
       WHEN ABS(resprate_max - 19) < ABS(resprate_min - 19)
       THEN smin.resprate_score
-      WHEN ABS(resprate_max - 19) = ABS(resprate_max - 19)
+      WHEN ABS(resprate_max - 19) = ABS(resprate_min - 19)
       AND smax.resprate_score >= smin.resprate_score
       THEN smax.resprate_score
-      WHEN ABS(resprate_max - 19) = ABS(resprate_max - 19)
+      WHEN ABS(resprate_max - 19) = ABS(resprate_min - 19)
       AND smax.resprate_score < smin.resprate_score
       THEN smin.resprate_score
     END AS resprate_score,
@@ -620,10 +620,10 @@ WITH pa AS (
       THEN smax.hematocrit_score
       WHEN ABS(hematocrit_max - 45.5) < ABS(hematocrit_min - 45.5)
       THEN smin.hematocrit_score
-      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_max - 45.5)
+      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_min - 45.5)
       AND smax.hematocrit_score >= smin.hematocrit_score
       THEN smax.hematocrit_score
-      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_max - 45.5)
+      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_min - 45.5)
       AND smax.hematocrit_score < smin.hematocrit_score
       THEN smin.hematocrit_score
     END AS hematocrit_score,
@@ -634,9 +634,9 @@ WITH pa AS (
       THEN smax.wbc_score
       WHEN ABS(wbc_max - 11.5) < ABS(wbc_min - 11.5)
       THEN smin.wbc_score
-      WHEN ABS(wbc_max - 11.5) = ABS(wbc_max - 11.5) AND smax.wbc_score >= smin.wbc_score
+      WHEN ABS(wbc_max - 11.5) = ABS(wbc_min - 11.5) AND smax.wbc_score >= smin.wbc_score
       THEN smax.wbc_score
-      WHEN ABS(wbc_max - 11.5) = ABS(wbc_max - 11.5) AND smax.wbc_score < smin.wbc_score
+      WHEN ABS(wbc_max - 11.5) = ABS(wbc_min - 11.5) AND smax.wbc_score < smin.wbc_score
       THEN smin.wbc_score
     END AS wbc_score,
     CASE
@@ -661,10 +661,10 @@ WITH pa AS (
       THEN smax.sodium_score
       WHEN ABS(sodium_max - 145.5) < ABS(sodium_min - 145.5)
       THEN smin.sodium_score
-      WHEN ABS(sodium_max - 145.5) = ABS(sodium_max - 145.5)
+      WHEN ABS(sodium_max - 145.5) = ABS(sodium_min - 145.5)
       AND smax.sodium_score >= smin.sodium_score
       THEN smax.sodium_score
-      WHEN ABS(sodium_max - 145.5) = ABS(sodium_max - 145.5)
+      WHEN ABS(sodium_max - 145.5) = ABS(sodium_min - 145.5)
       AND smax.sodium_score < smin.sodium_score
       THEN smin.sodium_score
     END AS sodium_score,
@@ -675,10 +675,10 @@ WITH pa AS (
       THEN smax.albumin_score
       WHEN ABS(albumin_max - 3.5) < ABS(albumin_min - 3.5)
       THEN smin.albumin_score
-      WHEN ABS(albumin_max - 3.5) = ABS(albumin_max - 3.5)
+      WHEN ABS(albumin_max - 3.5) = ABS(albumin_min - 3.5)
       AND smax.albumin_score >= smin.albumin_score
       THEN smax.albumin_score
-      WHEN ABS(albumin_max - 3.5) = ABS(albumin_max - 3.5)
+      WHEN ABS(albumin_max - 3.5) = ABS(albumin_min - 3.5)
       AND smax.albumin_score < smin.albumin_score
       THEN smin.albumin_score
     END AS albumin_score,
@@ -690,10 +690,10 @@ WITH pa AS (
       THEN smax.glucose_score
       WHEN ABS(glucose_max - 130) < ABS(glucose_min - 130)
       THEN smin.glucose_score
-      WHEN ABS(glucose_max - 130) = ABS(glucose_max - 130)
+      WHEN ABS(glucose_max - 130) = ABS(glucose_min - 130)
       AND smax.glucose_score >= smin.glucose_score
       THEN smax.glucose_score
-      WHEN ABS(glucose_max - 130) = ABS(glucose_max - 130)
+      WHEN ABS(glucose_max - 130) = ABS(glucose_min - 130)
       AND smax.glucose_score < smin.glucose_score
       THEN smin.glucose_score
     END AS glucose_score,

--- a/mimic-iii/concepts_postgres/pivot/pivoted_invasive_lines.sql
+++ b/mimic-iii/concepts_postgres/pivot/pivoted_invasive_lines.sql
@@ -26,15 +26,15 @@ WITH stg0 AS (
       ELSE NULL
     END AS line_number,
     CASE WHEN itemid < 8000 THEN value ELSE NULL END AS line_type,
-    CASE WHEN itemid > 8000 THEN value ELSE NULL END AS line_site, /* the stopped column is always present for invasive lines */
+    CASE WHEN itemid > 8000 THEN value ELSE NULL END AS line_site, /* the stopped column is always present for invasive lines */ /* LIKE avoids apostrophe escaping that breaks sqlglot transpile */
     CASE
-      WHEN ce.stopped = 'D/C''d'
+      WHEN ce.stopped LIKE 'D/C%'
       THEN 1
       WHEN ce.stopped = 'NotStopd'
       THEN 0
       ELSE NULL
     END AS line_dc
-  FROM mimiciii.chartevents AS ce
+  FROM mimiciii_clinical.chartevents AS ce
   WHERE
     ce.itemid IN (
       229, /* INV Line#1 [Type] */
@@ -135,8 +135,8 @@ WITH stg0 AS (
     mv.location AS line_site,
     starttime,
     endtime
-  FROM mimiciii.procedureevents_mv AS mv
-  INNER JOIN mimiciii.d_items AS di
+  FROM mimiciii_clinical.procedureevents_mv AS mv
+  INNER JOIN mimiciii_clinical.d_items AS di
     ON mv.itemid = di.itemid
   WHERE
     mv.itemid IN (

--- a/mimic-iii/concepts_postgres/severityscores/apsiii.sql
+++ b/mimic-iii/concepts_postgres/severityscores/apsiii.sql
@@ -613,10 +613,10 @@ WITH pa AS (
       THEN smax.resprate_score
       WHEN ABS(resprate_max - 19) < ABS(resprate_min - 19)
       THEN smin.resprate_score
-      WHEN ABS(resprate_max - 19) = ABS(resprate_max - 19)
+      WHEN ABS(resprate_max - 19) = ABS(resprate_min - 19)
       AND smax.resprate_score >= smin.resprate_score
       THEN smax.resprate_score
-      WHEN ABS(resprate_max - 19) = ABS(resprate_max - 19)
+      WHEN ABS(resprate_max - 19) = ABS(resprate_min - 19)
       AND smax.resprate_score < smin.resprate_score
       THEN smin.resprate_score
     END AS resprate_score,
@@ -627,10 +627,10 @@ WITH pa AS (
       THEN smax.hematocrit_score
       WHEN ABS(hematocrit_max - 45.5) < ABS(hematocrit_min - 45.5)
       THEN smin.hematocrit_score
-      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_max - 45.5)
+      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_min - 45.5)
       AND smax.hematocrit_score >= smin.hematocrit_score
       THEN smax.hematocrit_score
-      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_max - 45.5)
+      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_min - 45.5)
       AND smax.hematocrit_score < smin.hematocrit_score
       THEN smin.hematocrit_score
     END AS hematocrit_score,
@@ -641,9 +641,9 @@ WITH pa AS (
       THEN smax.wbc_score
       WHEN ABS(wbc_max - 11.5) < ABS(wbc_min - 11.5)
       THEN smin.wbc_score
-      WHEN ABS(wbc_max - 11.5) = ABS(wbc_max - 11.5) AND smax.wbc_score >= smin.wbc_score
+      WHEN ABS(wbc_max - 11.5) = ABS(wbc_min - 11.5) AND smax.wbc_score >= smin.wbc_score
       THEN smax.wbc_score
-      WHEN ABS(wbc_max - 11.5) = ABS(wbc_max - 11.5) AND smax.wbc_score < smin.wbc_score
+      WHEN ABS(wbc_max - 11.5) = ABS(wbc_min - 11.5) AND smax.wbc_score < smin.wbc_score
       THEN smin.wbc_score
     END AS wbc_score, /* For some labs, "furthest from normal" doesn't make sense */ /* e.g. creatinine w/ ARF, the minimum could be 0.3, and the max 1.6 */ /* while the minimum of 0.3 is "further from 1", seems like the max should be scored */
     CASE
@@ -668,10 +668,10 @@ WITH pa AS (
       THEN smax.sodium_score
       WHEN ABS(sodium_max - 145.5) < ABS(sodium_min - 145.5)
       THEN smin.sodium_score
-      WHEN ABS(sodium_max - 145.5) = ABS(sodium_max - 145.5)
+      WHEN ABS(sodium_max - 145.5) = ABS(sodium_min - 145.5)
       AND smax.sodium_score >= smin.sodium_score
       THEN smax.sodium_score
-      WHEN ABS(sodium_max - 145.5) = ABS(sodium_max - 145.5)
+      WHEN ABS(sodium_max - 145.5) = ABS(sodium_min - 145.5)
       AND smax.sodium_score < smin.sodium_score
       THEN smin.sodium_score
     END AS sodium_score,
@@ -682,10 +682,10 @@ WITH pa AS (
       THEN smax.albumin_score
       WHEN ABS(albumin_max - 3.5) < ABS(albumin_min - 3.5)
       THEN smin.albumin_score
-      WHEN ABS(albumin_max - 3.5) = ABS(albumin_max - 3.5)
+      WHEN ABS(albumin_max - 3.5) = ABS(albumin_min - 3.5)
       AND smax.albumin_score >= smin.albumin_score
       THEN smax.albumin_score
-      WHEN ABS(albumin_max - 3.5) = ABS(albumin_max - 3.5)
+      WHEN ABS(albumin_max - 3.5) = ABS(albumin_min - 3.5)
       AND smax.albumin_score < smin.albumin_score
       THEN smin.albumin_score
     END AS albumin_score,
@@ -697,10 +697,10 @@ WITH pa AS (
       THEN smax.glucose_score
       WHEN ABS(glucose_max - 130) < ABS(glucose_min - 130)
       THEN smin.glucose_score
-      WHEN ABS(glucose_max - 130) = ABS(glucose_max - 130)
+      WHEN ABS(glucose_max - 130) = ABS(glucose_min - 130)
       AND smax.glucose_score >= smin.glucose_score
       THEN smax.glucose_score
-      WHEN ABS(glucose_max - 130) = ABS(glucose_max - 130)
+      WHEN ABS(glucose_max - 130) = ABS(glucose_min - 130)
       AND smax.glucose_score < smin.glucose_score
       THEN smin.glucose_score
     END AS glucose_score, /* Below are interactions/special cases where only 1 value is important */

--- a/mimic-iv/concepts/score/apsiii.sql
+++ b/mimic-iv/concepts/score/apsiii.sql
@@ -631,10 +631,10 @@ WITH pa AS (
             WHEN ABS(resp_rate_max - 19) < ABS(resp_rate_min - 19)
                 THEN smin.resp_rate_score
             -- values are equidistant - pick the larger score
-            WHEN ABS(resp_rate_max - 19) = ABS(resp_rate_max - 19)
+            WHEN ABS(resp_rate_max - 19) = ABS(resp_rate_min - 19)
                 AND smax.resp_rate_score >= smin.resp_rate_score
                 THEN smax.resp_rate_score
-            WHEN ABS(resp_rate_max - 19) = ABS(resp_rate_max - 19)
+            WHEN ABS(resp_rate_max - 19) = ABS(resp_rate_min - 19)
                 AND smax.resp_rate_score < smin.resp_rate_score
                 THEN smin.resp_rate_score
         END AS resp_rate_score
@@ -646,10 +646,10 @@ WITH pa AS (
             WHEN ABS(hematocrit_max - 45.5) < ABS(hematocrit_min - 45.5)
                 THEN smin.hematocrit_score
             -- values are equidistant - pick the larger score
-            WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_max - 45.5)
+            WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_min - 45.5)
                 AND smax.hematocrit_score >= smin.hematocrit_score
                 THEN smax.hematocrit_score
-            WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_max - 45.5)
+            WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_min - 45.5)
                 AND smax.hematocrit_score < smin.hematocrit_score
                 THEN smin.hematocrit_score
         END AS hematocrit_score
@@ -661,10 +661,10 @@ WITH pa AS (
             WHEN ABS(wbc_max - 11.5) < ABS(wbc_min - 11.5)
                 THEN smin.wbc_score
             -- values are equidistant - pick the larger score
-            WHEN ABS(wbc_max - 11.5) = ABS(wbc_max - 11.5)
+            WHEN ABS(wbc_max - 11.5) = ABS(wbc_min - 11.5)
                 AND smax.wbc_score >= smin.wbc_score
                 THEN smax.wbc_score
-            WHEN ABS(wbc_max - 11.5) = ABS(wbc_max - 11.5)
+            WHEN ABS(wbc_max - 11.5) = ABS(wbc_min - 11.5)
                 AND smax.wbc_score < smin.wbc_score
                 THEN smin.wbc_score
         END AS wbc_score
@@ -704,10 +704,10 @@ WITH pa AS (
             WHEN ABS(sodium_max - 145.5) < ABS(sodium_min - 145.5)
                 THEN smin.sodium_score
             -- values are equidistant - pick the larger score
-            WHEN ABS(sodium_max - 145.5) = ABS(sodium_max - 145.5)
+            WHEN ABS(sodium_max - 145.5) = ABS(sodium_min - 145.5)
                 AND smax.sodium_score >= smin.sodium_score
                 THEN smax.sodium_score
-            WHEN ABS(sodium_max - 145.5) = ABS(sodium_max - 145.5)
+            WHEN ABS(sodium_max - 145.5) = ABS(sodium_min - 145.5)
                 AND smax.sodium_score < smin.sodium_score
                 THEN smin.sodium_score
         END AS sodium_score
@@ -719,10 +719,10 @@ WITH pa AS (
             WHEN ABS(albumin_max - 3.5) < ABS(albumin_min - 3.5)
                 THEN smin.albumin_score
             -- values are equidistant - pick the larger score
-            WHEN ABS(albumin_max - 3.5) = ABS(albumin_max - 3.5)
+            WHEN ABS(albumin_max - 3.5) = ABS(albumin_min - 3.5)
                 AND smax.albumin_score >= smin.albumin_score
                 THEN smax.albumin_score
-            WHEN ABS(albumin_max - 3.5) = ABS(albumin_max - 3.5)
+            WHEN ABS(albumin_max - 3.5) = ABS(albumin_min - 3.5)
                 AND smax.albumin_score < smin.albumin_score
                 THEN smin.albumin_score
         END AS albumin_score
@@ -739,10 +739,10 @@ WITH pa AS (
             WHEN ABS(glucose_max - 130) < ABS(glucose_min - 130)
                 THEN smin.glucose_score
             -- values are equidistant - pick the larger score
-            WHEN ABS(glucose_max - 130) = ABS(glucose_max - 130)
+            WHEN ABS(glucose_max - 130) = ABS(glucose_min - 130)
                 AND smax.glucose_score >= smin.glucose_score
                 THEN smax.glucose_score
-            WHEN ABS(glucose_max - 130) = ABS(glucose_max - 130)
+            WHEN ABS(glucose_max - 130) = ABS(glucose_min - 130)
                 AND smax.glucose_score < smin.glucose_score
                 THEN smin.glucose_score
         END AS glucose_score

--- a/mimic-iv/concepts_duckdb/score/apsiii.sql
+++ b/mimic-iv/concepts_duckdb/score/apsiii.sql
@@ -651,10 +651,10 @@ WITH pa AS (
       THEN smax.resp_rate_score
       WHEN ABS(resp_rate_max - 19) < ABS(resp_rate_min - 19)
       THEN smin.resp_rate_score
-      WHEN ABS(resp_rate_max - 19) = ABS(resp_rate_max - 19)
+      WHEN ABS(resp_rate_max - 19) = ABS(resp_rate_min - 19)
       AND smax.resp_rate_score >= smin.resp_rate_score
       THEN smax.resp_rate_score
-      WHEN ABS(resp_rate_max - 19) = ABS(resp_rate_max - 19)
+      WHEN ABS(resp_rate_max - 19) = ABS(resp_rate_min - 19)
       AND smax.resp_rate_score < smin.resp_rate_score
       THEN smin.resp_rate_score
     END AS resp_rate_score,
@@ -665,10 +665,10 @@ WITH pa AS (
       THEN smax.hematocrit_score
       WHEN ABS(hematocrit_max - 45.5) < ABS(hematocrit_min - 45.5)
       THEN smin.hematocrit_score
-      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_max - 45.5)
+      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_min - 45.5)
       AND smax.hematocrit_score >= smin.hematocrit_score
       THEN smax.hematocrit_score
-      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_max - 45.5)
+      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_min - 45.5)
       AND smax.hematocrit_score < smin.hematocrit_score
       THEN smin.hematocrit_score
     END AS hematocrit_score,
@@ -679,9 +679,9 @@ WITH pa AS (
       THEN smax.wbc_score
       WHEN ABS(wbc_max - 11.5) < ABS(wbc_min - 11.5)
       THEN smin.wbc_score
-      WHEN ABS(wbc_max - 11.5) = ABS(wbc_max - 11.5) AND smax.wbc_score >= smin.wbc_score
+      WHEN ABS(wbc_max - 11.5) = ABS(wbc_min - 11.5) AND smax.wbc_score >= smin.wbc_score
       THEN smax.wbc_score
-      WHEN ABS(wbc_max - 11.5) = ABS(wbc_max - 11.5) AND smax.wbc_score < smin.wbc_score
+      WHEN ABS(wbc_max - 11.5) = ABS(wbc_min - 11.5) AND smax.wbc_score < smin.wbc_score
       THEN smin.wbc_score
     END AS wbc_score,
     CASE
@@ -706,10 +706,10 @@ WITH pa AS (
       THEN smax.sodium_score
       WHEN ABS(sodium_max - 145.5) < ABS(sodium_min - 145.5)
       THEN smin.sodium_score
-      WHEN ABS(sodium_max - 145.5) = ABS(sodium_max - 145.5)
+      WHEN ABS(sodium_max - 145.5) = ABS(sodium_min - 145.5)
       AND smax.sodium_score >= smin.sodium_score
       THEN smax.sodium_score
-      WHEN ABS(sodium_max - 145.5) = ABS(sodium_max - 145.5)
+      WHEN ABS(sodium_max - 145.5) = ABS(sodium_min - 145.5)
       AND smax.sodium_score < smin.sodium_score
       THEN smin.sodium_score
     END AS sodium_score,
@@ -720,10 +720,10 @@ WITH pa AS (
       THEN smax.albumin_score
       WHEN ABS(albumin_max - 3.5) < ABS(albumin_min - 3.5)
       THEN smin.albumin_score
-      WHEN ABS(albumin_max - 3.5) = ABS(albumin_max - 3.5)
+      WHEN ABS(albumin_max - 3.5) = ABS(albumin_min - 3.5)
       AND smax.albumin_score >= smin.albumin_score
       THEN smax.albumin_score
-      WHEN ABS(albumin_max - 3.5) = ABS(albumin_max - 3.5)
+      WHEN ABS(albumin_max - 3.5) = ABS(albumin_min - 3.5)
       AND smax.albumin_score < smin.albumin_score
       THEN smin.albumin_score
     END AS albumin_score,
@@ -735,10 +735,10 @@ WITH pa AS (
       THEN smax.glucose_score
       WHEN ABS(glucose_max - 130) < ABS(glucose_min - 130)
       THEN smin.glucose_score
-      WHEN ABS(glucose_max - 130) = ABS(glucose_max - 130)
+      WHEN ABS(glucose_max - 130) = ABS(glucose_min - 130)
       AND smax.glucose_score >= smin.glucose_score
       THEN smax.glucose_score
-      WHEN ABS(glucose_max - 130) = ABS(glucose_max - 130)
+      WHEN ABS(glucose_max - 130) = ABS(glucose_min - 130)
       AND smax.glucose_score < smin.glucose_score
       THEN smin.glucose_score
     END AS glucose_score,

--- a/mimic-iv/concepts_postgres/score/apsiii.sql
+++ b/mimic-iv/concepts_postgres/score/apsiii.sql
@@ -658,10 +658,10 @@ WITH pa AS (
       THEN smax.resp_rate_score
       WHEN ABS(resp_rate_max - 19) < ABS(resp_rate_min - 19)
       THEN smin.resp_rate_score
-      WHEN ABS(resp_rate_max - 19) = ABS(resp_rate_max - 19)
+      WHEN ABS(resp_rate_max - 19) = ABS(resp_rate_min - 19)
       AND smax.resp_rate_score >= smin.resp_rate_score
       THEN smax.resp_rate_score
-      WHEN ABS(resp_rate_max - 19) = ABS(resp_rate_max - 19)
+      WHEN ABS(resp_rate_max - 19) = ABS(resp_rate_min - 19)
       AND smax.resp_rate_score < smin.resp_rate_score
       THEN smin.resp_rate_score
     END AS resp_rate_score,
@@ -672,10 +672,10 @@ WITH pa AS (
       THEN smax.hematocrit_score
       WHEN ABS(hematocrit_max - 45.5) < ABS(hematocrit_min - 45.5)
       THEN smin.hematocrit_score
-      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_max - 45.5)
+      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_min - 45.5)
       AND smax.hematocrit_score >= smin.hematocrit_score
       THEN smax.hematocrit_score
-      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_max - 45.5)
+      WHEN ABS(hematocrit_max - 45.5) = ABS(hematocrit_min - 45.5)
       AND smax.hematocrit_score < smin.hematocrit_score
       THEN smin.hematocrit_score
     END AS hematocrit_score,
@@ -686,9 +686,9 @@ WITH pa AS (
       THEN smax.wbc_score
       WHEN ABS(wbc_max - 11.5) < ABS(wbc_min - 11.5)
       THEN smin.wbc_score
-      WHEN ABS(wbc_max - 11.5) = ABS(wbc_max - 11.5) AND smax.wbc_score >= smin.wbc_score
+      WHEN ABS(wbc_max - 11.5) = ABS(wbc_min - 11.5) AND smax.wbc_score >= smin.wbc_score
       THEN smax.wbc_score
-      WHEN ABS(wbc_max - 11.5) = ABS(wbc_max - 11.5) AND smax.wbc_score < smin.wbc_score
+      WHEN ABS(wbc_max - 11.5) = ABS(wbc_min - 11.5) AND smax.wbc_score < smin.wbc_score
       THEN smin.wbc_score
     END AS wbc_score, /* For some labs, "furthest from normal" doesn't make sense */ /* e.g. creatinine w/ ARF, the minimum could be 0.3, */ /* and the max 1.6 while the minimum of 0.3 is */ /* "further from 1", seems like the max should */ /* be scored */
     CASE
@@ -713,10 +713,10 @@ WITH pa AS (
       THEN smax.sodium_score
       WHEN ABS(sodium_max - 145.5) < ABS(sodium_min - 145.5)
       THEN smin.sodium_score
-      WHEN ABS(sodium_max - 145.5) = ABS(sodium_max - 145.5)
+      WHEN ABS(sodium_max - 145.5) = ABS(sodium_min - 145.5)
       AND smax.sodium_score >= smin.sodium_score
       THEN smax.sodium_score
-      WHEN ABS(sodium_max - 145.5) = ABS(sodium_max - 145.5)
+      WHEN ABS(sodium_max - 145.5) = ABS(sodium_min - 145.5)
       AND smax.sodium_score < smin.sodium_score
       THEN smin.sodium_score
     END AS sodium_score,
@@ -727,10 +727,10 @@ WITH pa AS (
       THEN smax.albumin_score
       WHEN ABS(albumin_max - 3.5) < ABS(albumin_min - 3.5)
       THEN smin.albumin_score
-      WHEN ABS(albumin_max - 3.5) = ABS(albumin_max - 3.5)
+      WHEN ABS(albumin_max - 3.5) = ABS(albumin_min - 3.5)
       AND smax.albumin_score >= smin.albumin_score
       THEN smax.albumin_score
-      WHEN ABS(albumin_max - 3.5) = ABS(albumin_max - 3.5)
+      WHEN ABS(albumin_max - 3.5) = ABS(albumin_min - 3.5)
       AND smax.albumin_score < smin.albumin_score
       THEN smin.albumin_score
     END AS albumin_score,
@@ -742,10 +742,10 @@ WITH pa AS (
       THEN smax.glucose_score
       WHEN ABS(glucose_max - 130) < ABS(glucose_min - 130)
       THEN smin.glucose_score
-      WHEN ABS(glucose_max - 130) = ABS(glucose_max - 130)
+      WHEN ABS(glucose_max - 130) = ABS(glucose_min - 130)
       AND smax.glucose_score >= smin.glucose_score
       THEN smax.glucose_score
-      WHEN ABS(glucose_max - 130) = ABS(glucose_max - 130)
+      WHEN ABS(glucose_max - 130) = ABS(glucose_min - 130)
       AND smax.glucose_score < smin.glucose_score
       THEN smin.glucose_score
     END AS glucose_score, /* Below are interactions/special cases where only 1 value is important */


### PR DESCRIPTION
## Summary
- APS III “worst value” ties for resp rate, hematocrit, WBC, sodium, albumin, and glucose compared `ABS(max − mid) = ABS(max − mid)` instead of max vs min.
- Align those arms with heart rate / MBP / temperature (and Knaus APS III furthest-from-normal selection). Updated MIMIC-III and MIMIC-IV BigQuery, Postgres, and DuckDB copies.

## Test plan
- [ ] No remaining `ABS(*_max*) = ABS(*_max*)` in any `apsiii.sql`
- [ ] Equidistant example: glucose min=60, max=200 → still picks larger component score
- [ ] sqlfluff / transpile CI on changed concepts

Made with [Cursor](https://cursor.com)