### PR TITLE
fix: cap MIMIC-III MELD initial at raw sum > 4

### DIFF
--- a/mimic-iii/concepts/organfailure/meld.sql
+++ b/mimic-iii/concepts/organfailure/meld.sql
@@ -124,7 +124,7 @@ left join `physionet-data.mimiciii_derived.rrt_first_day` r
     , inr_score
 
     , case
-        when (creatinine_score + bilirubin_score + inr_score) > 40
+        when (creatinine_score + bilirubin_score + inr_score) > 4
           then 40.0
         else
           round(cast(creatinine_score + bilirubin_score + inr_score as numeric),1)*10

--- a/mimic-iii/concepts_duckdb/organfailure/meld.sql
+++ b/mimic-iii/concepts_duckdb/organfailure/meld.sql
@@ -83,7 +83,7 @@ WITH cohort AS (
     CASE
       WHEN (
         creatinine_score + bilirubin_score + inr_score
-      ) > 40
+      ) > 4
       THEN 40.0
       ELSE ROUND(CAST(creatinine_score + bilirubin_score + inr_score AS DECIMAL(38, 9)), 1) * 10
     END AS meld_initial

--- a/mimic-iii/concepts_postgres/organfailure/meld.sql
+++ b/mimic-iii/concepts_postgres/organfailure/meld.sql
@@ -85,7 +85,7 @@ WITH cohort AS (
     CASE
       WHEN (
         creatinine_score + bilirubin_score + inr_score
-      ) > 40
+      ) > 4
       THEN 40.0
       ELSE ROUND(CAST(creatinine_score + bilirubin_score + inr_score AS DECIMAL(38, 9)), 1) * 10
     END AS meld_initial


### PR DESCRIPTION
## Summary
- MIMIC-III `meld.sql` capped when the pre-scale creatinine+bilirubin+INR sum was `> 40`, so the OPTN max of 40 almost never applied (raw sum is typically ~1–5 before `round(...)*10`).
- Change the threshold to `> 4` to match MIMIC-IV and [OPTN MELD policy](https://optn.transplant.hrsa.gov/news/meld-serum-sodium-policy-changes/) (max 40 after rounding to one decimal and ×10). Updated BigQuery, Postgres, and DuckDB copies.

## Test plan
- [ ] Spot-check: raw sum `4.1` → `meld_initial` 40 (was 41 after round×10)
- [ ] Spot-check: raw sum `3.95` → `meld_initial` 40 via round×10
- [ ] Diff threshold against `mimic-iv/concepts/organfailure/meld.sql`

Made with [Cursor](https://cursor.com)