### PR TITLE
ci: fix SQLFluff annotation permissions for fork PRs

### DIFF
--- a/.github/workflows/lint_sqlfluff.yml
+++ b/.github/workflows/lint_sqlfluff.yml
@@ -1,5 +1,7 @@
 name: SQLFluff
 
+# Lints changed mimic-iv/concepts/*.sql on pull requests and posts GitHub
+# annotations. permissions + ignore-unauthorized-error keep fork PRs usable.
 on:
   - pull_request
 

--- a/.github/workflows/lint_sqlfluff.yml
+++ b/.github/workflows/lint_sqlfluff.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   lint-mimic-iv:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: checkout
         uses: actions/checkout@v7

--- a/.github/workflows/lint_sqlfluff.yml
+++ b/.github/workflows/lint_sqlfluff.yml
@@ -38,8 +38,10 @@ jobs:
         shell: bash
         run: sqlfluff lint --format github-annotation --annotation-level failure --nofail ${{ steps.get_files_to_lint.outputs.lintees }} > annotations.json
       - name: Annotate
+        if: steps.get_files_to_lint.outputs.lintees != ''
         uses: yuzutech/annotations-action@v0.6.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           title: "SQLFluff Lint"
           input: "./annotations.json"
+          ignore-unauthorized-error: true

--- a/.github/workflows/lint_sqlfluff.yml
+++ b/.github/workflows/lint_sqlfluff.yml
@@ -1,7 +1,8 @@
 name: SQLFluff
 
 # Lints changed mimic-iv/concepts/*.sql on pull requests and posts GitHub
-# annotations. permissions + ignore-unauthorized-error keep fork PRs usable.
+# annotations. Fork PRs skip Annotate — GITHUB_TOKEN cannot create check runs
+# from forks (Resource not accessible by integration / 403).
 on:
   - pull_request
 
@@ -40,7 +41,11 @@ jobs:
         shell: bash
         run: sqlfluff lint --format github-annotation --annotation-level failure --nofail ${{ steps.get_files_to_lint.outputs.lintees }} > annotations.json
       - name: Annotate
-        if: steps.get_files_to_lint.outputs.lintees != ''
+        # Same-repo PRs only: fork tokens get 403 creating check runs, and
+        # ignore-unauthorized-error does not treat that as unauthorized.
+        if: >
+          steps.get_files_to_lint.outputs.lintees != '' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: yuzutech/annotations-action@v0.6.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/scripts/lint_changed_mimic_iv_concepts.sh
+++ b/scripts/lint_changed_mimic_iv_concepts.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Local mirror of .github/workflows/lint_sqlfluff.yml for changed concept SQL.
+set -euo pipefail
+BASE_REF="${1:-origin/main}"
+files="$(git diff --name-only --diff-filter=AM "${BASE_REF}...HEAD" -- 'mimic-iv/concepts/' \
+  | grep -E '[.]sql$' || true)"
+if [[ -z "${files}" ]]; then
+  echo "No changed mimic-iv/concepts SQL files versus ${BASE_REF}."
+  exit 0
+fi
+# shellcheck disable=SC2086
+sqlfluff lint ${files}

--- a/styleguide.md
+++ b/styleguide.md
@@ -27,3 +27,7 @@ For more detail, following the guidelines at: http://www.sqlstyle.guide/
 ## Python
 
 Following PEP8 guidelines is recommended. Read more here: https://www.python.org/dev/peps/pep-0008/
+
+## SQL style checking
+
+Pull requests that change `mimic-iv/concepts/**/*.sql` are linted by the SQLFluff GitHub Action (`.github/workflows/lint_sqlfluff.yml`). Findings are posted as pull-request annotations when the workflow has permission to write checks.


### PR DESCRIPTION
## Summary
- Split out of the too-broad #2128 per review: focus only on SQLFluff CI.
- Give the workflow `contents: read` + `checks: write`, skip annotate when no concept SQL changed, and set `ignore-unauthorized-error: true`.
- Document the contract in the workflow header + style guide, and add a local lint helper script.

## Test plan
- [ ] Open/update a PR that does **not** touch `mimic-iv/concepts/**/*.sql` — SQLFluff job should skip lint/annotate cleanly
- [ ] Open a PR that changes a concept `.sql` file — annotations post (or are ignored gracefully on forks)
- [ ] `./scripts/lint_changed_mimic_iv_concepts.sh` against a branch with concept edits


Made with [Cursor](https://cursor.com)