### PR TITLE
fix: parse-safe D/C match in pivoted_invasive_lines

### DIFF
--- a/mimic-iii/concepts/pivot/pivoted_invasive_lines.sql
+++ b/mimic-iii/concepts/pivot/pivoted_invasive_lines.sql
@@ -19,8 +19,9 @@ WITH stg0 AS
         , CASE WHEN itemid < 8000 THEN value ELSE NULL END AS line_type
         , CASE WHEN itemid > 8000 THEN value ELSE NULL END AS line_site
         -- the stopped column is always present for invasive lines
+        -- LIKE avoids apostrophe escaping that breaks sqlglot transpile
         , CASE 
-              WHEN ce.stopped = 'D/C\'d' THEN 1
+              WHEN ce.stopped LIKE 'D/C%' THEN 1
               WHEN ce.stopped = 'NotStopd' THEN 0
           ELSE NULL END AS line_dc
     FROM `physionet-data.mimiciii_clinical.chartevents` ce

--- a/mimic-iii/concepts_duckdb/pivot/pivoted_invasive_lines.sql
+++ b/mimic-iii/concepts_duckdb/pivot/pivoted_invasive_lines.sql
@@ -28,13 +28,13 @@ WITH stg0 AS (
     CASE WHEN itemid < 8000 THEN value ELSE NULL END AS line_type,
     CASE WHEN itemid > 8000 THEN value ELSE NULL END AS line_site,
     CASE
-      WHEN ce.stopped = 'D/C''d'
+      WHEN ce.stopped LIKE 'D/C%'
       THEN 1
       WHEN ce.stopped = 'NotStopd'
       THEN 0
       ELSE NULL
     END AS line_dc
-  FROM mimiciii.chartevents AS ce
+  FROM mimiciii_clinical.chartevents AS ce
   WHERE
     ce.itemid IN (
       229,
@@ -138,8 +138,8 @@ WITH stg0 AS (
     mv.location AS line_site,
     starttime,
     endtime
-  FROM mimiciii.procedureevents_mv AS mv
-  INNER JOIN mimiciii.d_items AS di
+  FROM mimiciii_clinical.procedureevents_mv AS mv
+  INNER JOIN mimiciii_clinical.d_items AS di
     ON mv.itemid = di.itemid
   WHERE
     mv.itemid IN (

--- a/mimic-iii/concepts_postgres/pivot/pivoted_invasive_lines.sql
+++ b/mimic-iii/concepts_postgres/pivot/pivoted_invasive_lines.sql
@@ -26,15 +26,15 @@ WITH stg0 AS (
       ELSE NULL
     END AS line_number,
     CASE WHEN itemid < 8000 THEN value ELSE NULL END AS line_type,
-    CASE WHEN itemid > 8000 THEN value ELSE NULL END AS line_site, /* the stopped column is always present for invasive lines */
+    CASE WHEN itemid > 8000 THEN value ELSE NULL END AS line_site, /* the stopped column is always present for invasive lines */ /* LIKE avoids apostrophe escaping that breaks sqlglot transpile */
     CASE
-      WHEN ce.stopped = 'D/C''d'
+      WHEN ce.stopped LIKE 'D/C%'
       THEN 1
       WHEN ce.stopped = 'NotStopd'
       THEN 0
       ELSE NULL
     END AS line_dc
-  FROM mimiciii.chartevents AS ce
+  FROM mimiciii_clinical.chartevents AS ce
   WHERE
     ce.itemid IN (
       229, /* INV Line#1 [Type] */
@@ -135,8 +135,8 @@ WITH stg0 AS (
     mv.location AS line_site,
     starttime,
     endtime
-  FROM mimiciii.procedureevents_mv AS mv
-  INNER JOIN mimiciii.d_items AS di
+  FROM mimiciii_clinical.procedureevents_mv AS mv
+  INNER JOIN mimiciii_clinical.d_items AS di
     ON mv.itemid = di.itemid
   WHERE
     mv.itemid IN (


### PR DESCRIPTION
## Summary
- BigQuery `pivoted_invasive_lines` used `'D/C\'d'`, which sqlglot cannot parse (same class of failure as neuroblock).
- Switch to `stopped LIKE 'D/C%'` and regenerate postgres/duckdb copies.

## Test plan
- [x] `pytest tests/test_transpile.py -k invasive` (4 passed)
- [ ] Confirm transpile of this concept succeeds in CI

Made with [Cursor](https://cursor.com)