### PR TITLE
ci: extend sqlglot syntax check to mimic-iii concepts

### DIFF
--- a/.github/scripts/check_sql_syntax.py
+++ b/.github/scripts/check_sql_syntax.py
@@ -2,7 +2,8 @@
 """Validate that every BigQuery concept SQL file parses with sqlglot.
 
 Usage: ``python .github/scripts/check_sql_syntax.py [ROOT ...]``
-(defaults to ``mimic-iv/concepts``). Exits non-zero if any file fails to parse.
+(defaults to ``mimic-iv/concepts`` and ``mimic-iii/concepts``).
+Exits non-zero if any file fails to parse.
 """
 from __future__ import annotations
 
@@ -14,7 +15,10 @@ from sqlglot.errors import ParseError
 
 
 def main(argv: list[str]) -> int:
-    roots = [Path(p) for p in argv[1:]] or [Path("mimic-iv/concepts")]
+    roots = [Path(p) for p in argv[1:]] or [
+        Path("mimic-iv/concepts"),
+        Path("mimic-iii/concepts"),
+    ]
     files = sorted({f for root in roots for f in root.rglob("*.sql")})
     if not files:
         print(f"::error::No .sql files found under: {', '.join(map(str, roots))}")

--- a/.github/workflows/sql_syntax_check.yml
+++ b/.github/workflows/sql_syntax_check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'mimic-iv/concepts/**'
+      - 'mimic-iii/concepts/**'
       - 'src/mimic_utils/**'
       - '.github/scripts/check_sql_syntax.py'
       - '.github/workflows/sql_syntax_check.yml'
@@ -24,4 +25,4 @@ jobs:
       - name: Install package
         run: pip install -e . --no-deps
       - name: Parse concept SQL with sqlglot
-        run: python .github/scripts/check_sql_syntax.py mimic-iv/concepts
+        run: python .github/scripts/check_sql_syntax.py mimic-iv/concepts mimic-iii/concepts

--- a/mimic-iv/tests/test_measurement.py
+++ b/mimic-iv/tests/test_measurement.py
@@ -72,7 +72,7 @@ def test_common_bg_exist(dataset, project_id):
 
 
 def test_gcs_score_calculated_correctly(dataset, project_id):
-    """Verifies common blood gases occur > 50% of the time"""
+    """Verifies GCS verbal imputation and carry-forward logic."""
     # has verbal prev of 1 -> 11365767, 30015010, 2154-07-25T20:00:00
     # has verbal prev of 0 -> 13182319, 30159144, 2161-06-19T00:16:00
     query = f"""


### PR DESCRIPTION
## Summary
- Run `check_sql_syntax.py` on both `mimic-iv/concepts` and `mimic-iii/concepts` in CI
- Trigger the workflow when mimic-iii concept SQL changes
- Fix incorrect GCS test docstring copied from the bg test

## Test plan
- [x] `python .github/scripts/check_sql_syntax.py mimic-iii/concepts` (109 files OK)
- [x] `python .github/scripts/check_sql_syntax.py mimic-iv/concepts`


Made with [Cursor](https://cursor.com)